### PR TITLE
fix: fixed qBittorrent behind VPN download handling

### DIFF
--- a/server/downloaders.ts
+++ b/server/downloaders.ts
@@ -2084,7 +2084,6 @@ class QBittorrentClient implements DownloaderClient {
         );
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error";
-        // Type-safe error cause extraction
         const errorCause = error instanceof Error && "cause" in error
           ? (error.cause as { code?: string; message?: string; errno?: number } | undefined)
           : undefined;


### PR DESCRIPTION
This pull request improves the qBittorrent downloader integration by enhancing how torrent URLs and redirects are handled, especially in cases where indexers return a magnet link instead of a torrent file. It also adds better error handling and user-friendly error messages for troubleshooting download failures

Fixes #313 