### PR TITLE
feat: add indexerName to DownloadItem interface

### DIFF
--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -50,6 +50,8 @@ interface DownloadItem {
   uploadVolumeFactor?: number;
   guid?: string;
   comments?: string;
+  indexerId?: string;
+  indexerName?: string;
   // Usenet-specific fields
   grabs?: number;
   age?: number;
@@ -607,55 +609,60 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                   )}
                                 </Button>
                               </div>
-                              <div className="flex items-center gap-2 text-xs text-muted-foreground flex-wrap">
-                                <span>{formatDate(download.pubDate)}</span>
-                                <span>•</span>
-                                <span>{download.size ? formatBytes(download.size) : "-"}</span>
-                                <span>•</span>
-                                {isUsenet ? (
-                                  <div className="flex items-center gap-2">
-                                    {download.grabs !== undefined && (
-                                      <div className="flex items-center gap-1">
-                                        <span className="text-blue-600 font-medium">
-                                          {download.grabs}
-                                        </span>
-                                        <span>grabs</span>
-                                      </div>
-                                    )}
-                                    {download.grabs !== undefined && download.age !== undefined && (
+                              <div className="flex items-center gap-2 text-xs text-muted-foreground flex-wrap justify-between">
+                                <div className="flex items-center gap-2 flex-wrap">
+                                  <span>{formatDate(download.pubDate)}</span>
+                                  <span>•</span>
+                                  <span>{download.size ? formatBytes(download.size) : "-"}</span>
+                                  <span>•</span>
+                                  {isUsenet ? (
+                                    <div className="flex items-center gap-2">
+                                      {download.grabs !== undefined && (
+                                        <div className="flex items-center gap-1">
+                                          <span className="text-blue-600 font-medium">
+                                            {download.grabs}
+                                          </span>
+                                          <span>grabs</span>
+                                        </div>
+                                      )}
+                                      {download.grabs !== undefined && download.age !== undefined && (
+                                        <span>•</span>
+                                      )}
+                                      {download.age !== undefined && (
+                                        <div className="flex items-center gap-1">
+                                          <span className="text-purple-600 font-medium">
+                                            {formatAge(download.age)}
+                                          </span>
+                                          <span>old</span>
+                                        </div>
+                                      )}
+                                    </div>
+                                  ) : (
+                                    <div className="flex items-center gap-1">
+                                      <span className="text-green-600 font-medium">
+                                        {download.seeders ?? 0}
+                                      </span>
+                                      <span>/</span>
+                                      <span className="text-red-600 font-medium">
+                                        {download.leechers ?? 0}
+                                      </span>
+                                      <span>peers</span>
+                                    </div>
+                                  )}
+                                  {download.description && (
+                                    <>
                                       <span>•</span>
-                                    )}
-                                    {download.age !== undefined && (
-                                      <div className="flex items-center gap-1">
-                                        <span className="text-purple-600 font-medium">
-                                          {formatAge(download.age)}
-                                        </span>
-                                        <span>old</span>
-                                      </div>
-                                    )}
-                                  </div>
-                                ) : (
-                                  <div className="flex items-center gap-1">
-                                    <span className="text-green-600 font-medium">
-                                      {download.seeders ?? 0}
-                                    </span>
-                                    <span>/</span>
-                                    <span className="text-red-600 font-medium">
-                                      {download.leechers ?? 0}
-                                    </span>
-                                    <span>peers</span>
-                                  </div>
-                                )}
-                                {download.description && (
-                                  <>
-                                    <span>•</span>
-                                    <span
-                                      className="truncate max-w-[200px]"
-                                      title={download.description}
-                                    >
-                                      {download.description}
-                                    </span>
-                                  </>
+                                      <span
+                                        className="truncate max-w-[200px]"
+                                        title={download.description}
+                                      >
+                                        {download.description}
+                                      </span>
+                                    </>
+                                  )}
+                                </div>
+                                {download.indexerName && (
+                                  <span className="flex-shrink-0">{download.indexerName}</span>
                                 )}
                               </div>
                             </div>

--- a/client/src/pages/search.tsx
+++ b/client/src/pages/search.tsx
@@ -49,6 +49,8 @@ interface DownloadItem {
   uploadVolumeFactor?: number;
   guid?: string;
   comments?: string;
+  indexerId?: string;
+  indexerName?: string;
   // Usenet-specific fields
   grabs?: number;
   age?: number;


### PR DESCRIPTION
This pull request updates the `DownloadItem` interface to include new indexer-related fields and enhances the `GameDownloadDialog` component to display the indexer name for each download. These changes improve the visibility of the source indexer for downloads in the UI.

**Interface updates:**

* Added `indexerName` fields to the `DownloadItem` interface in both `client/src/components/GameDownloadDialog.tsx` and `client/src/pages/search.tsx` to support tracking and displaying the source indexer. [[1]](diffhunk://#diff-c3061fd23700c28750767d9d851897a6c6801155fe27dd016591ba459a8bcf52R53-R54) [[2]](diffhunk://#diff-dffc1103cbe3810608ad1831c194fb80473b25250d8ad6d9befa79f6ca1821daR52-R53)

**UI improvements:**

* Updated the layout in `GameDownloadDialog` to better organize download metadata and display the indexer name when available. [[1]](diffhunk://#diff-c3061fd23700c28750767d9d851897a6c6801155fe27dd016591ba459a8bcf52L610-R613) [[2]](diffhunk://#diff-c3061fd23700c28750767d9d851897a6c6801155fe27dd016591ba459a8bcf52R664-R667)