### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix error message information leakage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,9 @@
         "vite": "^5.4.21",
         "vitest": "^4.0.18"
       },
+      "engines": {
+        "node": ">=20"
+      },
       "optionalDependencies": {
         "bufferutil": "^4.0.8"
       }

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -917,6 +917,30 @@ describe("API Routes - Extended Coverage", () => {
       expect(response.body.errors).toHaveLength(1);
       expect(response.body.errors[0].downloaderId).toBe("dl-1");
     });
+
+    it("should sanitize downloader error details in production", async () => {
+      mockConfig.server.isProduction = true;
+      try {
+        vi.mocked(storage.getEnabledDownloaders).mockResolvedValue([
+          { id: "dl-1", name: "Failing DL" } as unknown as Downloader,
+        ]);
+        vi.mocked(DownloaderManager.getAllDownloads).mockRejectedValue(
+          new Error("Sensitive RPC failure")
+        );
+
+        const response = await request(app).get("/api/downloads");
+
+        expect(response.status).toBe(200);
+        expect(response.body.errors).toHaveLength(1);
+        expect(response.body.errors[0]).toMatchObject({
+          downloaderId: "dl-1",
+          downloaderName: "Failing DL",
+          error: "Internal Server Error",
+        });
+      } finally {
+        mockConfig.server.isProduction = false;
+      }
+    });
   });
 
   // ─── Notification routes ───

--- a/server/__tests__/security_error_handling.test.ts
+++ b/server/__tests__/security_error_handling.test.ts
@@ -1,0 +1,91 @@
+
+import { describe, it, expect, vi } from "vitest";
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+// We will implement this in the next step
+import { errorHandler } from "../middleware.js";
+
+// Mock logger to avoid actual logging during tests
+vi.mock("../logger.js", () => ({
+  expressLogger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+// Mock storage since middleware might import it
+vi.mock("../storage.js", () => ({
+  storage: {
+    getUserSettings: vi.fn(),
+  },
+}));
+
+describe("Security Error Handling", () => {
+  it("should sanitize 500 errors in production", async () => {
+    const app = express();
+    app.set("env", "production");
+
+    app.get("/error", (req, res, next) => {
+      const err: any = new Error("Sensitive Database Info");
+      err.status = 500;
+      next(err);
+    });
+
+    app.use(errorHandler);
+
+    const response = await request(app).get("/error");
+    expect(response.status).toBe(500);
+    expect(response.body.error).toBe("Internal Server Error");
+    expect(response.body.error).not.toContain("Sensitive Database Info");
+  });
+
+  it("should show details in development", async () => {
+    const app = express();
+    app.set("env", "development");
+
+    app.get("/error", (req, res, next) => {
+      const err: any = new Error("Debug Info");
+      err.status = 500;
+      next(err);
+    });
+
+    app.use(errorHandler);
+
+    const response = await request(app).get("/error");
+    expect(response.status).toBe(500);
+    expect(response.body.error).toBe("Debug Info");
+  });
+
+  it("should pass through client errors (4xx) unchanged", async () => {
+    const app = express();
+    // Environment shouldn't matter for 4xx
+    app.set("env", "production");
+
+    app.get("/error", (req, res, next) => {
+      const err: any = new Error("Invalid Input");
+      err.status = 400;
+      next(err);
+    });
+
+    app.use(errorHandler);
+
+    const response = await request(app).get("/error");
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("Invalid Input");
+  });
+
+  it("should handle errors explicitly thrown without status", async () => {
+     const app = express();
+    app.set("env", "production");
+
+    app.get("/error", (req, res, next) => {
+      next(new Error("Unexpected Error"));
+    });
+
+    app.use(errorHandler);
+
+    const response = await request(app).get("/error");
+    expect(response.status).toBe(500);
+    expect(response.body.error).toBe("Internal Server Error");
+  });
+});

--- a/server/__tests__/security_error_handling.test.ts
+++ b/server/__tests__/security_error_handling.test.ts
@@ -1,8 +1,6 @@
-
 import { describe, it, expect, vi } from "vitest";
-import express, { Request, Response, NextFunction } from "express";
+import express from "express";
 import request from "supertest";
-// We will implement this in the next step
 import { errorHandler } from "../middleware.js";
 
 // Mock logger to avoid actual logging during tests
@@ -75,7 +73,7 @@ describe("Security Error Handling", () => {
   });
 
   it("should handle errors explicitly thrown without status", async () => {
-     const app = express();
+    const app = express();
     app.set("env", "production");
 
     app.get("/error", (req, res, next) => {
@@ -87,5 +85,47 @@ describe("Security Error Handling", () => {
     const response = await request(app).get("/error");
     expect(response.status).toBe(500);
     expect(response.body.error).toBe("Internal Server Error");
+  });
+
+  it("should include error details when provided", async () => {
+    const app = express();
+    app.set("env", "production");
+
+    app.get("/error", (_req, _res, next) => {
+      const err: any = new Error("Validation failed");
+      err.status = 400;
+      err.details = [{ field: "name", message: "Required" }];
+      next(err);
+    });
+
+    app.use(errorHandler);
+
+    const response = await request(app).get("/error");
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("Validation failed");
+    expect(response.body.details).toEqual([{ field: "name", message: "Required" }]);
+  });
+
+  it("should delegate when headers are already sent", async () => {
+    const err: any = new Error("late failure");
+    err.status = 500;
+
+    const req: any = {
+      app: { get: vi.fn().mockReturnValue("production") },
+      path: "/error",
+      method: "GET",
+    };
+    const res: any = {
+      headersSent: true,
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+    const next = vi.fn();
+
+    errorHandler(err, req, res, next);
+
+    expect(next).toHaveBeenCalledWith(err);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
   });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import cors from "cors";
 
 import { registerRoutes } from "./routes.js";
 import { setupVite, serveStatic, log } from "./vite.js";
-import { generalApiLimiter } from "./middleware.js";
+import { generalApiLimiter, errorHandler } from "./middleware.js";
 import { config } from "./config.js";
 import { expressLogger } from "./logger.js";
 import { startCronJobs } from "./cron.js";
@@ -145,21 +145,8 @@ app.use((req, res, next) => {
     setupSocketIO(server);
 
     // Error handler must handle various error shapes
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-      const status = err.status || err.statusCode || 500;
-      const error = err.message || "Internal Server Error";
-
-      // Include details if available (e.g., validation errors)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response: { error: string; details?: any } = { error };
-      if (err.details) {
-        response.details = err.details;
-      }
-
-      res.status(status).json(response);
-      throw err;
-    });
+    // 🛡️ Sentinel: Use standardized error handler to prevent info leaks
+    app.use(errorHandler);
 
     // importantly only setup vite in development and after
     // setting up all the other routes so the catch-all route

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 // Force restart trigger
 import "dotenv/config";
-import express, { type Request, Response, NextFunction } from "express";
+import express from "express";
 import https from "https";
 import fs from "fs";
 import cors from "cors";

--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -2,6 +2,7 @@ import rateLimit from "express-rate-limit";
 import { body, param, query, validationResult } from "express-validator";
 import type { Request, Response, NextFunction } from "express";
 import { storage } from "./storage.js";
+import { expressLogger } from "./logger.js";
 
 // Dynamic rate limiter for IGDB API endpoints to prevent blacklisting
 // IGDB has a limit of 4 requests per second, we default to 3 to be conservative
@@ -437,3 +438,39 @@ export const sanitizeIndexerSearchQuery = [
     .withMessage("Offset must be a non-negative integer")
     .toInt(),
 ];
+
+// 🛡️ Sentinel: Global error handler middleware
+// Standardizes error responses and prevents leakage of sensitive details in production
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const errorHandler = (err: any, req: Request, res: Response, next: NextFunction) => {
+  const status = err.status || err.statusCode || 500;
+
+  // Log the error using our logger instead of relying on default express handler logging
+  // Use error level for 5xx, warn/info for client errors
+  if (status >= 500) {
+    expressLogger.error({ err, path: req.path, method: req.method }, "Request error");
+  } else {
+    expressLogger.warn({ err, path: req.path, method: req.method }, "Request error");
+  }
+
+  // Determine the error message to show to the client
+  // Sanitize error messages in production to prevent information leakage
+  let message = err.message || "Internal Server Error";
+  if (req.app.get("env") === "production" && status === 500) {
+    message = "Internal Server Error";
+  }
+
+  // Include details if available (e.g., validation errors)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const response: { error: string; details?: any } = { error: message };
+  if (err.details) {
+    response.details = err.details;
+  }
+
+  // If headers already sent, we can't send a JSON response
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  res.status(status).json(response);
+};

--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -456,7 +456,7 @@ export const errorHandler = (err: any, req: Request, res: Response, next: NextFu
   // Determine the error message to show to the client
   // Sanitize error messages in production to prevent information leakage
   let message = err.message || "Internal Server Error";
-  if (req.app.get("env") === "production" && status === 500) {
+  if (req.app.get("env") === "production" && status >= 500) {
     message = "Internal Server Error";
   }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -729,7 +729,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Sync indexers from Prowlarr
-  app.post("/api/indexers/prowlarr/sync", sensitiveEndpointLimiter, async (req, res) => {
+  app.post("/api/indexers/prowlarr/sync", sensitiveEndpointLimiter, async (req, res, next) => {
     try {
       const { url, apiKey } = req.body;
 
@@ -752,9 +752,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         results,
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Unknown error";
-      routesLogger.error({ error }, "Failed to sync from Prowlarr");
-      res.status(500).json({ error: message });
+      next(error);
     }
   });
 
@@ -1430,7 +1428,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
               downloaderId: downloader.id,
               downloaderName: downloader.name,
               freeSpace: 0,
-              error: error instanceof Error ? error.message : "Unknown error",
+              error: appConfig.server.isProduction
+                ? "Internal Server Error"
+                : error instanceof Error
+                  ? error.message
+                  : "Unknown error",
             };
           }
         })
@@ -1940,7 +1942,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           return {
             downloaderId: downloader.id,
             downloaderName: downloader.name,
-            error: errorMessage,
+            error: appConfig.server.isProduction ? "Internal Server Error" : errorMessage,
           };
         });
 
@@ -2230,7 +2232,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.patch("/api/settings", authenticateToken, async (req, res) => {
+  app.patch("/api/settings", authenticateToken, async (req, res, next) => {
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const userId = (req as any).user.id;
@@ -2257,16 +2259,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
         routesLogger.error({ error: error.errors }, "validation error in settings update");
         return res.status(400).json({ error: "Invalid settings data", details: error.errors });
       }
-      routesLogger.error({ error }, "error updating settings");
-      res.status(500).json({
-        error: "Failed to update settings",
-        message: error instanceof Error ? error.message : "Unknown error",
-      });
+      next(error);
     }
   });
 
   // xREL.to settings (API base URL in system config; scene/p2p in user settings)
-  app.patch("/api/settings/xrel", authenticateToken, async (req, res) => {
+  app.patch("/api/settings/xrel", authenticateToken, async (req, res, next) => {
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const userId = (req as any).user.id;
@@ -2339,16 +2337,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
           : undefined,
       });
     } catch (error) {
-      routesLogger.error({ error }, "error updating xREL settings");
-      res.status(500).json({
-        error: "Failed to update xREL settings",
-        message: error instanceof Error ? error.message : "Unknown error",
-      });
+      next(error);
     }
   });
 
   // xREL.to API proxy (rate-limited on xREL side; base URL from app settings)
-  app.get("/api/xrel/latest", authenticateToken, async (req, res) => {
+  app.get("/api/xrel/latest", authenticateToken, async (req, res, next) => {
     try {
       const page = req.query.page ? parseInt(String(req.query.page), 10) : 1;
       const baseUrl =
@@ -2478,15 +2472,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       res.json({ ...result, list: finallist });
     } catch (error) {
-      routesLogger.error({ error }, "xREL latest failed");
-      res.status(500).json({
-        error: "Failed to fetch xREL latest releases",
-        message: error instanceof Error ? error.message : "Unknown error",
-      });
+      next(error);
     }
   });
 
-  app.get("/api/xrel/search", authenticateToken, async (req, res) => {
+  app.get("/api/xrel/search", authenticateToken, async (req, res, next) => {
     try {
       const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
       if (!q) {
@@ -2504,16 +2494,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const list = await xrelClient.searchReleases(q, { scene, p2p, limit, baseUrl });
       res.json({ results: list });
     } catch (error) {
-      routesLogger.error({ error }, "xREL search failed");
-      res.status(500).json({
-        error: "xREL search failed",
-        message: error instanceof Error ? error.message : "Unknown error",
-      });
+      next(error);
     }
   });
 
   // Match and add game from name (Quick Add)
-  app.post("/api/games/match-and-add", authenticateToken, async (req, res) => {
+  app.post("/api/games/match-and-add", authenticateToken, async (req, res, next) => {
     try {
       const { title } = req.body;
       if (!title || typeof title !== "string") {
@@ -2565,11 +2551,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       );
       res.status(201).json(game);
     } catch (error) {
-      routesLogger.error({ error }, "match and add failed");
-      res.status(500).json({
-        error: "Failed to add game",
-        message: error instanceof Error ? error.message : "Unknown error",
-      });
+      next(error);
     }
   });
 


### PR DESCRIPTION
This PR addresses a medium-severity security issue where internal error details (including stack traces or database errors) were exposed to clients in 500 responses.

Changes:

- Refactored the inline error handler from `server/index.ts` into a reusable `errorHandler` middleware in `server/middleware.ts`.
- The new `errorHandler` checks `req.app.get("env")`. If it is "production" and the status is 500, the error message is replaced with a generic "Internal Server Error".
- In development mode, the original error message is preserved for debugging.
- The handler now logs errors using `expressLogger` instead of re-throwing them, ensuring consistent logging and preventing potential unhandled rejections or double-response attempts.
- Added `server/__tests__/security_error_handling.test.ts` to verify the fix.

Verification:

- Run `npm test server/__tests__/security_error_handling.test.ts` to verify the security behavior.
- Run `npm test` to ensure no regressions.

---

*PR created automatically by Jules for task [8431039535814491221](https://jules.google.com/task/8431039535814491221) started by @Doezer*