### PR TITLE
🎨 Palette: Improve screen reader context for Sidebar and Notifications

### DIFF
--- a/client/src/components/AppSidebar.tsx
+++ b/client/src/components/AppSidebar.tsx
@@ -169,7 +169,13 @@ export default function AppSidebar({ activeItem = "/", onNavigate }: AppSidebarP
                     <button
                       onClick={() => handleNavigation(item.url)}
                       className="flex items-center justify-between w-full"
-                      aria-label={item.badge ? `${item.title}, ${item.badge} notifications` : undefined}
+                      aria-label={
+                        item.badge
+                          ? `${item.title}, ${item.badge} ${
+                              item.title === "Downloads" ? "active downloads" : "items"
+                            }`
+                          : undefined
+                      }
                     >
                       <div className="flex items-center gap-2">
                         <item.icon className="w-4 h-4" />

--- a/client/src/components/AppSidebar.tsx
+++ b/client/src/components/AppSidebar.tsx
@@ -169,7 +169,7 @@ export default function AppSidebar({ activeItem = "/", onNavigate }: AppSidebarP
                     <button
                       onClick={() => handleNavigation(item.url)}
                       className="flex items-center justify-between w-full"
-aria-label={item.badge ? `${item.title}, ${item.badge} ${item.title === 'Downloads' ? 'active downloads' : 'items'}` : item.title}
+                      aria-label={item.badge ? `${item.title}, ${item.badge} notifications` : undefined}
                     >
                       <div className="flex items-center gap-2">
                         <item.icon className="w-4 h-4" />

--- a/client/src/components/AppSidebar.tsx
+++ b/client/src/components/AppSidebar.tsx
@@ -169,6 +169,7 @@ export default function AppSidebar({ activeItem = "/", onNavigate }: AppSidebarP
                     <button
                       onClick={() => handleNavigation(item.url)}
                       className="flex items-center justify-between w-full"
+                      aria-label={item.badge ? `${item.title}, ${item.badge} notifications` : item.title}
                     >
                       <div className="flex items-center gap-2">
                         <item.icon className="w-4 h-4" />

--- a/client/src/components/AppSidebar.tsx
+++ b/client/src/components/AppSidebar.tsx
@@ -169,7 +169,7 @@ export default function AppSidebar({ activeItem = "/", onNavigate }: AppSidebarP
                     <button
                       onClick={() => handleNavigation(item.url)}
                       className="flex items-center justify-between w-full"
-                      aria-label={item.badge ? `${item.title}, ${item.badge} notifications` : item.title}
+aria-label={item.badge ? `${item.title}, ${item.badge} ${item.title === 'Downloads' ? 'active downloads' : 'items'}` : item.title}
                     >
                       <div className="flex items-center gap-2">
                         <item.icon className="w-4 h-4" />

--- a/client/src/components/NotificationItem.tsx
+++ b/client/src/components/NotificationItem.tsx
@@ -45,6 +45,7 @@ export function NotificationItem({ notification, onRead, onClick }: Notification
         !notification.read && "bg-muted/30 border-l-2 border-primary"
       )}
       onClick={handleClick}
+      aria-label={`${notification.read ? "Read" : "Unread"} notification: ${notification.title}`}
     >
       <div className="mt-0.5">{getIcon()}</div>
       <div className="flex-1 space-y-1">

--- a/client/src/components/NotificationItem.tsx
+++ b/client/src/components/NotificationItem.tsx
@@ -45,7 +45,7 @@ export function NotificationItem({ notification, onRead, onClick }: Notification
         !notification.read && "bg-muted/30 border-l-2 border-primary"
       )}
       onClick={handleClick}
-      aria-label={`${notification.read ? "Read" : "Unread"} notification: ${notification.title}`}
+aria-label={`${notification.read ? "Read" : "Unread"} notification: ${notification.title}. ${notification.message}`}
     >
       <div className="mt-0.5">{getIcon()}</div>
       <div className="flex-1 space-y-1">

--- a/client/src/components/NotificationItem.tsx
+++ b/client/src/components/NotificationItem.tsx
@@ -45,8 +45,10 @@ export function NotificationItem({ notification, onRead, onClick }: Notification
         !notification.read && "bg-muted/30 border-l-2 border-primary"
       )}
       onClick={handleClick}
-      aria-label={`${notification.read ? "Read" : "Unread"} notification: ${notification.title}`}
     >
+      <span className="sr-only">
+        {notification.read ? "Read" : "Unread"} notification:
+      </span>
       <div className="mt-0.5">{getIcon()}</div>
       <div className="flex-1 space-y-1">
         <div className="flex justify-between items-start">

--- a/client/src/components/NotificationItem.tsx
+++ b/client/src/components/NotificationItem.tsx
@@ -45,7 +45,7 @@ export function NotificationItem({ notification, onRead, onClick }: Notification
         !notification.read && "bg-muted/30 border-l-2 border-primary"
       )}
       onClick={handleClick}
-aria-label={`${notification.read ? "Read" : "Unread"} notification: ${notification.title}. ${notification.message}`}
+      aria-label={`${notification.read ? "Read" : "Unread"} notification: ${notification.title}`}
     >
       <div className="mt-0.5">{getIcon()}</div>
       <div className="flex-1 space-y-1">


### PR DESCRIPTION
💡 **What**: Added context-rich `aria-label`s to `NotificationItem` and `AppSidebar` navigation elements.
🎯 **Why**: Screen readers were previously announcing just the numbers (for unread counts in the sidebar) or not distinguishing between read/unread notifications before hearing the entire title. This change ensures that screen reader users get immediate, clear context for these interactive elements.
♿ **Accessibility**: Improves keyboard and screen reader accessibility by providing consolidated labels for composite interactive components.

---

*PR created automatically by Jules for task [14628497871745792347](https://jules.google.com/task/14628497871745792347) started by @Doezer*