### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in RSS feeds

### DIFF
--- a/server/__tests__/rss-routes.test.ts
+++ b/server/__tests__/rss-routes.test.ts
@@ -5,6 +5,7 @@ import express from "express";
 import { registerRoutes } from "../routes.js";
 import { storage } from "../storage.js";
 import { rssService } from "../rss.js";
+import { isSafeUrl } from "../ssrf.js";
 
 // Mock dependencies
 vi.mock("../storage.js");
@@ -14,6 +15,11 @@ vi.mock("../db.js");
 vi.mock("../torznab.js");
 vi.mock("../downloaders.js");
 vi.mock("../prowlarr.js");
+
+vi.mock("../ssrf.js", () => ({
+  isSafeUrl: vi.fn(),
+  safeFetch: vi.fn(),
+}));
 
 vi.mock("../auth.js", () => ({
   authenticateToken: (req: any, res: any, next: any) => {
@@ -75,6 +81,7 @@ describe("RSS Routes", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    vi.mocked(isSafeUrl).mockResolvedValue(true);
     app = express();
     app.use(express.json());
     await registerRoutes(app);
@@ -135,6 +142,22 @@ describe("RSS Routes", () => {
       expect(res.status).toBe(400);
       // Verify verification rejection without strict body check due to serialization issues
     });
+
+    it("should reject unsafe URLs with 400", async () => {
+      vi.mocked(isSafeUrl).mockResolvedValue(false);
+
+      const feed = {
+        name: "Evil Feed",
+        url: "http://169.254.169.254/latest/meta-data",
+        type: "custom",
+        enabled: true,
+      };
+      const res = await request(app).post("/api/rss/feeds").send(feed);
+
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty("error", "Invalid or unsafe URL");
+      expect(storage.addRssFeed).not.toHaveBeenCalled();
+    });
   });
 
   describe("PUT /api/rss/feeds/:id", () => {
@@ -157,6 +180,28 @@ describe("RSS Routes", () => {
       const res = await request(app).put("/api/rss/feeds/999").send({ name: "Update" });
 
       expect(res.status).toBe(404);
+    });
+
+    it("should reject unsafe URLs with 400", async () => {
+      vi.mocked(isSafeUrl).mockResolvedValue(false);
+
+      const res = await request(app)
+        .put("/api/rss/feeds/1")
+        .send({ url: "http://192.168.1.1/admin" });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty("error", "Invalid or unsafe URL");
+      expect(storage.updateRssFeed).not.toHaveBeenCalled();
+    });
+
+    it("should not call isSafeUrl when URL is not being updated", async () => {
+      const updatedFeed = { id: "1", name: "Renamed", url: "http://existing.com/rss" };
+      vi.mocked(storage.updateRssFeed).mockResolvedValue(updatedFeed as any);
+
+      const res = await request(app).put("/api/rss/feeds/1").send({ name: "Renamed" });
+
+      expect(res.status).toBe(200);
+      expect(isSafeUrl).not.toHaveBeenCalled();
     });
   });
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2542,6 +2542,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/rss/feeds", async (req, res) => {
     try {
       const feedData = insertRssFeedSchema.parse(req.body);
+
+      if (!(await isSafeUrl(feedData.url))) {
+        return res.status(400).json({ error: "Invalid or unsafe URL" });
+      }
+
       const feed = await storage.addRssFeed(feedData);
       // Trigger immediate refresh for new feed
       rssService.refreshFeed(feed).catch((err) => {
@@ -2571,6 +2576,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.put("/api/rss/feeds/:id", async (req, res) => {
     try {
       const updates = insertRssFeedSchema.partial().parse(req.body);
+
+      if (updates.url && !(await isSafeUrl(updates.url))) {
+        return res.status(400).json({ error: "Invalid or unsafe URL" });
+      }
+
       const feed = await storage.updateRssFeed(req.params.id, updates);
       if (!feed) {
         return res.status(404).json({ error: "Feed not found" });


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/api/rss/feeds` POST and PUT endpoints were vulnerable to Server-Side Request Forgery (SSRF) as they did not sanitize the user-provided RSS feed URL before making internal HTTP requests.
🎯 Impact: Attackers could provide internal network URLs (like `http://localhost:5100/api/health` or internal IP spaces), forcing the server to make requests on their behalf, potentially exposing internal services or causing a Denial of Service.
🔧 Fix: Added explicit `await isSafeUrl(url)` checks from `server/ssrf.ts` to both endpoints. If the URL is found to be unsafe, the endpoints now return a `400 Bad Request` with an appropriate error message.
✅ Verification: Ran the test suite using `npm test` and ensured `ssrf-routes.test.ts` passed correctly. Also verified `npm run build` and `npm run lint` were successful.

---

*PR created automatically by Jules for task [870104645251400991](https://jules.google.com/task/870104645251400991) started by @Doezer*