### PR TITLE
🎨 Palette: Fix keyboard accessibility for GameCard overlay

### DIFF
--- a/client/src/components/GameCard.tsx
+++ b/client/src/components/GameCard.tsx
@@ -176,7 +176,7 @@ const GameCard = ({
             </Badge>
           )}
         </div>
-        <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-within:opacity-100 transition-opacity duration-200 rounded-t-md flex items-center justify-center gap-2">
+        <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-200 rounded-t-md flex items-center justify-center gap-2">
           {isDiscovery && (
             <Tooltip>
               <TooltipTrigger asChild>

--- a/client/src/components/GameCard.tsx
+++ b/client/src/components/GameCard.tsx
@@ -176,7 +176,7 @@ const GameCard = ({
             </Badge>
           )}
         </div>
-        <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity duration-200 rounded-t-md flex items-center justify-center gap-2">
+        <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus-within:opacity-100 transition-opacity duration-200 rounded-t-md flex items-center justify-center gap-2">
           {isDiscovery && (
             <Tooltip>
               <TooltipTrigger asChild>


### PR DESCRIPTION
## Description

This PR addresses a critical accessibility issue where interactive buttons (View Details, Download, Hide) in the `GameCard` overlay were invisible to keyboard users.

## 💡 What

Added `group-focus-within:opacity-100` and `focus-within:opacity-100` to the `GameCard` overlay.

## 🎯 Why

Previously, the overlay was only revealed on hover (`group-hover:opacity-100`). Keyboard users tabbing through the game list would focus on invisible buttons, creating a "keyboard trap" where focus is lost visually. This change ensures the overlay becomes visible when any element inside it receives focus.

## 📸 Before/After

**Before:** Tabbing to "View Details" button -> Button is focused but invisible (overlay remains transparent).
**After:** Tabbing to "View Details" button -> Overlay becomes opaque, button and background are visible.

## ♿ Accessibility

- Fixes WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) for GameCard actions.
- Ensures keyboard users have the same information access as mouse users.

---

*PR created automatically by Jules for task [14874160256127674956](https://jules.google.com/task/14874160256127674956) started by @Doezer*