### PR TITLE
feat(a11y): add dynamic aria-labels to game cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ vite.config.ts.*
 docker-compose.*local.yml
 notes/
 sqlite.db*
+.omc/

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Dynamic ARIA labels for list items
+**Learning:** Hardcoding `aria-label` values (like "Download game") on icon-only buttons within repeating list items (like GameCards) creates an ambiguous and frustrating experience for screen reader users, as all buttons announce the exact same generic text without indicating which specific item they apply to.
+**Action:** Always incorporate dynamic data (e.g., `aria-label={\`Download ${game.title}\`}`) into ARIA labels for interactive elements within lists, grids, or carousels to provide unique and necessary context.

--- a/client/__tests__/CompactGameCard.test.tsx
+++ b/client/__tests__/CompactGameCard.test.tsx
@@ -112,7 +112,7 @@ describe("CompactGameCard", () => {
     renderWithProviders(<CompactGameCard game={mockGame} onViewDetails={onViewDetails} />);
 
     // Info button is wrapped in a tooltip, but the button content is accessible via the icon mock or aria-label
-    const infoButton = screen.getByLabelText("View details");
+    const infoButton = screen.getByLabelText(`View details for ${mockGame.title}`);
     fireEvent.click(infoButton);
 
     expect(onViewDetails).toHaveBeenCalledWith("1");

--- a/client/__tests__/CompactGameCard.test.tsx
+++ b/client/__tests__/CompactGameCard.test.tsx
@@ -117,4 +117,26 @@ describe("CompactGameCard", () => {
 
     expect(onViewDetails).toHaveBeenCalledWith("1");
   });
+
+  describe("dynamic aria-labels for status button", () => {
+    it.each([
+      { status: "wanted" as const, expectedLabel: "Owned", expectedNext: "owned" },
+      { status: "owned" as const, expectedLabel: "Completed", expectedNext: "completed" },
+      { status: "completed" as const, expectedLabel: "Wanted", expectedNext: "wanted" },
+    ])(
+      "shows aria-label 'Mark $title as $expectedLabel' when status is $status",
+      ({ status, expectedLabel, expectedNext }) => {
+        const onStatusChange = vi.fn();
+        renderWithProviders(
+          <CompactGameCard game={{ ...mockGame, status }} onStatusChange={onStatusChange} />
+        );
+
+        const btn = screen.getByLabelText(`Mark ${mockGame.title} as ${expectedLabel}`);
+        expect(btn).toBeInTheDocument();
+
+        fireEvent.click(btn);
+        expect(onStatusChange).toHaveBeenCalledWith(mockGame.id, expectedNext);
+      }
+    );
+  });
 });

--- a/client/src/components/CompactGameCard.tsx
+++ b/client/src/components/CompactGameCard.tsx
@@ -47,6 +47,12 @@ function getReleaseStatus(game: Game): {
   };
 }
 
+const getNextStatusInfo = (status: GameStatus): { id: GameStatus; label: string } => {
+  if (status === "wanted") return { id: "owned", label: "Owned" };
+  if (status === "owned") return { id: "completed", label: "Completed" };
+  return { id: "wanted", label: "Wanted" };
+};
+
 const CompactGameCard = ({
   game,
   onStatusChange,
@@ -100,9 +106,7 @@ const CompactGameCard = ({
   });
 
   const handleStatusClick = () => {
-    const nextStatus: GameStatus =
-      game.status === "wanted" ? "owned" : game.status === "owned" ? "completed" : "wanted";
-    onStatusChange?.(game.id, nextStatus);
+    onStatusChange?.(game.id, getNextStatusInfo(game.status).id);
   };
 
   const handleDetailsClick = () => {
@@ -307,9 +311,7 @@ const CompactGameCard = ({
                   : "h-8 text-xs"
               )}
               onClick={handleStatusClick}
-              aria-label={`Mark ${game.title} as ${
-                game.status === "wanted" ? "Owned" : game.status === "owned" ? "Completed" : "Wanted"
-              }`}
+              aria-label={`Mark ${game.title} as ${getNextStatusInfo(game.status).label}`}
             >
               {density !== "comfortable" ? (
                 game.status === "wanted" ? (
@@ -319,12 +321,8 @@ const CompactGameCard = ({
                 ) : (
                   <span title="Mark Wanted">★</span>
                 )
-              ) : game.status === "wanted" ? (
-                "Mark Owned"
-              ) : game.status === "owned" ? (
-                "Mark Completed"
               ) : (
-                "Mark Wanted"
+                `Mark ${getNextStatusInfo(game.status).label}`
               )}
             </Button>
           )}

--- a/client/src/components/CompactGameCard.tsx
+++ b/client/src/components/CompactGameCard.tsx
@@ -285,7 +285,7 @@ const CompactGameCard = ({
                   )}
                   onClick={handleDownloadClick}
                   disabled={addGameMutation.isPending}
-                  aria-label="Download game"
+                  aria-label={`Download ${game.title}`}
                 >
                   {addGameMutation.isPending ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
@@ -307,6 +307,9 @@ const CompactGameCard = ({
                   : "h-8 text-xs"
               )}
               onClick={handleStatusClick}
+              aria-label={`Mark ${game.title} as ${
+                game.status === "wanted" ? "Owned" : game.status === "owned" ? "Completed" : "Wanted"
+              }`}
             >
               {density !== "comfortable" ? (
                 game.status === "wanted" ? (
@@ -333,7 +336,7 @@ const CompactGameCard = ({
                 variant="ghost"
                 className={cn("transition-all", density !== "comfortable" ? "h-6 w-6" : "h-8 w-8")}
                 onClick={handleDetailsClick}
-                aria-label="View details"
+                aria-label={`View details for ${game.title}`}
               >
                 <Info className={density !== "comfortable" ? "w-3 h-3" : "w-4 h-4"} />
               </Button>
@@ -352,7 +355,7 @@ const CompactGameCard = ({
                     density !== "comfortable" ? "h-6 w-6" : "h-8 w-8"
                   )}
                   onClick={handleToggleHidden}
-                  aria-label={game.hidden ? "Unhide game" : "Hide game"}
+                  aria-label={game.hidden ? `Unhide ${game.title}` : `Hide ${game.title}`}
                 >
                   {game.hidden ? (
                     <Eye className={density !== "comfortable" ? "w-3 h-3" : "w-4 h-4"} />

--- a/client/src/components/GameCard.tsx
+++ b/client/src/components/GameCard.tsx
@@ -189,7 +189,7 @@ const GameCard = ({
                   variant="default"
                   onClick={handleDownloadClick}
                   disabled={addGameMutation.isPending}
-                  aria-label="Download game"
+                  aria-label={`Download ${game.title}`}
                   data-testid={`button-download-${game.id}`}
                 >
                   {addGameMutation.isPending ? (
@@ -210,7 +210,7 @@ const GameCard = ({
                 size="icon"
                 variant="secondary"
                 onClick={handleDetailsClick}
-                aria-label="View details"
+                aria-label={`View details for ${game.title}`}
                 data-testid={`button-details-${game.id}`}
               >
                 <Info className="w-4 h-4" />
@@ -227,7 +227,7 @@ const GameCard = ({
                   size="icon"
                   variant="secondary"
                   onClick={handleToggleHidden}
-                  aria-label={game.hidden ? "Unhide game" : "Hide game"}
+                  aria-label={game.hidden ? `Unhide ${game.title}` : `Hide ${game.title}`}
                   data-testid={`button-toggle-hidden-${game.id}`}
                 >
                   {game.hidden ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}


### PR DESCRIPTION
**🎨 Palette: Dynamic ARIA labels for game cards**

💡 **What:** Added dynamic `aria-label`s to the icon-only buttons (Download, View Details, Hide/Unhide, Status) in `GameCard` and `CompactGameCard`.
🎯 **Why:** Previously, these buttons had static labels like "Download game" or "View details". When rendered in a list or grid, a screen reader user would hear the same generic label repeatedly, without knowing which specific game the button pertained to. By including the game's title (e.g., "Download Super Mario Bros"), we provide crucial context and make the interface significantly more accessible and intuitive to navigate with assistive technology.
📸 **Before/After:** No visual changes, as this is purely an accessibility enhancement for screen readers.
♿ **Accessibility:** Significantly improves screen reader experience for list items containing identical controls.

Also documented this finding in `.jules/palette.md` for future reference.

---

*PR created automatically by Jules for task [9106218107201265560](https://jules.google.com/task/9106218107201265560) started by @Doezer*