### PR TITLE
Refactor game update notifications and add autosearch tests

### DIFF
--- a/server/__tests__/cron_autosearch.test.ts
+++ b/server/__tests__/cron_autosearch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Game, UserSettings } from "@shared/schema";
 
 // --- Mocks ---
@@ -78,6 +78,8 @@ const { checkAutoSearch } = await import("../cron.js");
 
 describe("Cron - checkAutoSearch", () => {
   const userId = "user-123";
+  const FIXED_NOW = new Date("2026-01-01T12:00:00.000Z");
+  const FIXED_PUB_DATE = "2026-01-01T10:00:00.000Z";
 
   const baseGame: Game = {
     id: "game-1",
@@ -87,7 +89,7 @@ describe("Cron - checkAutoSearch", () => {
     status: "wanted",
     releaseStatus: "released",
     hidden: false,
-    addedAt: new Date(),
+    addedAt: new Date(FIXED_NOW),
     completedAt: null,
     // Optional fields
     summary: null,
@@ -116,11 +118,13 @@ describe("Cron - checkAutoSearch", () => {
     xrelSceneReleases: true,
     xrelP2pReleases: false,
     autoSearchUnreleased: false, // Default: false
-    updatedAt: new Date(),
+    updatedAt: new Date(FIXED_NOW),
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
 
     // Default mock setup:
     // - 1 user with 1 wanted game (released)
@@ -129,6 +133,10 @@ describe("Cron - checkAutoSearch", () => {
     mockGetUserGames.mockResolvedValue([]);
     mockGetUserSettings.mockResolvedValue(baseSettings);
     mockSearchAllIndexers.mockResolvedValue({ items: [], errors: [], total: 0 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("should search for released games when autoSearchUnreleased is false (default)", async () => {
@@ -261,7 +269,7 @@ describe("Cron - checkAutoSearch", () => {
         {
           title: "Test Game Update v1.1",
           link: "https://example.com/update",
-          pubDate: new Date().toISOString(),
+          pubDate: FIXED_PUB_DATE,
           seeders: 100,
           size: 1024,
         },
@@ -289,7 +297,7 @@ describe("Cron - checkAutoSearch", () => {
         {
           title: "Test Game Update v1.1",
           link: "https://example.com/update",
-          pubDate: new Date().toISOString(),
+          pubDate: FIXED_PUB_DATE,
           seeders: 100,
           size: 1024,
         },
@@ -320,14 +328,14 @@ describe("Cron - checkAutoSearch", () => {
         {
           title: "Test Game MULTi",
           link: "https://example.com/main",
-          pubDate: new Date().toISOString(),
+          pubDate: FIXED_PUB_DATE,
           seeders: 120,
           size: 10_000,
         },
         {
           title: "Test Game Update v1.1",
           link: "https://example.com/update",
-          pubDate: new Date().toISOString(),
+          pubDate: FIXED_PUB_DATE,
           seeders: 100,
           size: 2_000,
         },

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -50,36 +50,96 @@ function categorizeSearchItems(
   items: Awaited<ReturnType<typeof searchAllIndexers>>["items"],
   rules: AutoSearchRules
 ): AutoSearchCategorizedItems {
-  let filteredItems = items.filter((item) => {
-    const seeders = item.seeders ?? 0;
-    return seeders >= rules.minSeeders;
-  });
-
-  filteredItems = filteredItems.sort((a, b) => {
-    if (rules.sortBy === "seeders") {
-      return (b.seeders ?? 0) - (a.seeders ?? 0);
-    }
-    if (rules.sortBy === "date") {
-      return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
-    }
-    return (b.size ?? 0) - (a.size ?? 0);
-  });
-
-  const categorizedItems = filteredItems
-    .map((item) => {
-      const { category } = categorizeDownload(item.title);
-      return { item, category };
+  const sortedItems = items
+    .filter((item) => {
+      const seeders = item.seeders ?? 0;
+      return seeders >= rules.minSeeders;
     })
-    .filter(({ category }) => rules.visibleCategoriesSet.has(category));
+    .sort((a, b) => {
+      if (rules.sortBy === "seeders") {
+        return (b.seeders ?? 0) - (a.seeders ?? 0);
+      }
+      if (rules.sortBy === "date") {
+        return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
+      }
+      return (b.size ?? 0) - (a.size ?? 0);
+    });
 
-  return {
-    mainItems: categorizedItems
-      .filter(({ category }) => category === "main")
-      .map(({ item }) => item),
-    updateItems: categorizedItems
-      .filter(({ category }) => category === "update")
-      .map(({ item }) => item),
-  };
+  return sortedItems.reduce<AutoSearchCategorizedItems>(
+    (acc, item) => {
+      const { category } = categorizeDownload(item.title);
+
+      if (!rules.visibleCategoriesSet.has(category)) {
+        return acc;
+      }
+
+      if (category === "main") {
+        acc.mainItems.push(item);
+      } else if (category === "update") {
+        acc.updateItems.push(item);
+      }
+
+      return acc;
+    },
+    { mainItems: [], updateItems: [] }
+  );
+}
+
+async function searchAndCategorizeItemsForGame(
+  game: Pick<Game, "title">,
+  downloadRules: string | null
+): Promise<AutoSearchCategorizedItems | null> {
+  const { items, errors } = await searchAllIndexers({
+    query: game.title,
+    limit: 10,
+  });
+
+  if (errors.length > 0) {
+    const networkKeywords = [
+      "fetch failed",
+      "Unsafe URL detected",
+      "ENOTFOUND",
+      "EAI_AGAIN",
+      "ETIMEDOUT",
+      "network timeout",
+    ];
+
+    const areAllErrorsNetworkRelated = errors.every((err) =>
+      networkKeywords.some((keyword) => err.includes(keyword))
+    );
+
+    if (areAllErrorsNetworkRelated) {
+      igdbLogger.warn(
+        { gameTitle: game.title, errorCount: errors.length },
+        "Search failed due to network connectivity issues (DNS/Fetch/Safety check). Please check your internet connection."
+      );
+    } else {
+      igdbLogger.warn({ gameTitle: game.title, errors }, "Errors during search");
+    }
+  }
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  const matchedItems = items.filter((item) => releaseMatchesGame(item.title, game.title));
+  if (matchedItems.length === 0) {
+    igdbLogger.debug(
+      { gameTitle: game.title, originalCount: items.length },
+      "No items passed strict title matching"
+    );
+    return null;
+  }
+
+  let rules: AutoSearchRules;
+  try {
+    rules = getAutoSearchRules(downloadRules);
+  } catch (error) {
+    igdbLogger.warn({ gameTitle: game.title, error }, "Failed to parse download rules");
+    rules = getAutoSearchRules(null);
+  }
+
+  return categorizeSearchItems(matchedItems, rules);
 }
 
 export function startCronJobs() {
@@ -525,62 +585,17 @@ export async function checkAutoSearch() {
               continue;
             }
 
-            // Search for the game across all indexers
-            const { items, errors } = await searchAllIndexers({
-              query: game.title,
-              limit: 10,
-            });
-
-            if (errors.length > 0) {
-              const networkKeywords = [
-                "fetch failed",
-                "Unsafe URL detected",
-                "ENOTFOUND",
-                "EAI_AGAIN",
-                "ETIMEDOUT",
-                "network timeout",
-              ];
-
-              const areAllErrorsNetworkRelated = errors.every((err) =>
-                networkKeywords.some((keyword) => err.includes(keyword))
-              );
-
-              if (areAllErrorsNetworkRelated) {
-                igdbLogger.warn(
-                  { gameTitle: game.title, errorCount: errors.length },
-                  "Search failed due to network connectivity issues (DNS/Fetch/Safety check). Please check your internet connection."
-                );
-              } else {
-                igdbLogger.warn({ gameTitle: game.title, errors }, "Errors during search");
-              }
-            }
-
-            if (items.length === 0) {
-              continue;
-            }
-
-            // Double-check matches locally to ensure they actually match the game title
-            const matchedItems = items.filter((item) => releaseMatchesGame(item.title, game.title));
-
-            if (matchedItems.length === 0) {
-              igdbLogger.debug(
-                { gameTitle: game.title, originalCount: items.length },
-                "No items passed strict title matching"
-              );
+            const searchResult = await searchAndCategorizeItemsForGame(
+              game,
+              settings.downloadRules
+            );
+            if (!searchResult) {
               continue;
             }
 
             gamesWithResults++;
 
-            let rules: AutoSearchRules;
-            try {
-              rules = getAutoSearchRules(settings.downloadRules);
-            } catch (error) {
-              igdbLogger.warn({ gameTitle: game.title, error }, "Failed to parse download rules");
-              rules = getAutoSearchRules(null);
-            }
-
-            const { mainItems } = categorizeSearchItems(matchedItems, rules);
+            const { mainItems } = searchResult;
 
             // Handle main items
             if (mainItems.length === 0) {
@@ -669,33 +684,15 @@ export async function checkAutoSearch() {
               continue;
             }
 
-            const { items, errors } = await searchAllIndexers({
-              query: game.title,
-              limit: 10,
-            });
-
-            if (errors.length > 0) {
-              igdbLogger.warn({ gameTitle: game.title, errors }, "Errors during owned game search");
-            }
-
-            if (items.length === 0) {
+            const searchResult = await searchAndCategorizeItemsForGame(
+              game,
+              settings.downloadRules
+            );
+            if (!searchResult) {
               continue;
             }
 
-            const matchedItems = items.filter((item) => releaseMatchesGame(item.title, game.title));
-            if (matchedItems.length === 0) {
-              continue;
-            }
-
-            let rules: AutoSearchRules;
-            try {
-              rules = getAutoSearchRules(settings.downloadRules);
-            } catch (error) {
-              igdbLogger.warn({ gameTitle: game.title, error }, "Failed to parse download rules");
-              rules = getAutoSearchRules(null);
-            }
-
-            const { updateItems } = categorizeSearchItems(matchedItems, rules);
+            const { updateItems } = searchResult;
 
             if (updateItems.length > 0 && settings.notifyUpdates) {
               const notification = await storage.addNotification({


### PR DESCRIPTION
This pull request enhances the auto-search functionality to support update notifications for owned games and refactors the categorization and filtering logic for search results. The changes improve clarity, maintainability, and test coverage for the auto-search feature.

### Auto-search logic improvements

* Added support for searching owned games for update packs and notifying users when updates are found, if the `notifyUpdates` setting is enabled. Previously, only wanted games were considered for update notifications. (`server/cron.ts`)
* Refactored the search result filtering and categorization logic into new helper functions (`getAutoSearchRules` and `categorizeSearchItems`) for improved readability and maintainability. (`server/cron.ts`) [[1]](diffhunk://#diff-ba75421762c7e2b9cb1f0fa76c848def77f657ddd7b9306cead260d843a10a72R18-R83) [[2]](diffhunk://#diff-ba75421762c7e2b9cb1f0fa76c848def77f657ddd7b9306cead260d843a10a72L507-R583)

### Test coverage enhancements

* Added new tests to verify that update notifications are only sent for owned games and not for wanted games, and that game availability notifications for wanted games are still triggered when main results exist. (`server/__tests__/cron_autosearch.test.ts`)

### Storage and query changes

* Updated the auto-search logic to fetch both wanted and owned games for each user, and adjusted the early exit condition to handle cases where neither are present. (`server/cron.ts`)
* Added a mock for `getUserGames` in the test suite to support the new owned games search logic. (`server/__tests__/cron_autosearch.test.ts`)