### PR TITLE
Fix torznab client not able to correctly handle prowlarr links

### DIFF
--- a/server/__tests__/torznab.test.ts
+++ b/server/__tests__/torznab.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Indexer } from "@shared/schema";
+
+vi.mock("../db.js", () => ({ pool: {}, db: {} }));
+vi.mock("../logger.js", () => ({
+  torznabLogger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("../ssrf.js", () => ({ safeFetch: vi.fn() }));
+
+const { TorznabClient } = await import("../torznab.js");
+const { safeFetch } = await import("../ssrf.js");
+
+const mockSafeFetch = vi.mocked(safeFetch);
+
+function makeIndexer(overrides: Partial<Indexer> = {}): Indexer {
+  return {
+    id: "idx-1",
+    name: "Test Indexer",
+    url: "http://indexer.example.com/api",
+    apiKey: "testkey",
+    protocol: "torznab",
+    enabled: true,
+    priority: 1,
+    categories: [],
+    rssEnabled: true,
+    autoSearchEnabled: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeTorznabXml(enclosureUrl: string, link?: string): string {
+  const linkEl = link ? `<link>${link}</link>` : "";
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <title>Test</title>
+    <item>
+      <title>Some Game</title>
+      ${linkEl}
+      <guid>https://limetorrents.info/some-game-torrent-1234.html</guid>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
+      <enclosure url="${enclosureUrl}" length="1000000" type="application/x-bittorrent"/>
+    </item>
+  </channel>
+</rss>`;
+}
+
+function mockFetchResponse(xml: string) {
+  mockSafeFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => xml,
+  } as Response);
+}
+
+describe("TorznabClient — download link rewriting", () => {
+  let client: InstanceType<typeof TorznabClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new TorznabClient();
+  });
+
+  it("leaves the link unchanged when it already points to the indexer host", async () => {
+    const indexer = makeIndexer({ url: "http://indexer.example.com/api" });
+    const expectedLink = "http://indexer.example.com/download/file.torrent";
+    mockFetchResponse(makeTorznabXml(expectedLink));
+
+    const result = await client.searchGames(indexer, { query: "game" });
+
+    expect(result.items[0].link).toBe(expectedLink);
+  });
+
+  it("applies standard host rewrite for non-Prowlarr indexers returning an internal URL", async () => {
+    const indexer = makeIndexer({ url: "https://my-indexer.com/api" });
+    // Indexer returns its internal hostname in the download URL
+    mockFetchResponse(makeTorznabXml("http://internal-host:8080/download/file.torrent"));
+
+    const result = await client.searchGames(indexer, { query: "game" });
+
+    // Host is rewritten to the configured host; port from the internal URL is preserved
+    expect(result.items[0].link).toBe("https://my-indexer.com:8080/download/file.torrent");
+  });
+
+  it("builds a Prowlarr proxy URL when a Prowlarr indexer returns a raw external download URL", async () => {
+    const prowlarrIndexer = makeIndexer({
+      url: "http://prowlarr:9696/5/api",
+      apiKey: "prowlarr-api-key",
+    });
+    const rawExternalUrl = "https://limetorrents.info/download/8/some-game.torrent";
+    mockFetchResponse(makeTorznabXml(rawExternalUrl));
+
+    const result = await client.searchGames(prowlarrIndexer, { query: "game" });
+
+    const link = result.items[0].link;
+    const parsed = new URL(link);
+
+    // Must point to Prowlarr, not the external indexer
+    expect(parsed.hostname).toBe("prowlarr");
+    expect(parsed.port).toBe("9696");
+    expect(parsed.pathname).toBe("/5/download");
+
+    // Must include apikey matching the indexer config
+    expect(parsed.searchParams.get("apikey")).toBe("prowlarr-api-key");
+
+    // The 'link' param must be the base64-encoded original URL
+    const encodedLink = parsed.searchParams.get("link");
+    expect(encodedLink).not.toBeNull();
+    const decoded = Buffer.from(encodedLink!, "base64").toString("utf-8");
+    expect(decoded).toBe(rawExternalUrl);
+  });
+
+  it("uses Prowlarr proxy URL format when Prowlarr indexer has numeric ID in URL path", async () => {
+    const prowlarrIndexer = makeIndexer({
+      url: "http://192.168.1.100:9696/12/api",
+      apiKey: "secret",
+    });
+    const rawUrl = "https://external-indexer.org/torrents/download/99999.torrent";
+    mockFetchResponse(makeTorznabXml(rawUrl));
+
+    const result = await client.searchGames(prowlarrIndexer, { query: "game" });
+
+    const link = result.items[0].link;
+    expect(link).toMatch(/^http:\/\/192\.168\.1\.100:9696\/12\/download\?/);
+
+    const parsed = new URL(link);
+    expect(parsed.searchParams.get("apikey")).toBe("secret");
+    const decoded = Buffer.from(parsed.searchParams.get("link")!, "base64").toString();
+    expect(decoded).toBe(rawUrl);
+  });
+
+  it("leaves Prowlarr proxy URLs unchanged when Prowlarr already returned its own proxy URL", async () => {
+    const prowlarrIndexer = makeIndexer({
+      url: "http://prowlarr:9696/5/api",
+      apiKey: "prowlarr-api-key",
+    });
+    // Prowlarr already generated its own proxy URL — must not be double-encoded
+    const prowlarrProxyUrl =
+      "http://prowlarr:9696/5/download?file=Some+Game&link=aHR0cHM6Ly9leGFtcGxlLmNvbQ%3D%3D&apikey=prowlarr-api-key";
+    mockFetchResponse(makeTorznabXml(prowlarrProxyUrl));
+
+    const result = await client.searchGames(prowlarrIndexer, { query: "game" });
+
+    expect(result.items[0].link).toBe(prowlarrProxyUrl);
+  });
+
+  it("falls back to standard host rewrite for Prowlarr-style URL path but missing apiKey", async () => {
+    const indexer = makeIndexer({
+      url: "http://prowlarr:9696/5/api",
+      apiKey: "",
+    });
+    mockFetchResponse(makeTorznabXml("https://external.com/download/game.torrent"));
+
+    const result = await client.searchGames(indexer, { query: "game" });
+
+    // No apiKey → falls through to standard host rewrite
+    const link = result.items[0].link;
+    expect(new URL(link).host).toBe("prowlarr:9696");
+  });
+});

--- a/server/__tests__/torznab.test.ts
+++ b/server/__tests__/torznab.test.ts
@@ -24,8 +24,8 @@ function makeIndexer(overrides: Partial<Indexer> = {}): Indexer {
     categories: [],
     rssEnabled: true,
     autoSearchEnabled: true,
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2024-01-01T00:00:00.000Z"),
     ...overrides,
   };
 }
@@ -77,7 +77,7 @@ describe("TorznabClient — download link rewriting", () => {
   it("applies standard host rewrite for non-Prowlarr indexers returning an internal URL", async () => {
     const indexer = makeIndexer({ url: "https://my-indexer.com/api" });
     // Indexer returns its internal hostname in the download URL
-    mockFetchResponse(makeTorznabXml("http://internal-host:8080/download/file.torrent"));
+    mockFetchResponse(makeTorznabXml("https://internal-host:8080/download/file.torrent"));
 
     const result = await client.searchGames(indexer, { query: "game" });
 
@@ -87,7 +87,7 @@ describe("TorznabClient — download link rewriting", () => {
 
   it("builds a Prowlarr proxy URL when a Prowlarr indexer returns a raw external download URL", async () => {
     const prowlarrIndexer = makeIndexer({
-      url: "http://prowlarr:9696/5/api",
+      url: "https://prowlarr:9696/5/api",
       apiKey: "prowlarr-api-key",
     });
     const rawExternalUrl = "https://limetorrents.info/download/8/some-game.torrent";
@@ -115,7 +115,7 @@ describe("TorznabClient — download link rewriting", () => {
 
   it("uses Prowlarr proxy URL format when Prowlarr indexer has numeric ID in URL path", async () => {
     const prowlarrIndexer = makeIndexer({
-      url: "http://192.168.1.100:9696/12/api",
+      url: "https://192.168.1.100:9696/12/api",
       apiKey: "secret",
     });
     const rawUrl = "https://external-indexer.org/torrents/download/99999.torrent";
@@ -124,7 +124,7 @@ describe("TorznabClient — download link rewriting", () => {
     const result = await client.searchGames(prowlarrIndexer, { query: "game" });
 
     const link = result.items[0].link;
-    expect(link).toMatch(/^http:\/\/192\.168\.1\.100:9696\/12\/download\?/);
+    expect(link).toMatch(/^https:\/\/192\.168\.1\.100:9696\/12\/download\?/);
 
     const parsed = new URL(link);
     expect(parsed.searchParams.get("apikey")).toBe("secret");
@@ -134,12 +134,12 @@ describe("TorznabClient — download link rewriting", () => {
 
   it("leaves Prowlarr proxy URLs unchanged when Prowlarr already returned its own proxy URL", async () => {
     const prowlarrIndexer = makeIndexer({
-      url: "http://prowlarr:9696/5/api",
+      url: "https://prowlarr:9696/5/api",
       apiKey: "prowlarr-api-key",
     });
     // Prowlarr already generated its own proxy URL — must not be double-encoded
     const prowlarrProxyUrl =
-      "http://prowlarr:9696/5/download?file=Some+Game&link=aHR0cHM6Ly9leGFtcGxlLmNvbQ%3D%3D&apikey=prowlarr-api-key";
+      "https://prowlarr:9696/5/download?file=Some+Game&link=aHR0cHM6Ly9leGFtcGxlLmNvbQ%3D%3D&apikey=prowlarr-api-key";
     mockFetchResponse(makeTorznabXml(prowlarrProxyUrl));
 
     const result = await client.searchGames(prowlarrIndexer, { query: "game" });
@@ -149,7 +149,7 @@ describe("TorznabClient — download link rewriting", () => {
 
   it("falls back to standard host rewrite for Prowlarr-style URL path but missing apiKey", async () => {
     const indexer = makeIndexer({
-      url: "http://prowlarr:9696/5/api",
+      url: "https://prowlarr:9696/5/api",
       apiKey: "",
     });
     mockFetchResponse(makeTorznabXml("https://external.com/download/game.torrent"));

--- a/server/torznab.ts
+++ b/server/torznab.ts
@@ -331,14 +331,15 @@ export class TorznabClient {
             // Prowlarr — which has FlareSolverr configured to bypass Cloudflare.
             const prowlarrMatch = indexerUrlObj.pathname.match(/^\/(\d+)\/api\/?$/i);
             if (prowlarrMatch && indexer?.apiKey) {
-              const prowlarrIndexerId = prowlarrMatch[1];
-              const prowlarrBase = `${indexerUrlObj.protocol}//${indexerUrlObj.host}`;
-              const encodedLink = encodeURIComponent(
+              const prowlarrUrl = new URL(`${indexerUrlObj.protocol}//${indexerUrlObj.host}`);
+              prowlarrUrl.pathname = `/${prowlarrMatch[1]}/download`;
+              prowlarrUrl.searchParams.set("file", torznabItem.title || "download");
+              prowlarrUrl.searchParams.set(
+                "link",
                 Buffer.from(torznabItem.link).toString("base64")
               );
-              const fileName = encodeURIComponent(torznabItem.title || "download");
-              const apiKey = encodeURIComponent(indexer.apiKey);
-              torznabItem.link = `${prowlarrBase}/${prowlarrIndexerId}/download?file=${fileName}&link=${encodedLink}&apikey=${apiKey}`;
+              prowlarrUrl.searchParams.set("apikey", indexer.apiKey);
+              torznabItem.link = prowlarrUrl.toString();
             } else {
               // Standard host rewrite for reverse-proxy / seedbox setups where the indexer
               // returns its internal address but should be reached via the configured URL.

--- a/server/torznab.ts
+++ b/server/torznab.ts
@@ -323,15 +323,32 @@ export class TorznabClient {
         if (linkUrl.protocol === "http:" || linkUrl.protocol === "https:") {
           const indexerUrlObj = new URL(indexerUrl);
 
-          // If the link uses a different port or host than the configured indexer,
-          // but shares the same path structure (heuristic), we force the configured URL.
-          // We assume that the path part returned by the indexer is correct relative to the base.
-
-          linkUrl.protocol = indexerUrlObj.protocol;
-          linkUrl.host = indexerUrlObj.host; // overrides port too
-
-          // Use the modified URL
-          torznabItem.link = linkUrl.toString();
+          if (linkUrl.host !== indexerUrlObj.host) {
+            // Check if this is a Prowlarr indexer URL (pattern: /{numericId}/api).
+            // When Prowlarr returns a raw external download URL (e.g. from a Cloudflare-protected
+            // indexer), a naive host swap would produce an invalid path on Prowlarr. Instead,
+            // construct a proper Prowlarr download proxy URL so the request goes through
+            // Prowlarr — which has FlareSolverr configured to bypass Cloudflare.
+            const prowlarrMatch = indexerUrlObj.pathname.match(/^\/(\d+)\/api\/?$/i);
+            if (prowlarrMatch && indexer?.apiKey) {
+              const prowlarrIndexerId = prowlarrMatch[1];
+              const prowlarrBase = `${indexerUrlObj.protocol}//${indexerUrlObj.host}`;
+              const encodedLink = encodeURIComponent(
+                Buffer.from(torznabItem.link).toString("base64")
+              );
+              const fileName = encodeURIComponent(torznabItem.title || "download");
+              const apiKey = encodeURIComponent(indexer.apiKey);
+              torznabItem.link = `${prowlarrBase}/${prowlarrIndexerId}/download?file=${fileName}&link=${encodedLink}&apikey=${apiKey}`;
+            } else {
+              // Standard host rewrite for reverse-proxy / seedbox setups where the indexer
+              // returns its internal address but should be reached via the configured URL.
+              linkUrl.protocol = indexerUrlObj.protocol;
+              linkUrl.host = indexerUrlObj.host;
+              torznabItem.link = linkUrl.toString();
+            }
+          }
+          // If hosts already match the configured indexer (e.g. Prowlarr already returned its
+          // own proxy URL), leave the link unchanged.
         }
       } catch {
         // Ignore invalid URLs or parsing errors


### PR DESCRIPTION
- tests for the Torznab download link rewriting logic
- modif how TorznabClient rewrites download URLs, especially for Prowlarr indexers.  proxy URLs & edge cases


* Updated the `TorznabClient` logic to:
  - Detect Prowlarr indexer URLs (using the `/numericId/api` path pattern) and, when necessary, construct a proper Prowlarr proxy download URL with base64-encoded original links and required query parameters.
  - Fall back to standard host/port rewriting for non-Prowlarr indexers or when the API key is missing.
  - Leave links unchanged if they already match the configured indexer host (e.g., when Prowlarr already returned a proxy URL).