### PR TITLE
🎨 Palette: Add missing ARIA labels to icon buttons

### DIFF
--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -935,6 +935,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                     <Button
                                       variant="ghost"
                                       size="icon"
+                                      aria-label={`Download ${download.title}`}
                                       onClick={() => handleDownload(download)}
                                       disabled={
                                         downloadingGuid === (download.guid || download.link)
@@ -950,7 +951,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
 
                                     <DropdownMenu>
                                       <DropdownMenuTrigger asChild>
-                                        <Button variant="ghost" size="icon" className="h-9 w-9">
+                                        <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="More download options">
                                           <MoreVertical className="h-4 w-4" />
                                         </Button>
                                       </DropdownMenuTrigger>

--- a/client/src/components/NotificationCenter.tsx
+++ b/client/src/components/NotificationCenter.tsx
@@ -152,7 +152,7 @@ export function NotificationCenter() {
     <>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button variant="ghost" size="icon" className="relative">
+          <Button variant="ghost" size="icon" className="relative" aria-label="Notifications">
             <Bell className="h-5 w-5" />
             {unreadCount > 0 && (
               <span className="absolute top-1.5 right-1.5 h-2 w-2 rounded-full bg-red-600 animate-pulse" />

--- a/client/src/components/RssSettings.tsx
+++ b/client/src/components/RssSettings.tsx
@@ -172,6 +172,7 @@ export default function RssSettings() {
                     <Button
                       variant="ghost"
                       size="icon"
+                      aria-label="Delete RSS Feed"
                       onClick={() => deleteFeedMutation.mutate(feed.id)}
                       className="text-destructive"
                     >

--- a/client/src/components/ui/sidebar.tsx
+++ b/client/src/components/ui/sidebar.tsx
@@ -258,6 +258,7 @@ const SidebarTrigger = React.forwardRef<
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon"
+      aria-label="Toggle Sidebar"
       className={cn("h-7 w-7", className)}
       onClick={(event) => {
         onClick?.(event);


### PR DESCRIPTION
**💡 What**: Added missing `aria-label` attributes to icon-only buttons across various components (GameDownloadDialog, NotificationCenter, RssSettings, Sidebar).
**🎯 Why**: Icon-only buttons without `aria-label` attributes are inaccessible to screen reader users as there is no textual context for the button's action. Adding descriptive labels significantly improves the accessibility of these interactive elements.
**📸 Before/After**: Screen reader users would previously hear "button" for these items, but now they will hear "Notifications", "More download options", "Delete RSS Feed", "Toggle Sidebar", or "Download [game title]".
**♿ Accessibility**: Fixes an accessibility issue where icon buttons were missing textual context for screen readers.

---

*PR created automatically by Jules for task [6339725966157345610](https://jules.google.com/task/6339725966157345610) started by @Doezer*