### PR TITLE
feat: Disable auto-search for unreleased games and allow enabling it optionally

### DIFF
--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -74,6 +74,7 @@ export default function SettingsPage() {
 
   // Local state for form
   const [autoSearchEnabled, setAutoSearchEnabled] = useState(true);
+  const [autoSearchUnreleased, setAutoSearchUnreleased] = useState(false);
   const [autoDownloadEnabled, setAutoDownloadEnabled] = useState(false);
   const [notifyMultipleDownloads, setNotifyMultipleDownloads] = useState(true);
   const [notifyUpdates, setNotifyUpdates] = useState(true);
@@ -93,6 +94,7 @@ export default function SettingsPage() {
   useEffect(() => {
     if (userSettings) {
       setAutoSearchEnabled(userSettings.autoSearchEnabled);
+      setAutoSearchUnreleased(userSettings.autoSearchUnreleased ?? false);
       setAutoDownloadEnabled(userSettings.autoDownloadEnabled);
       setNotifyMultipleDownloads(userSettings.notifyMultipleDownloads);
       setNotifyUpdates(userSettings.notifyUpdates);
@@ -353,6 +355,7 @@ export default function SettingsPage() {
     updateSettingsMutation.mutate({
       updates: {
         autoSearchEnabled,
+        autoSearchUnreleased,
         autoDownloadEnabled,
         notifyMultipleDownloads,
         notifyUpdates,
@@ -520,6 +523,25 @@ export default function SettingsPage() {
                       <p className="text-xs text-muted-foreground">
                         How often to search for new releases (1-168 hours)
                       </p>
+                    </div>
+                  )}
+
+                  {/* Auto Search Unreleased Toggle */}
+                  {autoSearchEnabled && (
+                    <div className="flex items-center justify-between pl-4 border-l-2">
+                      <div className="space-y-0.5">
+                        <Label htmlFor="auto-search-unreleased" className="text-sm font-medium">
+                          Search Unreleased Games
+                        </Label>
+                        <p className="text-xs text-muted-foreground">
+                          Include unreleased (upcoming/delayed) games in search
+                        </p>
+                      </div>
+                      <Switch
+                        id="auto-search-unreleased"
+                        checked={autoSearchUnreleased}
+                        onCheckedChange={setAutoSearchUnreleased}
+                      />
                     </div>
                   )}
 

--- a/migrations/0004_thin_wendigo.sql
+++ b/migrations/0004_thin_wendigo.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_settings` ADD `auto_search_unreleased` integer DEFAULT false NOT NULL;

--- a/migrations/meta/0004_snapshot.json
+++ b/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1051 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d7cbee11-9966-46ae-b1c9-56274dfc9eeb",
+  "prevId": "0b4f22a4-997f-4b74-869f-4d781ab46f5b",
+  "tables": {
+    "downloaders": {
+      "name": "downloaders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "url_path": {
+          "name": "url_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "download_path": {
+          "name": "download_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'games'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Questarr'"
+        },
+        "add_stopped": {
+          "name": "add_stopped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "remove_completed": {
+          "name": "remove_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "post_import_category": {
+          "name": "post_import_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_downloads": {
+      "name": "game_downloads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "downloader_id": {
+          "name": "downloader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_type": {
+          "name": "download_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torrent'"
+        },
+        "download_hash": {
+          "name": "download_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_title": {
+          "name": "download_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'downloading'"
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_downloads_game_id_games_id_fk": {
+          "name": "game_downloads_game_id_games_id_fk",
+          "tableFrom": "game_downloads",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_downloads_downloader_id_downloaders_id_fk": {
+          "name": "game_downloads_downloader_id_downloaders_id_fk",
+          "tableFrom": "game_downloads",
+          "tableTo": "downloaders",
+          "columnsFrom": ["downloader_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "games": {
+      "name": "games",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publishers": {
+          "name": "publishers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "developers": {
+          "name": "developers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "original_release_date": {
+          "name": "original_release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_status": {
+          "name": "release_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'upcoming'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_user_id_users_id_fk": {
+          "name": "games_user_id_users_id_fk",
+          "tableFrom": "games",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexers": {
+      "name": "indexers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torznab'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "rss_enabled": {
+          "name": "rss_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_search_enabled": {
+          "name": "auto_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read": {
+          "name": "read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_feed_items": {
+      "name": "rss_feed_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pub_date": {
+          "name": "pub_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_game_id": {
+          "name": "igdb_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_game_name": {
+          "name": "igdb_game_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rss_feed_items_feed_id_rss_feeds_id_fk": {
+          "name": "rss_feed_items_feed_id_rss_feeds_id_fk",
+          "tableFrom": "rss_feed_items",
+          "tableTo": "rss_feeds",
+          "columnsFrom": ["feed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_feeds": {
+      "name": "rss_feeds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "mapping": {
+          "name": "mapping",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_config": {
+      "name": "system_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auto_search_enabled": {
+          "name": "auto_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_download_enabled": {
+          "name": "auto_download_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_multiple_downloads": {
+          "name": "notify_multiple_downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_updates": {
+          "name": "notify_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "search_interval_hours": {
+          "name": "search_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 6
+        },
+        "igdb_rate_limit_per_second": {
+          "name": "igdb_rate_limit_per_second",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "download_rules": {
+          "name": "download_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_auto_search": {
+          "name": "last_auto_search",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "xrel_scene_releases": {
+          "name": "xrel_scene_releases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "xrel_p2p_releases": {
+          "name": "xrel_p2p_releases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_search_unreleased": {
+          "name": "auto_search_unreleased",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "xrel_notified_releases": {
+      "name": "xrel_notified_releases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "xrel_release_id": {
+          "name": "xrel_release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "xrel_notified_releases_game_id_games_id_fk": {
+          "name": "xrel_notified_releases_game_id_games_id_fk",
+          "tableFrom": "xrel_notified_releases",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1770123406692,
       "tag": "0003_free_centennial",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1771060272911,
+      "tag": "0004_thin_wendigo",
+      "breakpoints": true
     }
   ]
 }

--- a/server/__tests__/cron_autosearch.test.ts
+++ b/server/__tests__/cron_autosearch.test.ts
@@ -1,46 +1,23 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Game, UserSettings } from "@shared/schema";
 
 // --- Mocks ---
+const createMockLogger = () => ({
+  info: vi.fn(),
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
 // Mock logger to avoid noise and missing exports
 vi.mock("../logger.js", () => ({
   logger: { child: vi.fn().mockReturnThis() },
-  igdbLogger: {
-    info: vi.fn(),
-    debug: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
-  searchLogger: {
-    warn: vi.fn(),
-    info: vi.fn(),
-    debug: vi.fn(),
-    error: vi.fn(),
-  },
-  torznabLogger: {
-    info: vi.fn(),
-    debug: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
-  routesLogger: {
-    info: vi.fn(),
-    debug: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
-  expressLogger: {
-    info: vi.fn(),
-    debug: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
-  downloadersLogger: {
-    info: vi.fn(),
-    debug: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
+  igdbLogger: createMockLogger(),
+  searchLogger: createMockLogger(),
+  torznabLogger: createMockLogger(),
+  routesLogger: createMockLogger(),
+  expressLogger: createMockLogger(),
+  downloadersLogger: createMockLogger(),
 }));
 
 // Mock storage

--- a/server/__tests__/cron_autosearch.test.ts
+++ b/server/__tests__/cron_autosearch.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Game, UserSettings } from "@shared/schema";
+
+// --- Mocks ---
+// Mock logger to avoid noise and missing exports
+vi.mock("../logger.js", () => ({
+  logger: { child: vi.fn().mockReturnThis() },
+  igdbLogger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  searchLogger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+  torznabLogger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  routesLogger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  expressLogger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  downloadersLogger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock storage
+const mockGetWantedGamesGroupedByUser = vi.fn();
+const mockGetUserSettings = vi.fn();
+const mockUpdateUserSettings = vi.fn();
+const mockAddNotification = vi.fn();
+
+vi.mock("../storage.js", () => ({
+  storage: {
+    getWantedGamesGroupedByUser: mockGetWantedGamesGroupedByUser,
+    getUserSettings: mockGetUserSettings,
+    updateUserSettings: mockUpdateUserSettings,
+    addNotification: mockAddNotification,
+    // Other methods that might be called (though ideally we isolate the test enough)
+    getEnabledDownloaders: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+// Mock search
+const mockSearchAllIndexers = vi.fn();
+vi.mock("../search.js", () => ({
+  searchAllIndexers: mockSearchAllIndexers,
+}));
+
+// Mock socket
+vi.mock("../socket.js", () => ({
+  notifyUser: vi.fn(),
+}));
+
+// Mock downloaders
+vi.mock("../downloaders.js", () => ({
+  DownloaderManager: {
+    addDownloadWithFallback: vi.fn(),
+  },
+}));
+
+// Mock igdb
+vi.mock("../igdb.js", () => ({
+  igdbClient: {
+    getGamesByIds: vi.fn(),
+  },
+}));
+
+// Mock xrel
+vi.mock("../xrel.js", () => ({
+  xrelClient: {
+    getLatestReleases: vi.fn(),
+  },
+  DEFAULT_XREL_BASE: "http://example.com",
+}));
+
+// Import the function under test
+// We need to use dynamic import or require because of the hoisting of vi.mock
+const { checkAutoSearch } = await import("../cron.js");
+
+describe("Cron - checkAutoSearch", () => {
+  const userId = "user-123";
+
+  const baseGame: Game = {
+    id: "game-1",
+    userId: userId,
+    igdbId: 1001,
+    title: "Test Game",
+    status: "wanted",
+    releaseStatus: "released",
+    hidden: false,
+    addedAt: new Date(),
+    completedAt: null,
+    // Optional fields
+    summary: null,
+    coverUrl: null,
+    releaseDate: null,
+    rating: null,
+    platforms: [],
+    genres: [],
+    publishers: [],
+    developers: [],
+    screenshots: [],
+    originalReleaseDate: null,
+  };
+
+  const baseSettings: UserSettings = {
+    id: "settings-1",
+    userId: userId,
+    autoSearchEnabled: true,
+    autoDownloadEnabled: false,
+    notifyMultipleDownloads: false,
+    notifyUpdates: false,
+    searchIntervalHours: 6, // Default interval
+    igdbRateLimitPerSecond: 3,
+    downloadRules: null,
+    lastAutoSearch: null, // Never searched before, so should run immediately
+    xrelSceneReleases: true,
+    xrelP2pReleases: false,
+    autoSearchUnreleased: false, // Default: false
+    updatedAt: new Date(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default mock setup:
+    // - 1 user with 1 wanted game (released)
+    // - User has auto search enabled
+    mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [baseGame]]]));
+    mockGetUserSettings.mockResolvedValue(baseSettings);
+    mockSearchAllIndexers.mockResolvedValue({ items: [], errors: [], total: 0 });
+  });
+
+  it("should search for released games when autoSearchUnreleased is false (default)", async () => {
+    // Setup: Game is released. Settings default (autoSearchUnreleased = false).
+    const game = { ...baseGame, releaseStatus: "released" as const };
+    mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+
+    await checkAutoSearch();
+
+    expect(mockSearchAllIndexers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: game.title,
+      })
+    );
+  });
+
+  it("should NOT search for unreleased games when autoSearchUnreleased is false", async () => {
+    // Setup: Game is unreleased (upcoming). Settings default (autoSearchUnreleased = false).
+    const game = { ...baseGame, releaseStatus: "upcoming" as const };
+    mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+
+    await checkAutoSearch();
+
+    expect(mockSearchAllIndexers).not.toHaveBeenCalled();
+  });
+
+  it("should search for released games when autoSearchUnreleased is true", async () => {
+    // Setup: Game is released. Settings enabled (autoSearchUnreleased = true).
+    const game = { ...baseGame, releaseStatus: "released" as const };
+    const settings = { ...baseSettings, autoSearchUnreleased: true };
+
+    mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+    mockGetUserSettings.mockResolvedValue(settings);
+
+    await checkAutoSearch();
+
+    expect(mockSearchAllIndexers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: game.title,
+      })
+    );
+  });
+
+  it("should search for unreleased games when autoSearchUnreleased is true", async () => {
+    // Setup: Game is unreleased (upcoming). Settings enabled (autoSearchUnreleased = true).
+    const game = { ...baseGame, releaseStatus: "upcoming" as const };
+    const settings = { ...baseSettings, autoSearchUnreleased: true };
+
+    mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+    mockGetUserSettings.mockResolvedValue(settings);
+
+    await checkAutoSearch();
+
+    expect(mockSearchAllIndexers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: game.title,
+      })
+    );
+  });
+
+  it("should search for delayed games when autoSearchUnreleased is true", async () => {
+    // Setup: Game is delayed. Settings enabled (autoSearchUnreleased = true).
+    const game = { ...baseGame, releaseStatus: "delayed" as const };
+    const settings = { ...baseSettings, autoSearchUnreleased: true };
+
+    mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+    mockGetUserSettings.mockResolvedValue(settings);
+
+    await checkAutoSearch();
+
+    expect(mockSearchAllIndexers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: game.title,
+      })
+    );
+  });
+
+  it("should NOT search for delayed games when autoSearchUnreleased is false", async () => {
+    // Setup: Game is delayed. Settings disabled (autoSearchUnreleased = false).
+    const game = { ...baseGame, releaseStatus: "delayed" as const };
+    const settings = { ...baseSettings, autoSearchUnreleased: false };
+
+    mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+    mockGetUserSettings.mockResolvedValue(settings);
+
+    await checkAutoSearch();
+
+    expect(mockSearchAllIndexers).not.toHaveBeenCalled();
+  });
+
+  it("should respect search interval", async () => {
+    // Setup: Last search was very recent.
+    const settings = {
+      ...baseSettings,
+      lastAutoSearch: new Date(), // Just now
+      searchIntervalHours: 6,
+    };
+    mockGetUserSettings.mockResolvedValue(settings);
+
+    await checkAutoSearch();
+
+    expect(mockSearchAllIndexers).not.toHaveBeenCalled();
+  });
+
+  it("should search if interval has passed", async () => {
+    // Setup: Last search was long ago.
+    const lastSearch = new Date();
+    lastSearch.setHours(lastSearch.getHours() - 7); // 7 hours ago
+
+    const settings = {
+      ...baseSettings,
+      lastAutoSearch: lastSearch,
+      searchIntervalHours: 6,
+    };
+    mockGetUserSettings.mockResolvedValue(settings);
+
+    await checkAutoSearch();
+
+    expect(mockSearchAllIndexers).toHaveBeenCalled();
+  });
+});

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -448,6 +448,15 @@ async function checkAutoSearch() {
 
         for (const game of wantedGames) {
           try {
+            // Skip unreleased games if configured to do so
+            if (!settings.autoSearchUnreleased && game.releaseStatus !== "released") {
+              igdbLogger.debug(
+                { gameTitle: game.title, status: game.releaseStatus },
+                "Skipping auto-search for unreleased game"
+              );
+              continue;
+            }
+
             // Search for the game across all indexers
             const { items, errors } = await searchAllIndexers({
               query: game.title,

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -402,7 +402,7 @@ async function checkDownloadStatus() {
   }
 }
 
-async function checkAutoSearch() {
+export async function checkAutoSearch() {
   igdbLogger.debug("Checking auto-search for wanted games...");
 
   try {

--- a/server/run-migrations.ts
+++ b/server/run-migrations.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { runMigrations } from "./migrate.js";
 import { logger } from "./logger.js";
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -751,6 +751,7 @@ export class MemStorage implements IStorage {
       lastAutoSearch: insertSettings.lastAutoSearch ?? null,
       xrelSceneReleases: insertSettings.xrelSceneReleases ?? true,
       xrelP2pReleases: insertSettings.xrelP2pReleases ?? false,
+      autoSearchUnreleased: insertSettings.autoSearchUnreleased ?? false,
       updatedAt: new Date(),
     };
     this.userSettings.set(id, settings);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -29,6 +29,9 @@ export const userSettings = sqliteTable("user_settings", {
   lastAutoSearch: integer("last_auto_search", { mode: "timestamp_ms" }),
   xrelSceneReleases: integer("xrel_scene_releases", { mode: "boolean" }).notNull().default(true),
   xrelP2pReleases: integer("xrel_p2p_releases", { mode: "boolean" }).notNull().default(false),
+  autoSearchUnreleased: integer("auto_search_unreleased", { mode: "boolean" })
+    .notNull()
+    .default(false),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }).default(
     sql`(strftime('%s', 'now') * 1000)`
   ),


### PR DESCRIPTION
This pull request introduces a new user setting that allows users to control whether unreleased games are included in the automatic search feature. The change is implemented across the database schema, backend logic, and frontend settings UI. Additionally, a minor update ensures environment variables are loaded for migrations.

**New "Auto Search Unreleased" Setting**

*Database and Schema:*

- Added a new `auto_search_unreleased` boolean column to the `user_settings` table, with a default of `false`. This is reflected in both the SQL migration and the shared schema definition. [[1]](diffhunk://#diff-20da29e3da936b1513f4f7a17e855d5f0726974f597aa5d618ef73c0f2172bd3R1) [[2]](diffhunk://#diff-248adfc01eb4816dcacc7b777efec7f15df5a4c21da1eaa3f5214b3eb61e1e9aR32-R34)
- Updated the migration journal to include the new migration.

*Backend Logic:*

- Updated the auto-search cron job to skip unreleased games if the user has disabled the new setting.
- Ensured the in-memory storage implementation and settings update logic handle the new field with a default of `false`.

*Frontend/UI:*

- Added local state and UI controls in `SettingsPage` to allow users to toggle the "Search Unreleased Games" option, which is only shown if auto-search is enabled. [[1]](diffhunk://#diff-ef86b78ab3a2fcb20b1b2b6d4acb9f78241d5b4c4583ea386e82b788f4aa688aR63) [[2]](diffhunk://#diff-ef86b78ab3a2fcb20b1b2b6d4acb9f78241d5b4c4583ea386e82b788f4aa688aR83) [[3]](diffhunk://#diff-ef86b78ab3a2fcb20b1b2b6d4acb9f78241d5b4c4583ea386e82b788f4aa688aR381-R399)
- Ensured that the new setting is included when updating user settings.

**Other Improvements**

*Migration Tooling:*

- Ensured environment variables are loaded when running migrations by importing `dotenv/config` in the migration runner.