### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons with aria-labels

### DIFF
--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -940,6 +940,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                         downloadingGuid === (download.guid || download.link)
                                       }
                                       className="h-9 w-9 hover:bg-primary hover:text-primary-foreground transition-all"
+                                      aria-label={`Download ${download.title}`}
                                     >
                                       {downloadingGuid === (download.guid || download.link) ? (
                                         <Loader2 className="h-4 w-4 animate-spin" />
@@ -950,7 +951,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
 
                                     <DropdownMenu>
                                       <DropdownMenuTrigger asChild>
-                                        <Button variant="ghost" size="icon" className="h-9 w-9">
+                                        <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="More options">
                                           <MoreVertical className="h-4 w-4" />
                                         </Button>
                                       </DropdownMenuTrigger>

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -940,7 +940,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                         downloadingGuid === (download.guid || download.link)
                                       }
                                       className="h-9 w-9 hover:bg-primary hover:text-primary-foreground transition-all"
-                                      aria-label={`Download ${download.title}`}
+                                      aria-label={`Download ${download.title.replace(/[._]/g, " ")}`}
                                     >
                                       {downloadingGuid === (download.guid || download.link) ? (
                                         <Loader2 className="h-4 w-4 animate-spin" />
@@ -951,7 +951,12 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
 
                                     <DropdownMenu>
                                       <DropdownMenuTrigger asChild>
-                                        <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="More options">
+                                        <Button
+                                          variant="ghost"
+                                          size="icon"
+                                          className="h-9 w-9"
+                                          aria-label="More options"
+                                        >
                                           <MoreVertical className="h-4 w-4" />
                                         </Button>
                                       </DropdownMenuTrigger>

--- a/client/src/components/NotificationCenter.tsx
+++ b/client/src/components/NotificationCenter.tsx
@@ -152,12 +152,16 @@ export function NotificationCenter() {
     <>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
-          <Button variant="ghost" size="icon" className="relative">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="relative"
+            aria-label={unreadCount > 0 ? `Notifications, ${unreadCount} unread` : "Notifications"}
+          >
             <Bell className="h-5 w-5" />
             {unreadCount > 0 && (
               <span className="absolute top-1.5 right-1.5 h-2 w-2 rounded-full bg-red-600 animate-pulse" />
             )}
-            <span className="sr-only">Notifications</span>
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-[640px] p-0" align="end">

--- a/client/src/components/NotificationItem.tsx
+++ b/client/src/components/NotificationItem.tsx
@@ -47,11 +47,11 @@ export function NotificationItem({ notification, onRead, onClick }: Notification
       onClick={handleClick}
     >
       <span className="sr-only">
-        {notification.read ? "Read" : "Unread"} notification:
+        {notification.read ? "Read" : "Unread"} notification: {notification.title}
       </span>
-      <div className="mt-0.5">{getIcon()}</div>
+      <div className="mt-0.5" aria-hidden="true">{getIcon()}</div>
       <div className="flex-1 space-y-1">
-        <div className="flex justify-between items-start">
+        <div className="flex justify-between items-start" aria-hidden="true">
           <p className="font-medium leading-none">{notification.title}</p>
           {!notification.read && <span className="h-2 w-2 rounded-full bg-primary flex-shrink-0" />}
         </div>


### PR DESCRIPTION
💡 **What:** Added dynamic and descriptive `aria-label` attributes to multiple icon-only interactive elements across the app.
🎯 **Why:** To improve screen reader accessibility so users understand the context of icon-only buttons, particularly for notifications and downloads.
♿ **Accessibility:**

- The Notification Center bell icon now reads out "Notifications, X unread" instead of relying on a visually hidden span for screen readers.
- The `NotificationItem` now uses a single consolidated `aria-label` to announce the read status along with the notification title seamlessly, hiding the inner visual icons from the screen reader to prevent redundant announcements.
- Icon-only action buttons in the `GameDownloadDialog` now have `aria-label`s like "Download [Game Title]" and "More options" for context.

---

*PR created automatically by Jules for task [960916284616878748](https://jules.google.com/task/960916284616878748) started by @Doezer*