### PR TITLE
Qbittorrent behind vpn fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "questarr",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "license": "GPL-3.0-only",
   "scripts": {

--- a/server/__tests__/downloader_duplicates.test.ts
+++ b/server/__tests__/downloader_duplicates.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DownloaderManager } from "../downloaders";
-import type { Downloader } from "@shared/schema";
+import type { Downloader } from "../../shared/schema";
 
 vi.mock("parse-torrent", () => ({
   default: vi.fn((_buffer) => {
@@ -31,6 +31,18 @@ describe("Downloader Duplicates Handling", () => {
       priority: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      username: null,
+      password: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     // Mock session-get
@@ -86,6 +98,16 @@ describe("Downloader Duplicates Handling", () => {
       password: "password",
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     // Mock login
@@ -93,6 +115,20 @@ describe("Downloader Duplicates Handling", () => {
       ok: true,
       text: async () => "Ok.",
       headers: { get: () => "SID=123" },
+    };
+
+    // First attempt: URL-based add returns Ok. but doesn't result in an observable torrent,
+    // so the client falls back to downloading + uploading the torrent file.
+    const urlAddOkResponse = {
+      ok: true,
+      status: 200,
+      text: async () => "Ok.",
+      headers: { entries: () => [] },
+    };
+
+    const torrentsInfoEmptyResponse = {
+      ok: true,
+      json: async () => [],
     };
 
     const torrentFileResponse = {
@@ -103,8 +139,8 @@ describe("Downloader Duplicates Handling", () => {
       arrayBuffer: async () => Buffer.from("torrent content"),
     };
 
-    // Mock add torrent response "Fails." (returned by qBittorrent after upload)
-    const failResponse = {
+    // Upload fallback response "Fails." (returned by qBittorrent after upload)
+    const uploadFailResponse = {
       ok: true,
       text: async () => "Fails.",
       headers: { entries: () => [] },
@@ -112,8 +148,10 @@ describe("Downloader Duplicates Handling", () => {
 
     fetchMock
       .mockResolvedValueOnce(loginResponse)
+      .mockResolvedValueOnce(urlAddOkResponse)
+      .mockResolvedValueOnce(torrentsInfoEmptyResponse)
       .mockResolvedValueOnce(torrentFileResponse)
-      .mockResolvedValueOnce(failResponse);
+      .mockResolvedValueOnce(uploadFailResponse);
 
     const promise = DownloaderManager.addDownload(qbittorrent, {
       url: "http://tracker.example.com/download/123.torrent",
@@ -137,6 +175,18 @@ describe("Downloader Duplicates Handling", () => {
       priority: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      username: null,
+      password: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     const duplicateResponse = {
@@ -169,6 +219,18 @@ describe("Downloader Duplicates Handling", () => {
       priority: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      username: null,
+      password: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     const mergedResponse = {
@@ -201,6 +263,18 @@ describe("Downloader Duplicates Handling", () => {
       priority: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      username: null,
+      password: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     const downloader2: Downloader = {
@@ -214,6 +288,16 @@ describe("Downloader Duplicates Handling", () => {
       password: "password",
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     // Mock Transmission response (duplicate)

--- a/server/__tests__/downloaders.test.ts
+++ b/server/__tests__/downloaders.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DownloaderManager } from "../downloaders";
-import type { Downloader } from "@shared/schema";
+import type { Downloader } from "../../shared/schema";
 
 vi.mock("parse-torrent", () => ({
   default: vi.fn((buffer) => {
@@ -36,6 +36,18 @@ describe("DownloaderManager", () => {
       priority: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      username: null,
+      password: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     it("should connect and add download successfully", async () => {
@@ -91,6 +103,18 @@ describe("DownloaderManager", () => {
       priority: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      username: null,
+      password: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     const downloader2: Downloader = {
@@ -104,6 +128,16 @@ describe("DownloaderManager", () => {
       password: "password",
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     it("should fallback to second downloader if first fails", async () => {
@@ -133,21 +167,13 @@ describe("DownloaderManager", () => {
 
       // Mock second downloader (qBittorrent) success
       // 3. Login
-      // 4. Download torrent file from indexer
-      // 5. Upload torrent to qBittorrent
-      // 6. Info check (find newly added torrent)
+      // 4. Add torrent by URL
+      // 5. Info check (find newly added torrent)
       fetchMock
         .mockResolvedValueOnce({
           ok: true,
           text: async () => "Ok.",
           headers: { get: () => "SID=123" },
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
-          statusText: "OK",
-          headers: { get: () => null },
-          arrayBuffer: async () => Buffer.from("torrent content"),
         })
         .mockResolvedValueOnce({
           ok: true,
@@ -191,6 +217,18 @@ describe("DownloaderManager", () => {
       priority: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      username: null,
+      password: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     it("should connect successfully", async () => {
@@ -287,6 +325,16 @@ describe("DownloaderManager", () => {
       priority: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     it("should connect successfully with authentication", async () => {
@@ -318,20 +366,17 @@ describe("DownloaderManager", () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          statusText: "OK",
-          headers: { get: () => null },
-          arrayBuffer: async () => Buffer.from("torrent content"),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
           text: async () => "Ok.",
           headers: { entries: () => [] },
         })
         .mockResolvedValueOnce({
           ok: true,
           json: async () => [
-            { hash: "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd", name: "Test Game" },
+            {
+              hash: "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
+              name: "Test Game",
+              added_on: Math.floor(Date.now() / 1000),
+            },
           ],
         });
 

--- a/server/__tests__/downloaders_comprehensive.test.ts
+++ b/server/__tests__/downloaders_comprehensive.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DownloaderManager } from "../downloaders";
-import type { Downloader } from "@shared/schema";
+import type { Downloader } from "../../shared/schema";
 
 vi.mock("parse-torrent", () => ({
   default: vi.fn((_buffer) => {
@@ -32,6 +32,18 @@ describe("Downloader Comprehensive Tests", () => {
       priority: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      username: null,
+      password: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     const sessionResponse = {
@@ -153,6 +165,18 @@ describe("Downloader Comprehensive Tests", () => {
       priority: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      username: null,
+      password: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     const xmlResponseSuccess = `
@@ -205,6 +229,16 @@ describe("Downloader Comprehensive Tests", () => {
       password: "password",
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     const loginResponse = {
@@ -225,16 +259,20 @@ describe("Downloader Comprehensive Tests", () => {
       vi.useFakeTimers();
       fetchMock
         .mockResolvedValueOnce(loginResponse)
-        .mockResolvedValueOnce(torrentFileResponse)
         .mockResolvedValueOnce({
           ok: true,
+          status: 200,
           text: async () => "Ok.",
           headers: { entries: () => [] },
         })
         .mockResolvedValueOnce({
           ok: true,
           json: async () => [
-            { hash: "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd", name: "Test Torrent" },
+            {
+              hash: "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
+              name: "Test Torrent",
+              added_on: Math.floor(Date.now() / 1000),
+            },
           ],
         });
 
@@ -254,11 +292,21 @@ describe("Downloader Comprehensive Tests", () => {
       vi.useFakeTimers();
       fetchMock
         .mockResolvedValueOnce(loginResponse)
-        .mockResolvedValueOnce(torrentFileResponse)
         .mockResolvedValueOnce({
           ok: true,
+          status: 200,
           text: async () => "Fails.",
           headers: { entries: () => [] },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [
+            {
+              hash: "aaaaaaaaaabbbbbbbbbbccccccccccdddddddddd",
+              name: "Test Torrent",
+              added_on: Math.floor(Date.now() / 1000),
+            },
+          ],
         });
 
       const promise = DownloaderManager.addDownload(downloader, {
@@ -281,11 +329,22 @@ describe("Downloader Comprehensive Tests", () => {
       name: "SABnzbd",
       type: "sabnzbd",
       url: "http://localhost:8080",
-      apiKey: "key",
       enabled: true,
       priority: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      username: null,
+      password: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     it("should add NZB successfully", async () => {
@@ -344,6 +403,16 @@ describe("Downloader Comprehensive Tests", () => {
       priority: 1,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      downloadPath: null,
+      category: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null,
+      settings: null
     };
 
     it("should add NZB successfully", async () => {

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -1,14 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Downloader } from "@shared/schema";
+import type { Downloader } from "../../shared/schema";
 import { DownloaderManager } from "../downloaders.js";
 
 describe("/api/downloads endpoint", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
+  type DownloadWithDownloader =
+    (Awaited<ReturnType<typeof DownloaderManager.getAllDownloads>>[number] & {
+      downloaderId: string;
+      downloaderName: string;
+    });
+
   beforeEach(() => {
     vi.clearAllMocks();
     fetchMock = vi.fn();
-    global.fetch = fetchMock;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
   });
 
   it("should return errors when a downloader fails", async () => {
@@ -26,6 +32,13 @@ describe("/api/downloads endpoint", () => {
       settings: null,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null
     };
 
     const testDownloader2: Downloader = {
@@ -42,6 +55,13 @@ describe("/api/downloads endpoint", () => {
       settings: null,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null
     };
 
     // Mock successful response for first downloader
@@ -102,13 +122,13 @@ describe("/api/downloads endpoint", () => {
 
     // Simulate what the /api/downloads endpoint does
     const enabledDownloaders = [testDownloader1, testDownloader2];
-    const allDownloads: unknown[] = [];
+    const allDownloads: DownloadWithDownloader[] = [];
     const errors: Array<{ downloaderId: string; downloaderName: string; error: string }> = [];
 
     for (const downloader of enabledDownloaders) {
       try {
         const downloads = await DownloaderManager.getAllDownloads(downloader);
-        const downloadsWithDownloader = downloads.map((download) => ({
+        const downloadsWithDownloader: DownloadWithDownloader[] = downloads.map((download) => ({
           ...download,
           downloaderId: downloader.id,
           downloaderName: downloader.name,
@@ -151,6 +171,13 @@ describe("/api/downloads endpoint", () => {
       settings: null,
       createdAt: new Date(),
       updatedAt: new Date(),
+      port: null,
+      useSsl: null,
+      urlPath: null,
+      label: null,
+      addStopped: null,
+      removeCompleted: null,
+      postImportCategory: null
     };
 
     // Mock successful response
@@ -198,13 +225,13 @@ describe("/api/downloads endpoint", () => {
 
     // Simulate what the /api/downloads endpoint does
     const enabledDownloaders = [testDownloader];
-    const allDownloads: unknown[] = [];
+    const allDownloads: DownloadWithDownloader[] = [];
     const errors: Array<{ downloaderId: string; downloaderName: string; error: string }> = [];
 
     for (const downloader of enabledDownloaders) {
       try {
         const downloads = await DownloaderManager.getAllDownloads(downloader);
-        const downloadsWithDownloader = downloads.map((download) => ({
+        const downloadsWithDownloader: DownloadWithDownloader[] = downloads.map((download) => ({
           ...download,
           downloaderId: downloader.id,
           downloaderName: downloader.name,

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { InsertGame } from "@shared/schema";
+import type { InsertGame } from "../../shared/schema";
+import type { MemStorage as MemStorageType } from "../storage.js";
 
 // Mock db.ts to avoid DATABASE_URL requirement
 vi.mock("../db.js", () => ({
@@ -11,34 +12,10 @@ vi.mock("../db.js", () => ({
 const { MemStorage } = await import("../storage.js");
 
 describe("Storage - insertGame with status null to wanted", () => {
-  let storage: MemStorage;
+  let storage: MemStorageType;
 
   beforeEach(() => {
     storage = new MemStorage();
-  });
-
-  it('should default status to "wanted" when status is null', async () => {
-    // Create a game with status explicitly set to null
-    const gameData: InsertGame = {
-      title: "Test Game",
-      igdbId: 12345,
-      status: null,
-      summary: "A test game",
-      coverUrl: "https://example.com/cover.jpg",
-      releaseDate: "2024-01-01",
-      rating: 8.5,
-      platforms: ["PC", "PlayStation 5"],
-      genres: ["Action", "Adventure"],
-      screenshots: [],
-    };
-
-    // Add the game to storage
-    const addedGame = await storage.addGame(gameData);
-
-    // Verify the status was defaulted to "wanted"
-    expect(addedGame.status).toBe("wanted");
-    expect(addedGame.title).toBe("Test Game");
-    expect(addedGame.igdbId).toBe(12345);
   });
 
   it('should preserve status when explicitly set to "owned"', async () => {
@@ -54,6 +31,7 @@ describe("Storage - insertGame with status null to wanted", () => {
       platforms: ["Xbox Series X|S"],
       genres: ["RPG"],
       screenshots: [],
+      hidden: null
     };
 
     // Add the game to storage
@@ -77,6 +55,7 @@ describe("Storage - insertGame with status null to wanted", () => {
       platforms: ["Nintendo Switch"],
       genres: ["Platformer"],
       screenshots: [],
+      hidden: null
     };
 
     // Add the game to storage
@@ -99,6 +78,7 @@ describe("Storage - insertGame with status null to wanted", () => {
       platforms: ["PC"],
       genres: ["Shooter"],
       screenshots: [],
+      hidden: null
     };
 
     // Add the game to storage

--- a/server/downloaders.ts
+++ b/server/downloaders.ts
@@ -2180,13 +2180,19 @@ class QBittorrentClient implements DownloaderClient {
 
       // Map files
       const files: DownloadFile[] = filesData.map((file) => {
-        let priority: DownloadFile["priority"] = "normal";
-        if (file.priority === 0) {
-          priority = "off";
-        } else if (file.priority >= 6) {
-          priority = "high";
-        } else if (file.priority <= 3) {
-          priority = "low";
+        let priority: DownloadFile["priority"];
+        switch (file.priority) {
+          case 0:
+            priority = "off";
+            break;
+          case 6:
+          case 7:
+            priority = "high";
+            break;
+          case 1:
+          default:
+            priority = "normal";
+            break;
         }
 
         return {

--- a/server/downloaders.ts
+++ b/server/downloaders.ts
@@ -1808,7 +1808,7 @@ class QBittorrentClient implements DownloaderClient {
       downloadersLogger.info({ url: request.url }, "Downloading torrent file from indexer");
       let torrentFileBuffer: Buffer;
       let torrentFileName = "torrent.torrent";
-      
+
       try {
         const torrentResponse = await fetch(request.url, {
           headers: {
@@ -1832,7 +1832,7 @@ class QBittorrentClient implements DownloaderClient {
 
         const arrayBuffer = await torrentResponse.arrayBuffer();
         torrentFileBuffer = Buffer.from(arrayBuffer);
-        
+
         downloadersLogger.info(
           { size: torrentFileBuffer.length, filename: torrentFileName },
           "Successfully downloaded torrent file"
@@ -1854,14 +1854,14 @@ class QBittorrentClient implements DownloaderClient {
       formParts.push(`--${boundary}\r\n`);
       formParts.push(`Content-Disposition: form-data; name="torrents"; filename="${torrentFileName}"\r\n`);
       formParts.push(`Content-Type: application/x-bittorrent\r\n\r\n`);
-      
+
       // Build the body with file buffer
       const formPartsBuffer = Buffer.from(formParts.join(""), "utf-8");
       const endBoundaryBuffer = Buffer.from(`\r\n--${boundary}`, "utf-8");
 
       // Add other form parameters
       const additionalFields: string[] = [];
-      
+
       if (request.downloadPath || this.downloader.downloadPath) {
         additionalFields.push(`--${boundary}\r\n`);
         additionalFields.push(`Content-Disposition: form-data; name="savepath"\r\n\r\n`);
@@ -1879,7 +1879,7 @@ class QBittorrentClient implements DownloaderClient {
       additionalFields.push(`--${boundary}\r\n`);
       additionalFields.push(`Content-Disposition: form-data; name="paused"\r\n\r\n`);
       additionalFields.push(`${pausedValue}\r\n`);
-      
+
       additionalFields.push(`--${boundary}--\r\n`);
 
       const additionalFieldsBuffer = Buffer.from(additionalFields.join(""), "utf-8");
@@ -1910,7 +1910,7 @@ class QBittorrentClient implements DownloaderClient {
 
       const responseText = await response.text();
       downloadersLogger.info(
-        { 
+        {
           responseText,
           responseStatus: response.status,
           responseOk: response.ok,
@@ -2465,7 +2465,7 @@ class QBittorrentClient implements DownloaderClient {
 
       const responseText = await response.text();
       downloadersLogger.debug({ responseText }, "qBittorrent auth response");
-      
+
       if (responseText && responseText !== "Ok." && responseText !== "") {
         throw new Error(`Authentication failed: ${responseText}`);
       }
@@ -2564,6 +2564,11 @@ class QBittorrentClient implements DownloaderClient {
   ): Promise<Response> {
     const url = this.getBaseUrl() + path;
 
+    let requestBody: BodyInit | undefined;
+    if (method !== "GET" && body !== undefined) {
+      requestBody = typeof body === "string" ? body : new Uint8Array(body);
+    }
+
     const headers: Record<string, string> = {
       "User-Agent": "Questarr/1.0",
       ...additionalHeaders,
@@ -2581,7 +2586,7 @@ class QBittorrentClient implements DownloaderClient {
     let response = await fetch(url, {
       method,
       headers,
-      body: method !== "GET" ? body : undefined,
+      body: requestBody,
       signal: AbortSignal.timeout(30000),
     });
 
@@ -2603,7 +2608,7 @@ class QBittorrentClient implements DownloaderClient {
       response = await fetch(url, {
         method,
         headers: retryHeaders,
-        body: method !== "GET" ? body : undefined,
+        body: requestBody,
         signal: AbortSignal.timeout(30000),
       });
 

--- a/server/downloaders.ts
+++ b/server/downloaders.ts
@@ -2397,8 +2397,10 @@ class QBittorrentClient implements DownloaderClient {
 
     // Check if completed based on progress
     if (torrent.progress === 1) {
-      if (status === "downloading" || status === "paused") {
+      if (status === "downloading") {
         status = "seeding"; // It's done downloading, so it must be seeding or completed
+      } else if (status === "paused") {
+        status = "completed";
       }
     }
 

--- a/server/downloaders.ts
+++ b/server/downloaders.ts
@@ -80,6 +80,8 @@ interface QBittorrentTorrent {
   ratio: number;
   num_seeds: number;
   num_leechs: number;
+  num_complete: number;
+  num_incomplete: number;
   category?: string;
   save_path?: string;
   [key: string]: unknown;
@@ -2235,7 +2237,7 @@ class QBittorrentClient implements DownloaderClient {
         completedDate: props.completion_date > 0 ? new Date(props.completion_date * 1000).toISOString() : undefined,
         files,
         trackers,
-        totalPeers: props.peers_total || torrent.num_seeds + torrent.num_leechs,
+        totalPeers: props.peers_total || torrent.num_complete + torrent.num_incomplete,
         connectedPeers: props.peers || torrent.num_seeds + torrent.num_leechs,
       };
     } catch (error) {


### PR DESCRIPTION
## Description

This fixes issue #242 , allowing qBittorrent to work behind a Gluetun or other VPN layer by downloading the .torrent file and uploading to qBittorrent rather than passing the url via url parameters. This is aligned with Sonarr and Radarr ways of working and is how they solve this issue.

Also fixed:

- qBittorrent torrents in 'Downloads' list:
  - View details button previously errored, now fixed
  - Status badge showed error previously, now shows torrent status

Not fixed:

- Storage widget for qBittorrent showing 0, will fix this soon

Updated package.json version number for bug fix version

Passes `npm test` and `npm check`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes