### PR TITLE
🎨 Palette: Add dynamic ARIA labels to game cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-18 - Dynamic ARIA Labels in Lists
+**Learning:** List components (like `GameCard` and `CompactGameCard`) frequently use icon-only buttons for actions like "Download" or "View Details". Without dynamic `aria-label`s including the item title, screen reader users cannot distinguish between these buttons in a list.
+**Action:** Always include the item's unique identifier (e.g., title) in `aria-label`s for repeated action buttons in lists (e.g., `aria-label={\`Download ${game.title}\`}`).

--- a/client/__tests__/CompactGameCard.test.tsx
+++ b/client/__tests__/CompactGameCard.test.tsx
@@ -112,7 +112,7 @@ describe("CompactGameCard", () => {
     renderWithProviders(<CompactGameCard game={mockGame} onViewDetails={onViewDetails} />);
 
     // Info button is wrapped in a tooltip, but the button content is accessible via the icon mock or aria-label
-    const infoButton = screen.getByLabelText("View details");
+    const infoButton = screen.getByLabelText("View details for Test Game");
     fireEvent.click(infoButton);
 
     expect(onViewDetails).toHaveBeenCalledWith("1");

--- a/client/__tests__/GameCard.test.tsx
+++ b/client/__tests__/GameCard.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import GameCard from "../src/components/GameCard";
+import { Game } from "@shared/schema";
+import * as toastHook from "@/hooks/use-toast";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+// Mocks
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: vi.fn(),
+}));
+
+vi.mock("@/lib/queryClient", async () => {
+  const { QueryClient } = await import("@tanstack/react-query");
+  return {
+    apiRequest: vi.fn(),
+    queryClient: new QueryClient(),
+  };
+});
+
+// Setup QueryClient
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+const mockGame: Game = {
+  id: "game-123",
+  title: "Super Mario Odyssey",
+  coverUrl: "http://example.com/mario.jpg",
+  rating: 9,
+  releaseDate: "2017-10-27",
+  genres: ["Platformer", "Action"],
+  status: "wanted",
+  hidden: false,
+  summary: "Mario travels the world.",
+  igdbId: 123,
+  platform: "Nintendo Switch",
+  releaseStatus: "released",
+  folderName: null,
+  monitored: true,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe("GameCard", () => {
+  let queryClient: QueryClient;
+  const mockToast = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = createTestQueryClient();
+    (toastHook.useToast as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      toast: mockToast,
+    });
+  });
+
+  const renderComponent = (component: React.ReactNode) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>{component}</TooltipProvider>
+      </QueryClientProvider>
+    );
+  };
+
+  it("renders with correct accessibility labels", async () => {
+    renderComponent(<GameCard game={mockGame} />);
+
+    // Check for "View details" button
+    const detailsButton = screen.getByRole("button", {
+      name: `View details for ${mockGame.title}`,
+    });
+    expect(detailsButton).toBeInTheDocument();
+
+    // Check for "Hide game" button
+    const hideButton = screen.getByRole("button", {
+      name: `Hide ${mockGame.title}`,
+    });
+    expect(hideButton).toBeInTheDocument();
+  });
+
+  it("renders 'Unhide' label when game is hidden", async () => {
+    const hiddenGame = { ...mockGame, hidden: true };
+    renderComponent(<GameCard game={hiddenGame} />);
+
+    const unhideButton = screen.getByRole("button", {
+      name: `Unhide ${hiddenGame.title}`,
+    });
+    expect(unhideButton).toBeInTheDocument();
+  });
+
+  it("renders download button with correct label in discovery mode", async () => {
+    // Discovery mode uses a different button set
+    renderComponent(<GameCard game={mockGame} isDiscovery={true} />);
+
+    const downloadButton = screen.getByRole("button", {
+      name: `Download ${mockGame.title}`,
+    });
+    expect(downloadButton).toBeInTheDocument();
+  });
+});

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -10,133 +10,134 @@ import { Toaster } from "@/components/ui/toaster";
 
 // Mocking external dependencies
 vi.mock("@/hooks/use-toast", () => ({
-    useToast: () => ({
-        toast: vi.fn(),
-        toasts: [],
-    }),
+  useToast: () => ({
+    toast: vi.fn(),
+    toasts: [],
+  }),
 }));
 
 vi.mock("../src/components/StatusBadge", () => ({
-    default: ({ status }: { status: string }) => <div data-testid="status-badge">{status}</div>,
+  default: ({ status }: { status: string }) => <div data-testid="status-badge">{status}</div>,
 }));
 
 vi.mock("../src/components/GameDownloadDialog", () => ({
-    default: ({ open }: { open: boolean }) => (
-        open ? <div data-testid="game-download-dialog">Download Dialog</div> : null
-    ),
+  default: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="game-download-dialog">Download Dialog</div> : null,
 }));
 
 vi.mock("lucide-react", () => ({
-    Calendar: (props: Record<string, unknown>) => <div data-testid="icon-calendar" {...props} />,
-    Star: (props: Record<string, unknown>) => <div data-testid="icon-star" {...props} />,
-    Monitor: (props: Record<string, unknown>) => <div data-testid="icon-monitor" {...props} />,
-    Gamepad2: (props: Record<string, unknown>) => <div data-testid="icon-gamepad2" {...props} />,
-    Tag: (props: Record<string, unknown>) => <div data-testid="icon-tag" {...props} />,
-    Download: (props: Record<string, unknown>) => <div data-testid="icon-download" {...props} />,
-    X: (props: Record<string, unknown>) => <div data-testid="icon-x" {...props} />,
+  Calendar: (props: Record<string, unknown>) => <div data-testid="icon-calendar" {...props} />,
+  Star: (props: Record<string, unknown>) => <div data-testid="icon-star" {...props} />,
+  Monitor: (props: Record<string, unknown>) => <div data-testid="icon-monitor" {...props} />,
+  Gamepad2: (props: Record<string, unknown>) => <div data-testid="icon-gamepad2" {...props} />,
+  Tag: (props: Record<string, unknown>) => <div data-testid="icon-tag" {...props} />,
+  Download: (props: Record<string, unknown>) => <div data-testid="icon-download" {...props} />,
+  X: (props: Record<string, unknown>) => <div data-testid="icon-x" {...props} />,
 }));
 
 const mockGame = {
-    id: 1,
-    title: "Test Game",
-    summary: "This is a test summary for the game.",
-    status: "wanted",
-    rating: 8.5,
-    releaseDate: new Date("2023-01-01").toISOString(),
-    coverUrl: "http://test.com/cover.jpg",
-    genres: ["Action", "Adventure"],
-    platforms: ["PC", "PS5"],
-    screenshots: ["http://test.com/screen1.jpg", "http://test.com/screen2.jpg"],
+  id: 1,
+  title: "Test Game",
+  summary: "This is a test summary for the game.",
+  status: "wanted",
+  rating: 8.5,
+  releaseDate: new Date("2023-01-01").toISOString(),
+  coverUrl: "http://test.com/cover.jpg",
+  genres: ["Action", "Adventure"],
+  platforms: ["PC", "PS5"],
+  screenshots: ["http://test.com/screen1.jpg", "http://test.com/screen2.jpg"],
 };
 
 const queryClient = new QueryClient({
-    defaultOptions: {
-        queries: {
-            retry: false,
-            queryFn: async ({ queryKey }) => {
-                const response = await fetch(queryKey.join(""));
-                if (!response.ok) throw new Error("Network response was not ok");
-                return response.json();
-            },
-        },
+  defaultOptions: {
+    queries: {
+      retry: false,
+      queryFn: async ({ queryKey }) => {
+        const response = await fetch(queryKey.join(""));
+        if (!response.ok) throw new Error("Network response was not ok");
+        return response.json();
+      },
     },
+  },
 });
 
 // Mock fetch
 global.fetch = vi.fn();
 
 const renderComponent = (game = mockGame) => {
-    return render(
-        <QueryClientProvider client={queryClient}>
-            <GameDetailsModal game={game} open={true} onOpenChange={() => { }} />
-            <Toaster />
-        </QueryClientProvider>
-    );
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GameDetailsModal game={game} open={true} onOpenChange={() => {}} />
+      <Toaster />
+    </QueryClientProvider>
+  );
 };
 
 describe("GameDetailsModal", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders game details correctly", () => {
+    renderComponent();
+    expect(screen.getByTestId("text-game-title-1")).toHaveTextContent("Test Game");
+    expect(screen.getByTestId("text-summary-1")).toHaveTextContent(
+      "This is a test summary for the game."
+    );
+    expect(screen.getByTestId("text-rating-1")).toHaveTextContent("8.5/10");
+    expect(screen.getByTestId("text-release-date-1")).toHaveTextContent("2023");
+    expect(screen.getByTestId("img-cover-1")).toBeInTheDocument();
+  });
+
+  it("renders genres and platforms", () => {
+    renderComponent();
+    expect(screen.getByTestId("badge-genre-action")).toBeInTheDocument();
+    expect(screen.getByTestId("badge-genre-adventure")).toBeInTheDocument();
+    expect(screen.getByTestId("badge-platform-pc")).toBeInTheDocument();
+    expect(screen.getByTestId("badge-platform-ps5")).toBeInTheDocument();
+  });
+
+  it("renders screenshots", () => {
+    renderComponent();
+    expect(screen.getAllByRole("img", { name: /screenshot/i })).toHaveLength(2);
+  });
+
+  it("opens download dialog when download button is clicked", () => {
+    renderComponent();
+    const downloadButton = screen.getByTestId("button-download-game");
+    fireEvent.click(downloadButton);
+    expect(screen.getByTestId("game-download-dialog")).toBeInTheDocument();
+  });
+
+  it("handles remove game action", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true });
+    renderComponent();
+
+    // Need to find the remote button with the complex ID
+    const removeButton = screen.getByTestId(`button-remove-game-quick-${mockGame.id}`);
+    fireEvent.click(removeButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/games/1"),
+        expect.objectContaining({ method: "DELETE" })
+      );
     });
+  });
 
-    it("renders game details correctly", () => {
-        renderComponent();
-        expect(screen.getByTestId("text-game-title-1")).toHaveTextContent("Test Game");
-        expect(screen.getByTestId("text-summary-1")).toHaveTextContent("This is a test summary for the game.");
-        expect(screen.getByTestId("text-rating-1")).toHaveTextContent("8.5/10");
-        expect(screen.getByTestId("text-release-date-1")).toHaveTextContent("2023");
-        expect(screen.getByTestId("img-cover-1")).toBeInTheDocument();
-    });
+  it("truncates long summary and expands it", () => {
+    const longSummaryGame = {
+      ...mockGame,
+      summary: "A".repeat(300),
+    };
+    renderComponent(longSummaryGame);
 
-    it("renders genres and platforms", () => {
-        renderComponent();
-        expect(screen.getByTestId("badge-genre-action")).toBeInTheDocument();
-        expect(screen.getByTestId("badge-genre-adventure")).toBeInTheDocument();
-        expect(screen.getByTestId("badge-platform-pc")).toBeInTheDocument();
-        expect(screen.getByTestId("badge-platform-ps5")).toBeInTheDocument();
-    });
+    const summaryText = screen.getByTestId(`text-summary-${mockGame.id}`);
+    expect(summaryText).toHaveTextContent("Read more");
 
-    it("renders screenshots", () => {
-        renderComponent();
-        expect(screen.getAllByRole("img", { name: /screenshot/i })).toHaveLength(2);
-    });
+    const readMoreButton = screen.getByText("Read more");
+    fireEvent.click(readMoreButton);
 
-    it("opens download dialog when download button is clicked", () => {
-        renderComponent();
-        const downloadButton = screen.getByTestId("button-download-game");
-        fireEvent.click(downloadButton);
-        expect(screen.getByTestId("game-download-dialog")).toBeInTheDocument();
-    });
-
-    it("handles remove game action", async () => {
-        global.fetch = vi.fn().mockResolvedValue({ ok: true });
-        renderComponent();
-
-        // Need to find the remote button with the complex ID
-        const removeButton = screen.getByTestId(`button-remove-game-quick-${mockGame.id}`);
-        fireEvent.click(removeButton);
-
-        await waitFor(() => {
-            expect(global.fetch).toHaveBeenCalledWith(
-                expect.stringContaining("/api/games/1"),
-                expect.objectContaining({ method: "DELETE" })
-            );
-        });
-    });
-
-    it("truncates long summary and expands it", () => {
-        const longSummaryGame = {
-            ...mockGame,
-            summary: "A".repeat(300),
-        };
-        renderComponent(longSummaryGame);
-
-        const summaryText = screen.getByTestId(`text-summary-${mockGame.id}`);
-        expect(summaryText).toHaveTextContent("Read more");
-
-        const readMoreButton = screen.getByText("Read more");
-        fireEvent.click(readMoreButton);
-
-        expect(summaryText).toHaveTextContent("Show less");
-    });
+    expect(summaryText).toHaveTextContent("Show less");
+  });
 });

--- a/client/__tests__/usenet-utils.test.ts
+++ b/client/__tests__/usenet-utils.test.ts
@@ -2,18 +2,18 @@ import { describe, it, expect } from "vitest";
 import { isUsenetItem } from "../src/lib/downloads-utils";
 
 describe("isUsenetItem", () => {
-    it("should return true for items with grabs or age", () => {
-        expect(isUsenetItem({ grabs: 10 })).toBe(true);
-        expect(isUsenetItem({ age: 5 })).toBe(true);
-        expect(isUsenetItem({ grabs: 0, age: 0 })).toBe(true);
-    });
+  it("should return true for items with grabs or age", () => {
+    expect(isUsenetItem({ grabs: 10 })).toBe(true);
+    expect(isUsenetItem({ age: 5 })).toBe(true);
+    expect(isUsenetItem({ grabs: 0, age: 0 })).toBe(true);
+  });
 
-    it("should return false for items with seeders", () => {
-        expect(isUsenetItem({ seeders: 10 })).toBe(false);
-        expect(isUsenetItem({ seeders: 0 })).toBe(false);
-    });
+  it("should return false for items with seeders", () => {
+    expect(isUsenetItem({ seeders: 10 })).toBe(false);
+    expect(isUsenetItem({ seeders: 0 })).toBe(false);
+  });
 
-    it("should return false for empty items (default to torrent)", () => {
-        expect(isUsenetItem({})).toBe(false);
-    });
+  it("should return false for empty items (default to torrent)", () => {
+    expect(isUsenetItem({})).toBe(false);
+  });
 });

--- a/client/src/components/CompactGameCard.tsx
+++ b/client/src/components/CompactGameCard.tsx
@@ -285,7 +285,7 @@ const CompactGameCard = ({
                   )}
                   onClick={handleDownloadClick}
                   disabled={addGameMutation.isPending}
-                  aria-label="Download game"
+                  aria-label={`Download ${game.title}`}
                 >
                   {addGameMutation.isPending ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
@@ -333,7 +333,7 @@ const CompactGameCard = ({
                 variant="ghost"
                 className={cn("transition-all", density !== "comfortable" ? "h-6 w-6" : "h-8 w-8")}
                 onClick={handleDetailsClick}
-                aria-label="View details"
+                aria-label={`View details for ${game.title}`}
               >
                 <Info className={density !== "comfortable" ? "w-3 h-3" : "w-4 h-4"} />
               </Button>
@@ -352,7 +352,7 @@ const CompactGameCard = ({
                     density !== "comfortable" ? "h-6 w-6" : "h-8 w-8"
                   )}
                   onClick={handleToggleHidden}
-                  aria-label={game.hidden ? "Unhide game" : "Hide game"}
+                  aria-label={game.hidden ? `Unhide ${game.title}` : `Hide ${game.title}`}
                 >
                   {game.hidden ? (
                     <Eye className={density !== "comfortable" ? "w-3 h-3" : "w-4 h-4"} />

--- a/client/src/components/GameCard.tsx
+++ b/client/src/components/GameCard.tsx
@@ -189,7 +189,7 @@ const GameCard = ({
                   variant="default"
                   onClick={handleDownloadClick}
                   disabled={addGameMutation.isPending}
-                  aria-label="Download game"
+                  aria-label={`Download ${game.title}`}
                   data-testid={`button-download-${game.id}`}
                 >
                   {addGameMutation.isPending ? (
@@ -210,7 +210,7 @@ const GameCard = ({
                 size="icon"
                 variant="secondary"
                 onClick={handleDetailsClick}
-                aria-label="View details"
+                aria-label={`View details for ${game.title}`}
                 data-testid={`button-details-${game.id}`}
               >
                 <Info className="w-4 h-4" />
@@ -227,7 +227,7 @@ const GameCard = ({
                   size="icon"
                   variant="secondary"
                   onClick={handleToggleHidden}
-                  aria-label={game.hidden ? "Unhide game" : "Hide game"}
+                  aria-label={game.hidden ? `Unhide ${game.title}` : `Hide ${game.title}`}
                   data-testid={`button-toggle-hidden-${game.id}`}
                 >
                   {game.hidden ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}

--- a/client/src/components/RssFeedList.tsx
+++ b/client/src/components/RssFeedList.tsx
@@ -92,11 +92,13 @@ export default function RssFeedList() {
         </Button>
       </div>
 
-      <div className={cn(
-        "grid gap-4",
-        viewMode === "grid" ? "md:grid-cols-2 lg:grid-cols-3" : "grid-cols-1"
-      )}>
-        {items.map((item) => (
+      <div
+        className={cn(
+          "grid gap-4",
+          viewMode === "grid" ? "md:grid-cols-2 lg:grid-cols-3" : "grid-cols-1"
+        )}
+      >
+        {items.map((item) =>
           viewMode === "list" ? (
             <CompactRssFeedItem key={item.id} item={item} />
           ) : (
@@ -146,7 +148,7 @@ export default function RssFeedList() {
               </CardContent>
             </Card>
           )
-        ))}
+        )}
       </div>
     </div>
   );

--- a/client/src/components/ui/badge.tsx
+++ b/client/src/components/ui/badge.tsx
@@ -24,8 +24,7 @@ const badgeVariants = cva(
 );
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+  extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
 
 const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
   ({ className, variant, ...props }, ref) => {

--- a/client/src/pages/rss.tsx
+++ b/client/src/pages/rss.tsx
@@ -2,21 +2,21 @@ import RssFeedList from "@/components/RssFeedList";
 import RssSettings from "@/components/RssSettings";
 
 export default function RssPage() {
-    return (
-        <div className="container mx-auto p-6 space-y-6 h-full overflow-y-auto">
-            <div className="flex justify-between items-center">
-                <div>
-                    <h1 className="text-3xl font-bold tracking-tight">RSS Feeds</h1>
-                    <p className="text-muted-foreground mt-1">
-                        Browse and manage RSS feeds to automatically track releases.
-                    </p>
-                </div>
-                <RssSettings />
-            </div>
-
-            <div className="mt-6">
-                <RssFeedList />
-            </div>
+  return (
+    <div className="container mx-auto p-6 space-y-6 h-full overflow-y-auto">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">RSS Feeds</h1>
+          <p className="text-muted-foreground mt-1">
+            Browse and manage RSS feeds to automatically track releases.
+          </p>
         </div>
-    );
+        <RssSettings />
+      </div>
+
+      <div className="mt-6">
+        <RssFeedList />
+      </div>
+    </div>
+  );
 }

--- a/client/src/pages/xrel-releases.tsx
+++ b/client/src/pages/xrel-releases.tsx
@@ -204,7 +204,6 @@ export default function XrelReleasesPage() {
                           >
                             {rel.libraryStatus.charAt(0).toUpperCase() + rel.libraryStatus.slice(1)}
                           </Badge>
-
                         ) : rel.matchCandidate ? (
                           <Button
                             variant="ghost"
@@ -229,7 +228,7 @@ export default function XrelReleasesPage() {
                             title={`Add "${rel.matchCandidate.title}" to wanted list`}
                           >
                             {addGameMutation.isPending &&
-                              addGameMutation.variables === rel.matchCandidate.title ? (
+                            addGameMutation.variables === rel.matchCandidate.title ? (
                               <Loader2 className="h-3 w-3 animate-spin" />
                             ) : (
                               <Plus className="h-3 w-3" />
@@ -284,6 +283,6 @@ export default function XrelReleasesPage() {
           </CardContent>
         </Card>
       </div>
-    </div >
+    </div>
   );
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,29 +1,29 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
-    testDir: './tests/e2e',
-    fullyParallel: true,
-    forbidOnly: !!process.env.CI,
-    retries: process.env.CI ? 2 : 0,
-    workers: process.env.CI ? 1 : undefined,
-    reporter: 'html',
-    use: {
-        baseURL: 'http://127.0.0.1:5100',
-        trace: 'on-first-retry',
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://127.0.0.1:5100",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "setup",
+      testMatch: /setup\.spec\.ts/,
     },
-    projects: [
-        {
-            name: 'setup',
-            testMatch: /setup\.spec\.ts/,
-        },
-        {
-            name: 'e2e',
-            testMatch: /.*\.spec\.ts/,
-            testIgnore: /setup\.spec\.ts/,
-            dependencies: ['setup'],
-            use: {
-                storageState: 'playwright/.auth/user.json',
-            },
-        },
-    ],
+    {
+      name: "e2e",
+      testMatch: /.*\.spec\.ts/,
+      testIgnore: /setup\.spec\.ts/,
+      dependencies: ["setup"],
+      use: {
+        storageState: "playwright/.auth/user.json",
+      },
+    },
+  ],
 });

--- a/scripts/debug-igdb.ts
+++ b/scripts/debug-igdb.ts
@@ -1,30 +1,28 @@
-
 import { igdbClient } from "../server/igdb.js";
 
 async function run() {
-    console.log("=== IGDB DEBUG START ===");
+  console.log("=== IGDB DEBUG START ===");
 
-    try {
-        // Test 1: Standard Search
-        console.log("\n--- Test 1: Single Search 'The Land Beneath Us' ---");
-        const singleResults = await igdbClient.searchGames("The Land Beneath Us");
-        console.log(`Single Search Results: ${singleResults.length}`);
-        if (singleResults.length > 0) {
-            console.log(`First match: ${singleResults[0].name} (ID: ${singleResults[0].id})`);
-        }
-
-        // Test 2: Batch Search
-        console.log("\n--- Test 2: Batch Search ['The Land Beneath Us'] ---");
-        const batchResults = await igdbClient.batchSearchGames(["The Land Beneath Us"]);
-        console.log(`Batch Results Size: ${batchResults.size}`);
-        const match = batchResults.get("The Land Beneath Us");
-        console.log(`Batch Match: ${match ? match.name : "NULL"}`);
-
-    } catch (error) {
-        console.error("DEBUG SCRIPT FAILED:", error);
+  try {
+    // Test 1: Standard Search
+    console.log("\n--- Test 1: Single Search 'The Land Beneath Us' ---");
+    const singleResults = await igdbClient.searchGames("The Land Beneath Us");
+    console.log(`Single Search Results: ${singleResults.length}`);
+    if (singleResults.length > 0) {
+      console.log(`First match: ${singleResults[0].name} (ID: ${singleResults[0].id})`);
     }
 
-    console.log("=== IGDB DEBUG END ===");
+    // Test 2: Batch Search
+    console.log("\n--- Test 2: Batch Search ['The Land Beneath Us'] ---");
+    const batchResults = await igdbClient.batchSearchGames(["The Land Beneath Us"]);
+    console.log(`Batch Results Size: ${batchResults.size}`);
+    const match = batchResults.get("The Land Beneath Us");
+    console.log(`Batch Match: ${match ? match.name : "NULL"}`);
+  } catch (error) {
+    console.error("DEBUG SCRIPT FAILED:", error);
+  }
+
+  console.log("=== IGDB DEBUG END ===");
 }
 
 run();

--- a/server/__tests__/igdb.test.ts
+++ b/server/__tests__/igdb.test.ts
@@ -223,7 +223,7 @@ describe("IGDBClient - Fallback Mechanism", { timeout: 20000 }, () => {
         json: async () => mockGamesList,
       };
       fetchMock.mockResolvedValueOnce(authResponse).mockResolvedValueOnce(successResponse);
-    }
+    };
 
     it("getPopularGames should return list of games", async () => {
       setupMocks();
@@ -276,7 +276,9 @@ describe("IGDBClient - Fallback Mechanism", { timeout: 20000 }, () => {
       };
       const successResponse = {
         ok: true,
-        json: async () => [{ id: 4, name: "Switch Game", platforms: [{ name: "Nintendo Switch" }] }],
+        json: async () => [
+          { id: 4, name: "Switch Game", platforms: [{ name: "Nintendo Switch" }] },
+        ],
       };
       fetchMock.mockResolvedValueOnce(authResponse).mockResolvedValueOnce(successResponse);
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -28,7 +28,10 @@ const envSchema = z.object({
     .transform((val) => parseInt(val, 10)),
   HOST: z.string().default("0.0.0.0"),
   NODE_ENV: z.enum(["development", "production", "test"]).default("production"),
-  DISABLE_HSTS: z.string().transform((val) => val === "true").optional(),
+  DISABLE_HSTS: z
+    .string()
+    .transform((val) => val === "true")
+    .optional(),
 });
 
 /**

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1921,9 +1921,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
         xrel: { apiBase },
         settings: settings
           ? {
-            xrelSceneReleases: settings.xrelSceneReleases,
-            xrelP2pReleases: settings.xrelP2pReleases,
-          }
+              xrelSceneReleases: settings.xrelSceneReleases,
+              xrelP2pReleases: settings.xrelP2pReleases,
+            }
           : undefined,
       });
     } catch (error) {

--- a/server/rss.ts
+++ b/server/rss.ts
@@ -107,7 +107,7 @@ export class RssService {
 
     // 4. Trigger background matching
     if (newIds.length > 0) {
-      this.processPendingItems(newIds).catch(err => {
+      this.processPendingItems(newIds).catch((err) => {
         rssLogger.error({ err }, "Error in background item processing");
       });
     }

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,24 +1,24 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test.describe('Authentication Flow', () => {
-    // This test runs as part of the 'e2e' project which depends on 'setup'.
-    // It inherits the storage state (authenticated as admin).
+test.describe("Authentication Flow", () => {
+  // This test runs as part of the 'e2e' project which depends on 'setup'.
+  // It inherits the storage state (authenticated as admin).
 
-    test('should allow logout and login', async ({ page }) => {
-        await page.goto('/');
+  test("should allow logout and login", async ({ page }) => {
+    await page.goto("/");
 
-        // Verify we are logged in
-        await expect(page.locator('header')).toBeVisible();
+    // Verify we are logged in
+    await expect(page.locator("header")).toBeVisible();
 
-        // Logout
-        await page.getByText('Logged in').click();
-        await expect(page).toHaveURL('/login');
+    // Logout
+    await page.getByText("Logged in").click();
+    await expect(page).toHaveURL("/login");
 
-        // Log back in
-        await page.fill('input[name="username"]', 'admin');
-        await page.fill('input[name="password"]', 'password123');
-        await page.click('button[type="submit"]');
+    // Log back in
+    await page.fill('input[name="username"]', "admin");
+    await page.fill('input[name="password"]', "password123");
+    await page.click('button[type="submit"]');
 
-        await expect(page).toHaveURL('/');
-    });
+    await expect(page).toHaveURL("/");
+  });
 });

--- a/tests/e2e/game-details.spec.ts
+++ b/tests/e2e/game-details.spec.ts
@@ -1,44 +1,46 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test.describe('Game Details', () => {
-    // Inherits authenticated state from 'setup' project
+test.describe("Game Details", () => {
+  // Inherits authenticated state from 'setup' project
 
-    test('should view game details', async ({ page }) => {
-        // Mock the games API to ensure we have a game to click
-        await page.route('/api/games*', async route => {
-            const json = [{
-                id: 'test-game-id-123',
-                title: 'Cyberpunk 2077',
-                coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/co2mjs.jpg',
-                platforms: ['PC', 'PS5'],
-                genres: ['RPG'],
-                status: 'wanted',
-                addedAt: new Date().toISOString(),
-                igdbId: 1877,
-                hidden: false
-            }];
-            await route.fulfill({ json });
-        });
-
-        await page.goto('/');
-
-        // Look for the game card
-        // Look for the game card using test ID for better stability
-        const card = page.getByTestId('card-game-test-game-id-123');
-        await expect(card).toBeVisible();
-
-        // Hover to show actions
-        await card.hover();
-
-        // Click the details button
-        await page.getByTestId('button-details-test-game-id-123').click();
-
-        // Expect a modal
-        await expect(page.getByRole('dialog')).toBeVisible();
-        await expect(page.getByRole('heading', { name: 'Cyberpunk 2077' })).toBeVisible();
-
-        // Close the modal
-        await page.keyboard.press('Escape');
-        await expect(page.getByRole('dialog')).not.toBeVisible();
+  test("should view game details", async ({ page }) => {
+    // Mock the games API to ensure we have a game to click
+    await page.route("/api/games*", async (route) => {
+      const json = [
+        {
+          id: "test-game-id-123",
+          title: "Cyberpunk 2077",
+          coverUrl: "https://images.igdb.com/igdb/image/upload/t_cover_big/co2mjs.jpg",
+          platforms: ["PC", "PS5"],
+          genres: ["RPG"],
+          status: "wanted",
+          addedAt: new Date().toISOString(),
+          igdbId: 1877,
+          hidden: false,
+        },
+      ];
+      await route.fulfill({ json });
     });
+
+    await page.goto("/");
+
+    // Look for the game card
+    // Look for the game card using test ID for better stability
+    const card = page.getByTestId("card-game-test-game-id-123");
+    await expect(card).toBeVisible();
+
+    // Hover to show actions
+    await card.hover();
+
+    // Click the details button
+    await page.getByTestId("button-details-test-game-id-123").click();
+
+    // Expect a modal
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Cyberpunk 2077" })).toBeVisible();
+
+    // Close the modal
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).not.toBeVisible();
+  });
 });

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,21 +1,19 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test.describe('Navigation', () => {
-    // Inherits authenticated state from 'setup' project
+test.describe("Navigation", () => {
+  // Inherits authenticated state from 'setup' project
 
-    test('should navigate to main pages', async ({ page }) => {
-        await page.goto('/');
-        await expect(page).toHaveTitle(/Questarr|Dashboard/);
+  test("should navigate to main pages", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveTitle(/Questarr|Dashboard/);
 
-        await page.getByRole('button', { name: /Discover/i }).click();
-        await expect(page).toHaveURL('/discover');
+    await page.getByRole("button", { name: /Discover/i }).click();
+    await expect(page).toHaveURL("/discover");
 
+    await page.getByRole("button", { name: /Library/i }).click();
+    await expect(page).toHaveURL("/library");
 
-
-        await page.getByRole('button', { name: /Library/i }).click();
-        await expect(page).toHaveURL('/library');
-
-        await page.getByRole('button', { name: /Settings/i }).click();
-        await expect(page).toHaveURL('/settings');
-    });
+    await page.getByRole("button", { name: /Settings/i }).click();
+    await expect(page).toHaveURL("/settings");
+  });
 });


### PR DESCRIPTION
🎨 **What:**

- Added dynamic `aria-label` attributes to "Download", "View Details", and "Hide/Unhide" buttons in `GameCard` and `CompactGameCard`.
- The labels now include the game title (e.g., `aria-label="Download Super Mario Odyssey"` instead of just "Download").

🎯 **Why:**

- Screen reader users navigating a list of games would previously hear "Download button, Download button, Download button..." without knowing which game each button belonged to.
- This change provides necessary context, making the list fully accessible.

📸 **Before/After:**

- **Visuals:** No visual changes (invisible UX improvement).
- **Screen Reader:**
  - Before: "Download button"
  - After: "Download Super Mario Odyssey button"

♿ **Accessibility:**

- Complies with WCAG 2.1 Success Criterion 2.4.6 (Headings and Labels) and 4.1.2 (Name, Role, Value).
- Verified using `testing-library` queries (`getByRole('button', { name: ... })`) which simulate accessible name computation.

---

*PR created automatically by Jules for task [4330250907887781947](https://jules.google.com/task/4330250907887781947) started by @Doezer*