### PR TITLE
🎨 Palette: Dynamic ARIA labels for game actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Dynamic Button Context]
+**Learning:** Icon-only buttons in list components (like `GameCard` and `CompactGameCard`) were using generic labels ("Download game"), which is confusing for screen reader users navigating a list.
+**Action:** Always include the item's unique identifier (e.g., `game.title`) in `aria-label` for actions within a list item (e.g., `aria-label={`Download ${game.title}`}`).

--- a/client/__tests__/Accessibility.test.tsx
+++ b/client/__tests__/Accessibility.test.tsx
@@ -4,7 +4,6 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import CompactGameCard from "../src/components/CompactGameCard";
 import GameCard from "../src/components/GameCard";
-import AddGameModal from "../src/components/AddGameModal";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Game } from "@shared/schema";
@@ -53,7 +52,7 @@ const renderWithProviders = (ui: React.ReactElement) => {
   );
 };
 
-const mockGame: Game = {
+const mockGame = {
   id: "1",
   title: "Test Game",
   coverUrl: "http://example.com/cover.jpg",
@@ -67,7 +66,7 @@ const mockGame: Game = {
   folderName: "Test Game",
   createdAt: new Date(),
   updatedAt: new Date(),
-};
+} as unknown as Game;
 
 describe("Accessibility Improvements", () => {
   describe("CompactGameCard", () => {

--- a/client/__tests__/Accessibility.test.tsx
+++ b/client/__tests__/Accessibility.test.tsx
@@ -1,0 +1,104 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import CompactGameCard from "../src/components/CompactGameCard";
+import GameCard from "../src/components/GameCard";
+import AddGameModal from "../src/components/AddGameModal";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Game } from "@shared/schema";
+
+// Mock resize observer
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// Mock components
+vi.mock("lucide-react", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    Download: () => <div data-testid="icon-download" />,
+    Info: () => <div data-testid="icon-info" />,
+    Star: () => <div data-testid="icon-star" />,
+    Calendar: () => <div data-testid="icon-calendar" />,
+    Eye: () => <div data-testid="icon-eye" />,
+    EyeOff: () => <div data-testid="icon-eye-off" />,
+    Loader2: () => <div data-testid="icon-loader" />,
+    Plus: () => <div data-testid="icon-plus" />,
+    Search: () => <div data-testid="icon-search" />,
+  };
+});
+
+// Mock hooks
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// Setup QueryClient
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false },
+  },
+});
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>{ui}</TooltipProvider>
+    </QueryClientProvider>
+  );
+};
+
+const mockGame: Game = {
+  id: "1",
+  title: "Test Game",
+  coverUrl: "http://example.com/cover.jpg",
+  status: "wanted",
+  releaseDate: "2023-01-01",
+  rating: 8.5,
+  genres: ["Action"],
+  summary: "Test summary",
+  releaseStatus: "released",
+  hidden: false,
+  folderName: "Test Game",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe("Accessibility Improvements", () => {
+  describe("CompactGameCard", () => {
+    it("should have descriptive aria-labels for Discovery mode", () => {
+      renderWithProviders(<CompactGameCard game={mockGame} isDiscovery={true} />);
+
+      expect(screen.getByLabelText(`Download ${mockGame.title}`)).toBeInTheDocument();
+      expect(screen.getByLabelText(`View details for ${mockGame.title}`)).toBeInTheDocument();
+    });
+
+    it("should have descriptive aria-labels for Library mode", () => {
+      renderWithProviders(<CompactGameCard game={mockGame} isDiscovery={false} />);
+
+      expect(screen.getByLabelText(`View details for ${mockGame.title}`)).toBeInTheDocument();
+      expect(screen.getByLabelText(`Hide ${mockGame.title}`)).toBeInTheDocument();
+    });
+  });
+
+  describe("GameCard", () => {
+    it("should have descriptive aria-labels for Discovery mode", () => {
+      renderWithProviders(<GameCard game={mockGame} isDiscovery={true} />);
+
+      expect(screen.getByLabelText(`Download ${mockGame.title}`)).toBeInTheDocument();
+      expect(screen.getByLabelText(`View details for ${mockGame.title}`)).toBeInTheDocument();
+    });
+
+    it("should have descriptive aria-labels for Library mode", () => {
+      renderWithProviders(<GameCard game={mockGame} isDiscovery={false} />);
+
+      expect(screen.getByLabelText(`View details for ${mockGame.title}`)).toBeInTheDocument();
+      expect(screen.getByLabelText(`Hide ${mockGame.title}`)).toBeInTheDocument();
+    });
+  });
+});

--- a/client/__tests__/CompactGameCard.test.tsx
+++ b/client/__tests__/CompactGameCard.test.tsx
@@ -112,7 +112,7 @@ describe("CompactGameCard", () => {
     renderWithProviders(<CompactGameCard game={mockGame} onViewDetails={onViewDetails} />);
 
     // Info button is wrapped in a tooltip, but the button content is accessible via the icon mock or aria-label
-    const infoButton = screen.getByLabelText("View details");
+    const infoButton = screen.getByLabelText("View details for Test Game");
     fireEvent.click(infoButton);
 
     expect(onViewDetails).toHaveBeenCalledWith("1");

--- a/client/__tests__/CompactGameCard.test.tsx
+++ b/client/__tests__/CompactGameCard.test.tsx
@@ -57,7 +57,7 @@ vi.mock("lucide-react", async (importOriginal) => {
 });
 
 describe("CompactGameCard", () => {
-  const mockGame: Game = {
+  const mockGame = {
     id: "1",
     title: "Test Game",
     coverUrl: "http://example.com/cover.jpg",
@@ -71,7 +71,7 @@ describe("CompactGameCard", () => {
     folderName: "Test Game",
     createdAt: new Date(),
     updatedAt: new Date(),
-  };
+  } as unknown as Game;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -112,7 +112,7 @@ describe("CompactGameCard", () => {
     renderWithProviders(<CompactGameCard game={mockGame} onViewDetails={onViewDetails} />);
 
     // Info button is wrapped in a tooltip, but the button content is accessible via the icon mock or aria-label
-    const infoButton = screen.getByLabelText("View details for Test Game");
+    const infoButton = screen.getByLabelText(`View details for ${mockGame.title}`);
     fireEvent.click(infoButton);
 
     expect(onViewDetails).toHaveBeenCalledWith("1");

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -46,7 +46,7 @@ const mockGame = {
   genres: ["Action", "Adventure"],
   platforms: ["PC", "PS5"],
   screenshots: ["http://test.com/screen1.jpg", "http://test.com/screen2.jpg"],
-};
+} as unknown as import("@shared/schema").Game;
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -58,7 +58,7 @@ const mockGame = {
   title: "Test Game",
   igdbId: 123,
   gameDetails: {},
-};
+} as unknown as import("@shared/schema").Game;
 
 const mockTorrents = {
   items: [
@@ -185,7 +185,7 @@ describe("GameDownloadDialog", () => {
       }
 
       return Promise.resolve({ ok: false, json: async () => ({}) });
-    });
+    }) as any;
   });
 
   it("renders search results correctly", async () => {

--- a/client/__tests__/tsconfig.json
+++ b/client/__tests__/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["**/*"],
+  "compilerOptions": {
+    "types": [
+      "vitest/importMeta",
+      "vite/client",
+      "vitest/globals",
+      "@testing-library/jest-dom",
+      "node"
+    ]
+  }
+}

--- a/client/src/components/AddGameModal.tsx
+++ b/client/src/components/AddGameModal.tsx
@@ -167,7 +167,7 @@ export default function AddGameModal({ children }: AddGameModalProps) {
               </Button>
             </form>
 
-            <div className="space-y-4">
+            <div className="space-y-4" aria-live="polite">
               {isSearching && (
                 <div className="text-center py-8 text-muted-foreground">Searching games...</div>
               )}
@@ -242,6 +242,7 @@ export default function AddGameModal({ children }: AddGameModalProps) {
                               onClick={() => handleAddGame(game)}
                               disabled={addGameMutation.isPending}
                               data-testid={`button-add-${game.id}`}
+                              aria-label={`Add ${game.title} to collection`}
                             >
                               <Plus className="w-4 h-4 mr-1" />
                               Add

--- a/client/src/components/CompactGameCard.tsx
+++ b/client/src/components/CompactGameCard.tsx
@@ -285,7 +285,7 @@ const CompactGameCard = ({
                   )}
                   onClick={handleDownloadClick}
                   disabled={addGameMutation.isPending}
-                  aria-label="Download game"
+                  aria-label={`Download ${game.title}`}
                 >
                   {addGameMutation.isPending ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
@@ -333,7 +333,7 @@ const CompactGameCard = ({
                 variant="ghost"
                 className={cn("transition-all", density !== "comfortable" ? "h-6 w-6" : "h-8 w-8")}
                 onClick={handleDetailsClick}
-                aria-label="View details"
+                aria-label={`View details for ${game.title}`}
               >
                 <Info className={density !== "comfortable" ? "w-3 h-3" : "w-4 h-4"} />
               </Button>
@@ -352,7 +352,7 @@ const CompactGameCard = ({
                     density !== "comfortable" ? "h-6 w-6" : "h-8 w-8"
                   )}
                   onClick={handleToggleHidden}
-                  aria-label={game.hidden ? "Unhide game" : "Hide game"}
+                  aria-label={game.hidden ? `Unhide ${game.title}` : `Hide ${game.title}`}
                 >
                   {game.hidden ? (
                     <Eye className={density !== "comfortable" ? "w-3 h-3" : "w-4 h-4"} />

--- a/client/src/components/GameCard.tsx
+++ b/client/src/components/GameCard.tsx
@@ -189,7 +189,7 @@ const GameCard = ({
                   variant="default"
                   onClick={handleDownloadClick}
                   disabled={addGameMutation.isPending}
-                  aria-label="Download game"
+                  aria-label={`Download ${game.title}`}
                   data-testid={`button-download-${game.id}`}
                 >
                   {addGameMutation.isPending ? (
@@ -210,7 +210,7 @@ const GameCard = ({
                 size="icon"
                 variant="secondary"
                 onClick={handleDetailsClick}
-                aria-label="View details"
+                aria-label={`View details for ${game.title}`}
                 data-testid={`button-details-${game.id}`}
               >
                 <Info className="w-4 h-4" />
@@ -227,7 +227,7 @@ const GameCard = ({
                   size="icon"
                   variant="secondary"
                   onClick={handleToggleHidden}
-                  aria-label={game.hidden ? "Unhide game" : "Hide game"}
+                  aria-label={game.hidden ? `Unhide ${game.title}` : `Hide ${game.title}`}
                   data-testid={`button-toggle-hidden-${game.id}`}
                 >
                   {game.hidden ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}


### PR DESCRIPTION
This PR enhances the accessibility of the application by ensuring that icon-only buttons in list views (Game Grid, Compact List, Add Game Search) have descriptive, unique `aria-label`s that include the game title. This helps screen reader users distinguish between multiple "Download" or "View details" buttons. It also adds `aria-live` to the search results to announce updates. A new test file `client/__tests__/Accessibility.test.tsx` is added to prevent regression.

---

*PR created automatically by Jules for task [3325529360133509848](https://jules.google.com/task/3325529360133509848) started by @Doezer*