### PR TITLE
feat: add ability to blacklist a release in downloads search

### DIFF
--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -52,6 +52,7 @@ vi.mock("lucide-react", () => ({
   ChevronsUpDown: () => <div data-testid="icon-chevrons-up-down" />,
   MoreVertical: () => <div />,
   Copy: () => <div />,
+  Ban: () => <div data-testid="icon-ban" />,
 }));
 
 const mockGame = {

--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -11,6 +11,24 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 
 // Mocking external dependencies
 const mockToast = vi.fn();
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+  }) => <button onClick={onClick}>{children}</button>,
+  DropdownMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSubContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSubTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuPortal: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+}));
 vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({
     toast: mockToast,
@@ -50,7 +68,7 @@ vi.mock("lucide-react", () => ({
   ChevronDown: () => <div data-testid="icon-chevron-down" />,
   ChevronUp: () => <div data-testid="icon-chevron-up" />,
   ChevronsUpDown: () => <div data-testid="icon-chevrons-up-down" />,
-  MoreVertical: () => <div />,
+  MoreVertical: () => <div data-testid="icon-more-vertical" />,
   Copy: () => <div />,
   Ban: () => <div data-testid="icon-ban" />,
 }));
@@ -148,6 +166,7 @@ type FetchOverrides = {
   search?: object;
   settings?: object;
   downloads?: object;
+  blacklist?: object;
 };
 
 /** Creates a fetch mock with sensible defaults, overridable per-endpoint. */
@@ -165,6 +184,13 @@ const createFetchMock = (overrides: FetchOverrides = {}) =>
     }
     if (urlString.includes("/api/settings")) {
       return { ok: true, json: async () => overrides.settings ?? {} };
+    }
+    if (urlString.includes("/blacklist")) {
+      return {
+        ok: true,
+        json: async () =>
+          overrides.blacklist ?? { id: "bl-1", gameId: mockGame.id, releaseTitle: "Test Torrent 1" },
+      };
     }
     if (urlString.includes("/api/downloads")) {
       return {
@@ -251,6 +277,30 @@ describe("GameDownloadDialog", () => {
 
     // Should trigger a re-sort -> Ascending -> ArrowUp
     expect(screen.getAllByTestId("icon-sort-up").length).toBeGreaterThan(0);
+  });
+
+  it("blacklists a release when clicking 'Blacklist release'", async () => {
+    renderComponent();
+
+    // Wait for results to load (dropdown is always rendered via mock)
+    await waitFor(
+      () => {
+        expect(screen.getAllByText("Blacklist release").length).toBeGreaterThan(0);
+      },
+      { timeout: 3000 }
+    );
+
+    fireEvent.click(screen.getAllByText("Blacklist release")[0]);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/blacklist"),
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining("Test Torrent 1"),
+        })
+      );
+    });
   });
 
   it("shows a loading spinner on the download button when clicked", async () => {

--- a/client/src/components/GameCard.tsx
+++ b/client/src/components/GameCard.tsx
@@ -196,7 +196,10 @@ const GameCard = ({
               <Button
                 size="icon"
                 variant="secondary"
-                onClick={handleDetailsClick}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleDetailsClick();
+                }}
                 aria-label={`View details for ${game.title}`}
                 data-testid={`button-details-${game.id}`}
               >

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -55,6 +55,7 @@ import {
   ArrowUp,
   ArrowDown,
   Activity,
+  Ban,
 } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
@@ -194,8 +195,12 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     }
   }, [open, game, applyDownloadRules, setDefaults]);
 
+  const searchQueryKey = game?.id
+    ? `/api/search?query=${encodeURIComponent(debouncedSearchQuery)}&gameId=${game.id}`
+    : `/api/search?query=${encodeURIComponent(debouncedSearchQuery)}`;
+
   const { data: searchResults, isLoading: isSearching } = useQuery<SearchResult>({
-    queryKey: [`/api/search?query=${encodeURIComponent(debouncedSearchQuery)}`],
+    queryKey: [searchQueryKey],
     enabled: open && debouncedSearchQuery.trim().length > 0,
   });
 
@@ -371,6 +376,26 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
         description: error.message,
         variant: "destructive",
       });
+    },
+  });
+
+  const blacklistMutation = useMutation({
+    mutationFn: async (item: DownloadItem) => {
+      if (!game) throw new Error("No game context");
+      await apiRequest("POST", `/api/games/${game.id}/blacklist`, {
+        releaseTitle: item.title,
+        indexerName: item.indexerName ?? null,
+      });
+    },
+    onSuccess: (_data, item) => {
+      queryClient.setQueryData<SearchResult>([searchQueryKey], (old) => {
+        if (!old) return old;
+        return { ...old, items: old.items.filter((i) => i.title !== item.title) };
+      });
+      toast({ description: "Release blacklisted" });
+    },
+    onError: () => {
+      toast({ variant: "destructive", description: "Failed to blacklist release" });
     },
   });
 
@@ -1031,6 +1056,13 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                             </DropdownMenuSub>
                                           );
                                         })()}
+                                        <DropdownMenuItem
+                                          onClick={() => blacklistMutation.mutate(download)}
+                                          className="text-destructive focus:text-destructive"
+                                        >
+                                          <Ban className="h-4 w-4 mr-2" />
+                                          Blacklist release
+                                        </DropdownMenuItem>
                                       </DropdownMenuContent>
                                     </DropdownMenu>
                                   </div>

--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from "react";
-import { useDebounce } from "@/hooks/use-debounce";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Search, Filter, X, LayoutGrid } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { useDebounce } from "@/hooks/use-debounce";
 
 interface SearchBarProps {
   onSearch?: (query: string) => void;
@@ -35,11 +35,9 @@ export default function SearchBar({
     e.preventDefault();
   };
 
-  // Trigger search on input change for live search
+  // Trigger search on input change for live search (debounced via useEffect above)
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setSearchQuery(value);
-    console.warn(`Search input change: ${value}`);
+    setSearchQuery(e.target.value);
   };
 
   const handleClearSearch = () => {
@@ -48,12 +46,10 @@ export default function SearchBar({
   };
 
   const handleFilterClick = () => {
-    console.warn("Filter toggle triggered");
     onFilterToggle?.();
   };
 
   const handleRemoveFilter = (filter: string) => {
-    console.warn(`Remove filter triggered: ${filter}`);
     onRemoveFilter?.(filter);
   };
 

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -47,7 +47,7 @@ import PasswordSettings from "@/components/PasswordSettings";
 import type { Config, UserSettings, DownloadRules, ReleaseBlacklist } from "@shared/schema";
 import { downloadRulesSchema } from "@shared/schema";
 import { parseJsonStringArray } from "@shared/title-utils";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 
 interface CertInfo {
   subject: string;
@@ -109,6 +109,17 @@ export default function SettingsPage() {
       toast({ variant: "destructive", description: "Failed to remove from blacklist" });
     },
   });
+
+  const blacklistByGame = useMemo(() => {
+    if (!blacklistEntries) return {};
+    return blacklistEntries.reduce<Record<string, (ReleaseBlacklist & { gameTitle: string })[]>>(
+      (acc, entry) => {
+        (acc[entry.gameTitle] ??= []).push(entry);
+        return acc;
+      },
+      {}
+    );
+  }, [blacklistEntries]);
 
   // Local state for form
   const [autoSearchEnabled, setAutoSearchEnabled] = useState(true);
@@ -1515,14 +1526,7 @@ export default function SettingsPage() {
                   <div className="text-sm text-muted-foreground">No blacklisted releases.</div>
                 ) : (
                   <div className="space-y-4">
-                    {Object.entries(
-                      blacklistEntries.reduce<
-                        Record<string, (ReleaseBlacklist & { gameTitle: string })[]>
-                      >((acc, entry) => {
-                        (acc[entry.gameTitle] ??= []).push(entry);
-                        return acc;
-                      }, {})
-                    ).map(([gameTitle, entries]) => (
+                    {Object.entries(blacklistByGame).map(([gameTitle, entries]) => (
                       <div key={gameTitle}>
                         <h4 className="text-sm font-semibold mb-2">{gameTitle}</h4>
                         <div className="space-y-2">
@@ -1538,7 +1542,7 @@ export default function SettingsPage() {
                                 <p className="text-xs text-muted-foreground">
                                   {entry.indexerName ? `${entry.indexerName} · ` : ""}
                                   {entry.createdAt
-                                    ? new Date(entry.createdAt).toLocaleDateString()
+                                    ? new Date(entry.createdAt).toISOString().split("T")[0]
                                     : ""}
                                 </p>
                               </div>

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -19,6 +19,8 @@ import {
   Upload,
   Gamepad2,
   Webhook,
+  Ban,
+  Trash2,
 } from "lucide-react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -42,7 +44,7 @@ import { apiRequest, clearSearchCache } from "@/lib/queryClient";
 import AutoDownloadRulesSettings from "@/components/AutoDownloadRulesSettings";
 import PreferredReleaseGroupsSettings from "@/components/PreferredReleaseGroupsSettings";
 import PasswordSettings from "@/components/PasswordSettings";
-import type { Config, UserSettings, DownloadRules } from "@shared/schema";
+import type { Config, UserSettings, DownloadRules, ReleaseBlacklist } from "@shared/schema";
 import { downloadRulesSchema } from "@shared/schema";
 import { parseJsonStringArray } from "@shared/title-utils";
 import { useState, useEffect, useRef } from "react";
@@ -87,6 +89,25 @@ export default function SettingsPage() {
 
   const { data: user } = useQuery<{ id: string; username: string; steamId64?: string }>({
     queryKey: ["/api/auth/me"],
+  });
+
+  const { data: blacklistEntries, isLoading: blacklistLoading } = useQuery<
+    (ReleaseBlacklist & { gameTitle: string })[]
+  >({
+    queryKey: ["/api/blacklist"],
+  });
+
+  const removeBlacklistMutation = useMutation({
+    mutationFn: async ({ gameId, id }: { gameId: string; id: string }) => {
+      await apiRequest("DELETE", `/api/games/${gameId}/blacklist/${id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/blacklist"] });
+      toast({ description: "Release removed from blacklist" });
+    },
+    onError: () => {
+      toast({ variant: "destructive", description: "Failed to remove from blacklist" });
+    },
   });
 
   // Local state for form
@@ -548,6 +569,7 @@ export default function SettingsPage() {
             <TabsTrigger value="account">Account</TabsTrigger>
             <TabsTrigger value="security">Security</TabsTrigger>
             <TabsTrigger value="system">System</TabsTrigger>
+            <TabsTrigger value="blacklist">Blacklist</TabsTrigger>
           </TabsList>
 
           <TabsContent value="general" className="space-y-6">
@@ -1469,6 +1491,75 @@ export default function SettingsPage() {
                       </Button>
                     </div>
                   </>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="blacklist" className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Ban className="h-5 w-5" />
+                  Blacklisted Releases
+                </CardTitle>
+                <CardDescription>
+                  Releases hidden from search results. They will not appear in game download
+                  searches or be auto-downloaded.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {blacklistLoading ? (
+                  <div className="text-sm text-muted-foreground">Loading...</div>
+                ) : !blacklistEntries || blacklistEntries.length === 0 ? (
+                  <div className="text-sm text-muted-foreground">No blacklisted releases.</div>
+                ) : (
+                  <div className="space-y-4">
+                    {Object.entries(
+                      blacklistEntries.reduce<
+                        Record<string, (ReleaseBlacklist & { gameTitle: string })[]>
+                      >((acc, entry) => {
+                        (acc[entry.gameTitle] ??= []).push(entry);
+                        return acc;
+                      }, {})
+                    ).map(([gameTitle, entries]) => (
+                      <div key={gameTitle}>
+                        <h4 className="text-sm font-semibold mb-2">{gameTitle}</h4>
+                        <div className="space-y-2">
+                          {entries.map((entry) => (
+                            <div
+                              key={entry.id}
+                              className="flex items-center justify-between rounded-md border p-3"
+                            >
+                              <div className="space-y-1">
+                                <p className="text-sm font-medium leading-none">
+                                  {entry.releaseTitle}
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                  {entry.indexerName ? `${entry.indexerName} · ` : ""}
+                                  {entry.createdAt
+                                    ? new Date(entry.createdAt).toLocaleDateString()
+                                    : ""}
+                                </p>
+                              </div>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() =>
+                                  removeBlacklistMutation.mutate({
+                                    gameId: entry.gameId,
+                                    id: entry.id,
+                                  })
+                                }
+                              >
+                                <Trash2 className="h-4 w-4 text-destructive" />
+                              </Button>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
                 )}
               </CardContent>
             </Card>

--- a/migrations/0008_ambiguous_tomorrow_man.sql
+++ b/migrations/0008_ambiguous_tomorrow_man.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `release_blacklist` (
+	`id` text PRIMARY KEY NOT NULL,
+	`game_id` text NOT NULL,
+	`release_title` text NOT NULL,
+	`indexer_name` text,
+	`created_at` integer DEFAULT (strftime('%s', 'now') * 1000),
+	FOREIGN KEY (`game_id`) REFERENCES `games`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `release_blacklist_game_title_idx` ON `release_blacklist` (`game_id`,`release_title`);

--- a/migrations/meta/0008_snapshot.json
+++ b/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1143 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9c1fdfcb-a3f8-45bd-b446-49ae63b87c5f",
+  "prevId": "4e009fa3-d587-4b79-91e4-b4bea160142e",
+  "tables": {
+    "downloaders": {
+      "name": "downloaders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "url_path": {
+          "name": "url_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "download_path": {
+          "name": "download_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'games'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Questarr'"
+        },
+        "add_stopped": {
+          "name": "add_stopped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "remove_completed": {
+          "name": "remove_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "post_import_category": {
+          "name": "post_import_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_downloads": {
+      "name": "game_downloads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "downloader_id": {
+          "name": "downloader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_type": {
+          "name": "download_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torrent'"
+        },
+        "download_hash": {
+          "name": "download_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_title": {
+          "name": "download_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'downloading'"
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_downloads_game_id_games_id_fk": {
+          "name": "game_downloads_game_id_games_id_fk",
+          "tableFrom": "game_downloads",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_downloads_downloader_id_downloaders_id_fk": {
+          "name": "game_downloads_downloader_id_downloaders_id_fk",
+          "tableFrom": "game_downloads",
+          "tableTo": "downloaders",
+          "columnsFrom": ["downloader_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "games": {
+      "name": "games",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steam_appid": {
+          "name": "steam_appid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publishers": {
+          "name": "publishers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "developers": {
+          "name": "developers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "original_release_date": {
+          "name": "original_release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_status": {
+          "name": "release_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'upcoming'"
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "search_results_available": {
+          "name": "search_results_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_user_id_users_id_fk": {
+          "name": "games_user_id_users_id_fk",
+          "tableFrom": "games",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexers": {
+      "name": "indexers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torznab'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "rss_enabled": {
+          "name": "rss_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_search_enabled": {
+          "name": "auto_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read": {
+          "name": "read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "release_blacklist": {
+      "name": "release_blacklist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_title": {
+          "name": "release_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexer_name": {
+          "name": "indexer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "release_blacklist_game_title_idx": {
+          "name": "release_blacklist_game_title_idx",
+          "columns": ["game_id", "release_title"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "release_blacklist_game_id_games_id_fk": {
+          "name": "release_blacklist_game_id_games_id_fk",
+          "tableFrom": "release_blacklist",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_feed_items": {
+      "name": "rss_feed_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pub_date": {
+          "name": "pub_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_game_id": {
+          "name": "igdb_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_game_name": {
+          "name": "igdb_game_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rss_feed_items_feed_id_rss_feeds_id_fk": {
+          "name": "rss_feed_items_feed_id_rss_feeds_id_fk",
+          "tableFrom": "rss_feed_items",
+          "tableTo": "rss_feeds",
+          "columnsFrom": ["feed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_feeds": {
+      "name": "rss_feeds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "mapping": {
+          "name": "mapping",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_config": {
+      "name": "system_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auto_search_enabled": {
+          "name": "auto_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_download_enabled": {
+          "name": "auto_download_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_multiple_downloads": {
+          "name": "notify_multiple_downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_updates": {
+          "name": "notify_updates",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "search_interval_hours": {
+          "name": "search_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 6
+        },
+        "igdb_rate_limit_per_second": {
+          "name": "igdb_rate_limit_per_second",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "download_rules": {
+          "name": "download_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_auto_search": {
+          "name": "last_auto_search",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "xrel_scene_releases": {
+          "name": "xrel_scene_releases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "xrel_p2p_releases": {
+          "name": "xrel_p2p_releases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_search_unreleased": {
+          "name": "auto_search_unreleased",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "steam_sync_failures": {
+          "name": "steam_sync_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "steam_id_64": {
+          "name": "steam_id_64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "xrel_notified_releases": {
+      "name": "xrel_notified_releases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "xrel_release_id": {
+          "name": "xrel_release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "xrel_notified_releases_game_id_games_id_fk": {
+          "name": "xrel_notified_releases_game_id_games_id_fk",
+          "tableFrom": "xrel_notified_releases",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1774639971136,
       "tag": "0007_broad_hannibal_king",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1774730644852,
+      "tag": "0008_ambiguous_tomorrow_man",
+      "breakpoints": true
     }
   ]
 }

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -93,6 +93,12 @@ vi.mock("../storage.js", () => ({
     removeRssFeed: vi.fn(),
     getAllRssFeedItems: vi.fn().mockResolvedValue([]),
     updateUserSteamId: vi.fn(),
+    getGame: vi.fn(),
+    addReleaseBlacklist: vi.fn(),
+    getReleaseBlacklist: vi.fn().mockResolvedValue([]),
+    getAllReleaseBlacklists: vi.fn().mockResolvedValue([]),
+    removeReleaseBlacklist: vi.fn(),
+    getReleaseBlacklistSet: vi.fn().mockResolvedValue(new Set()),
   },
 }));
 
@@ -213,6 +219,8 @@ vi.mock("../steam-routes.js", () => ({
 
 vi.mock("../search.js", () => ({
   searchAllIndexers: vi.fn().mockResolvedValue({ items: [], total: 0, errors: [] }),
+  filterBlacklistedReleases: (items: { title: string }[], blacklisted: Set<string>) =>
+    blacklisted.size > 0 ? items.filter((item) => !blacklisted.has(item.title)) : items,
 }));
 
 vi.mock("../config.js", () => ({
@@ -1563,6 +1571,130 @@ describe("API Routes - Extended Coverage", () => {
         .post("/api/stats/discord-share")
         .send({ image: validImageDataUrl });
       expect(response.status).toBe(500);
+    });
+  });
+  // ─── Release Blacklist routes ───
+  describe("Release Blacklist routes", () => {
+    const gameId = "123e4567-e89b-12d3-a456-426614174000";
+    const mockGame = { id: gameId, userId: "user-1", title: "Test Game" };
+    const blacklistEntry = {
+      id: "bl-1",
+      gameId,
+      releaseTitle: "Test Game-SKIDROW",
+      createdAt: new Date().toISOString(),
+    };
+
+    describe("POST /api/games/:gameId/blacklist", () => {
+      it("should add a release to the blacklist", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+        vi.mocked(storage.addReleaseBlacklist).mockResolvedValue(blacklistEntry as any);
+
+        const response = await request(app)
+          .post(`/api/games/${gameId}/blacklist`)
+          .send({ releaseTitle: "Test Game-SKIDROW" });
+
+        expect(response.status).toBe(201);
+        expect(response.body).toMatchObject({ releaseTitle: "Test Game-SKIDROW" });
+      });
+
+      it("should return 400 for missing releaseTitle", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+
+        const response = await request(app).post(`/api/games/${gameId}/blacklist`).send({});
+
+        expect(response.status).toBe(400);
+      });
+
+      it("should return 403 when game belongs to another user", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue({ ...mockGame, userId: "other-user" } as any);
+
+        const response = await request(app)
+          .post(`/api/games/${gameId}/blacklist`)
+          .send({ releaseTitle: "Test Game-SKIDROW" });
+
+        expect(response.status).toBe(403);
+      });
+
+      it("should return 404 when game not found", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(undefined as any);
+
+        const response = await request(app)
+          .post(`/api/games/${gameId}/blacklist`)
+          .send({ releaseTitle: "Test Game-SKIDROW" });
+
+        expect(response.status).toBe(404);
+      });
+    });
+
+    describe("GET /api/games/:gameId/blacklist", () => {
+      it("should return blacklist entries for a game", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+        vi.mocked(storage.getReleaseBlacklist).mockResolvedValue([blacklistEntry] as any);
+
+        const response = await request(app).get(`/api/games/${gameId}/blacklist`);
+
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveLength(1);
+        expect(response.body[0].releaseTitle).toBe("Test Game-SKIDROW");
+      });
+
+      it("should return 403 when game belongs to another user", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue({ ...mockGame, userId: "other-user" } as any);
+
+        const response = await request(app).get(`/api/games/${gameId}/blacklist`);
+
+        expect(response.status).toBe(403);
+      });
+    });
+
+    describe("DELETE /api/games/:gameId/blacklist/:id", () => {
+      it("should remove a blacklist entry", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+        vi.mocked(storage.removeReleaseBlacklist).mockResolvedValue(true);
+
+        const response = await request(app).delete(`/api/games/${gameId}/blacklist/bl-1`);
+
+        expect(response.status).toBe(204);
+      });
+
+      it("should return 404 when entry not found", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+        vi.mocked(storage.removeReleaseBlacklist).mockResolvedValue(false);
+
+        const response = await request(app).delete(`/api/games/${gameId}/blacklist/nonexistent`);
+
+        expect(response.status).toBe(404);
+      });
+
+      it("should return 403 when game belongs to another user", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue({ ...mockGame, userId: "other-user" } as any);
+
+        const response = await request(app).delete(`/api/games/${gameId}/blacklist/bl-1`);
+
+        expect(response.status).toBe(403);
+      });
+    });
+
+    describe("GET /api/blacklist", () => {
+      it("should return all blacklist entries for the user", async () => {
+        const entries = [{ ...blacklistEntry, gameTitle: "Test Game" }];
+        vi.mocked(storage.getAllReleaseBlacklists).mockResolvedValue(entries as any);
+
+        const response = await request(app).get("/api/blacklist");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveLength(1);
+        expect(response.body[0].gameTitle).toBe("Test Game");
+      });
+
+      it("should return empty array when no entries", async () => {
+        vi.mocked(storage.getAllReleaseBlacklists).mockResolvedValue([]);
+
+        const response = await request(app).get("/api/blacklist");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual([]);
+      });
     });
   });
 });

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -3,6 +3,7 @@ import express, { type Request, type Response, type NextFunction } from "express
 import request from "supertest";
 import { registerRoutes, parseCategories } from "../routes.js";
 import { storage } from "../storage.js";
+import { searchAllIndexers } from "../search.js";
 import { igdbClient, type IGDBGame } from "../igdb.js";
 import { type Game, type User, type Indexer, type Downloader } from "../../shared/schema.js";
 import { DownloaderManager } from "../downloaders.js";
@@ -1403,6 +1404,227 @@ describe("API Routes - Extended Coverage", () => {
   });
 
 
+    describe("POST /api/games/:gameId/blacklist", () => {
+      it("should add a release to the blacklist", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+        vi.mocked(storage.addReleaseBlacklist).mockResolvedValue(blacklistEntry as any);
+
+        const response = await request(app)
+          .post(`/api/games/${gameId}/blacklist`)
+          .send({ releaseTitle: "Test Game-SKIDROW" });
+
+        expect(response.status).toBe(201);
+        expect(response.body).toMatchObject({ releaseTitle: "Test Game-SKIDROW" });
+      });
+
+      it("should return 400 for missing releaseTitle", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+
+        const response = await request(app).post(`/api/games/${gameId}/blacklist`).send({});
+
+        expect(response.status).toBe(400);
+      });
+
+      it("should return 403 when game belongs to another user", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue({ ...mockGame, userId: "other-user" } as any);
+
+        const response = await request(app)
+          .post(`/api/games/${gameId}/blacklist`)
+          .send({ releaseTitle: "Test Game-SKIDROW" });
+
+        expect(response.status).toBe(403);
+      });
+
+      it("should return 404 when game not found", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(undefined as any);
+
+        const response = await request(app)
+          .post(`/api/games/${gameId}/blacklist`)
+          .send({ releaseTitle: "Test Game-SKIDROW" });
+
+        expect(response.status).toBe(404);
+      });
+
+      it("should return 400 when releaseTitle exceeds 500 characters", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+        const response = await request(app)
+          .post(`/api/games/${gameId}/blacklist`)
+          .send({ releaseTitle: "a".repeat(501) });
+        expect(response.status).toBe(400);
+      });
+
+      it("should return 500 on storage error", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+        vi.mocked(storage.addReleaseBlacklist).mockRejectedValue(new Error("DB error"));
+        const response = await request(app)
+          .post(`/api/games/${gameId}/blacklist`)
+          .send({ releaseTitle: "Test Game-SKIDROW" });
+        expect(response.status).toBe(500);
+      });
+    });
+
+    describe("GET /api/games/:gameId/blacklist", () => {
+      it("should return blacklist entries for a game", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+        vi.mocked(storage.getReleaseBlacklist).mockResolvedValue([blacklistEntry] as any);
+
+        const response = await request(app).get(`/api/games/${gameId}/blacklist`);
+
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveLength(1);
+        expect(response.body[0].releaseTitle).toBe("Test Game-SKIDROW");
+      });
+
+      it("should return 403 when game belongs to another user", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue({ ...mockGame, userId: "other-user" } as any);
+
+        const response = await request(app).get(`/api/games/${gameId}/blacklist`);
+
+        expect(response.status).toBe(403);
+      });
+
+      it("should return 404 when game not found", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(undefined as any);
+        const response = await request(app).get(`/api/games/${gameId}/blacklist`);
+        expect(response.status).toBe(404);
+      });
+
+      it("should return 500 on storage error", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+        vi.mocked(storage.getReleaseBlacklist).mockRejectedValue(new Error("DB error"));
+        const response = await request(app).get(`/api/games/${gameId}/blacklist`);
+        expect(response.status).toBe(500);
+      });
+    });
+
+    describe("DELETE /api/games/:gameId/blacklist/:id", () => {
+      it("should remove a blacklist entry", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+        vi.mocked(storage.removeReleaseBlacklist).mockResolvedValue(true);
+
+        const response = await request(app).delete(`/api/games/${gameId}/blacklist/bl-1`);
+
+        expect(response.status).toBe(204);
+      });
+
+      it("should return 404 when entry not found", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+        vi.mocked(storage.removeReleaseBlacklist).mockResolvedValue(false);
+
+        const response = await request(app).delete(`/api/games/${gameId}/blacklist/nonexistent`);
+
+        expect(response.status).toBe(404);
+      });
+
+      it("should return 403 when game belongs to another user", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue({ ...mockGame, userId: "other-user" } as any);
+
+        const response = await request(app).delete(`/api/games/${gameId}/blacklist/bl-1`);
+
+        expect(response.status).toBe(403);
+      });
+
+      it("should return 404 when game not found", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(undefined as any);
+        const response = await request(app).delete(`/api/games/${gameId}/blacklist/bl-1`);
+        expect(response.status).toBe(404);
+      });
+
+      it("should return 500 on storage error", async () => {
+        vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+        vi.mocked(storage.removeReleaseBlacklist).mockRejectedValue(new Error("DB error"));
+        const response = await request(app).delete(`/api/games/${gameId}/blacklist/bl-1`);
+        expect(response.status).toBe(500);
+      });
+    });
+
+    describe("GET /api/blacklist", () => {
+      it("should return all blacklist entries for the user", async () => {
+        const entries = [{ ...blacklistEntry, gameTitle: "Test Game" }];
+        vi.mocked(storage.getAllReleaseBlacklists).mockResolvedValue(entries as any);
+
+        const response = await request(app).get("/api/blacklist");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveLength(1);
+        expect(response.body[0].gameTitle).toBe("Test Game");
+      });
+
+      it("should return empty array when no entries", async () => {
+        vi.mocked(storage.getAllReleaseBlacklists).mockResolvedValue([]);
+
+        const response = await request(app).get("/api/blacklist");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual([]);
+      });
+
+      it("should return 500 on storage error", async () => {
+        vi.mocked(storage.getAllReleaseBlacklists).mockRejectedValue(new Error("DB error"));
+        const response = await request(app).get("/api/blacklist");
+        expect(response.status).toBe(500);
+      });
+    });
+  });
+
+  // ─── Search with blacklist filtering ───
+  describe("GET /api/search - blacklist filtering", () => {
+    it("should filter blacklisted releases when gameId belongs to user", async () => {
+      const mockGame = { id: "game-1", userId: "user-1", title: "Test Game" };
+      vi.mocked(storage.getGame).mockResolvedValue(mockGame as any);
+      vi.mocked(storage.getReleaseBlacklistSet).mockResolvedValue(new Set(["Test Game-SKIDROW"]));
+      vi.mocked(searchAllIndexers).mockResolvedValue({
+        items: [
+          {
+            title: "Test Game-SKIDROW",
+            link: "http://example.com/1",
+            downloadType: "torrent" as const,
+          },
+          {
+            title: "Test Game-CODEX",
+            link: "http://example.com/2",
+            downloadType: "torrent" as const,
+          },
+        ],
+        total: 2,
+        errors: [],
+      });
+
+      const response = await request(app).get("/api/search?query=Test+Game&gameId=game-1");
+
+      expect(response.status).toBe(200);
+      expect(response.body.items).toHaveLength(1);
+      expect(response.body.items[0].title).toBe("Test Game-CODEX");
+      expect(storage.getReleaseBlacklistSet).toHaveBeenCalledWith("game-1");
+    });
+
+    it("should not filter when game belongs to another user", async () => {
+      vi.mocked(storage.getGame).mockResolvedValue({
+        id: "game-1",
+        userId: "other-user",
+        title: "Test Game",
+      } as any);
+      vi.mocked(searchAllIndexers).mockResolvedValue({
+        items: [
+          {
+            title: "Test Game-SKIDROW",
+            link: "http://example.com/1",
+            downloadType: "torrent" as const,
+          },
+        ],
+        total: 1,
+        errors: [],
+      });
+
+      const response = await request(app).get("/api/search?query=Test+Game&gameId=game-1");
+
+      expect(response.status).toBe(200);
+      expect(response.body.items).toHaveLength(1);
+      expect(storage.getReleaseBlacklistSet).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Discord Settings ───
   describe("Discord settings", () => {
     describe("GET /api/settings/discord", () => {
       it("should return configured: true when webhook URL is set", async () => {

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -1403,6 +1403,16 @@ describe("API Routes - Extended Coverage", () => {
     });
   });
 
+  // ─── Release Blacklist routes ───
+  describe("Release Blacklist routes", () => {
+    const gameId = "123e4567-e89b-12d3-a456-426614174000";
+    const mockGame = { id: gameId, userId: "user-1", title: "Test Game" };
+    const blacklistEntry = {
+      id: "bl-1",
+      gameId,
+      releaseTitle: "Test Game-SKIDROW",
+      createdAt: new Date().toISOString(),
+    };
 
     describe("POST /api/games/:gameId/blacklist", () => {
       it("should add a release to the blacklist", async () => {

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -1402,7 +1402,7 @@ describe("API Routes - Extended Coverage", () => {
     });
   });
 
-  // ─── Discord Settings ───
+
   describe("Discord settings", () => {
     describe("GET /api/settings/discord", () => {
       it("should return configured: true when webhook URL is set", async () => {

--- a/server/__tests__/cron_autosearch.test.ts
+++ b/server/__tests__/cron_autosearch.test.ts
@@ -50,6 +50,8 @@ vi.mock("../storage.js", () => ({
 const mockSearchAllIndexers = vi.fn();
 vi.mock("../search.js", () => ({
   searchAllIndexers: mockSearchAllIndexers,
+  filterBlacklistedReleases: (items: { title: string }[], blacklisted: Set<string>) =>
+    blacklisted.size > 0 ? items.filter((item) => !blacklisted.has(item.title)) : items,
 }));
 
 // Mock socket

--- a/server/__tests__/cron_autosearch.test.ts
+++ b/server/__tests__/cron_autosearch.test.ts
@@ -30,6 +30,7 @@ const mockUpdateGameSearchResultsAvailable = vi.fn();
 const mockUpdateGameStatus = vi.fn();
 const mockAddGameDownload = vi.fn();
 const mockGetEnabledDownloaders = vi.fn().mockResolvedValue([]);
+const mockGetReleaseBlacklistSet = vi.fn();
 
 vi.mock("../storage.js", () => ({
   storage: {
@@ -42,7 +43,7 @@ vi.mock("../storage.js", () => ({
     updateGameStatus: mockUpdateGameStatus,
     addGameDownload: mockAddGameDownload,
     getEnabledDownloaders: mockGetEnabledDownloaders,
-    getReleaseBlacklistSet: vi.fn().mockResolvedValue(new Set()),
+    getReleaseBlacklistSet: mockGetReleaseBlacklistSet,
   },
 }));
 
@@ -148,6 +149,7 @@ describe("Cron - checkAutoSearch", () => {
     mockSearchAllIndexers.mockResolvedValue({ items: [], errors: [], total: 0 });
     mockGetEnabledDownloaders.mockResolvedValue([]);
     mockAddNotification.mockResolvedValue({ id: "notif-1" });
+    mockGetReleaseBlacklistSet.mockResolvedValue(new Set());
   });
 
   afterEach(() => {
@@ -653,5 +655,29 @@ describe("Cron - checkAutoSearch", () => {
         })
       );
     });
+  });
+
+  it("should not notify when all matched items are blacklisted", async () => {
+    const game = { ...baseGame, status: "wanted" as const, releaseStatus: "released" as const };
+    mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+    mockSearchAllIndexers.mockResolvedValue({
+      items: [
+        {
+          title: "Test Game-SKIDROW",
+          link: "https://example.com/download",
+          pubDate: FIXED_PUB_DATE,
+          seeders: 50,
+          size: 10_000,
+        },
+      ],
+      errors: [],
+      total: 1,
+    });
+    mockGetReleaseBlacklistSet.mockResolvedValue(new Set(["Test Game-SKIDROW"]));
+
+    await checkAutoSearch();
+
+    expect(mockAddNotification).not.toHaveBeenCalled();
+    expect(mockUpdateGameSearchResultsAvailable).not.toHaveBeenCalled();
   });
 });

--- a/server/__tests__/cron_autosearch.test.ts
+++ b/server/__tests__/cron_autosearch.test.ts
@@ -42,6 +42,7 @@ vi.mock("../storage.js", () => ({
     updateGameStatus: mockUpdateGameStatus,
     addGameDownload: mockAddGameDownload,
     getEnabledDownloaders: mockGetEnabledDownloaders,
+    getReleaseBlacklistSet: vi.fn().mockResolvedValue(new Set()),
   },
 }));
 

--- a/server/__tests__/search.test.ts
+++ b/server/__tests__/search.test.ts
@@ -25,7 +25,7 @@ vi.mock("../newznab.js", () => ({
   },
 }));
 
-const { searchAllIndexers } = await import("../search.js");
+const { searchAllIndexers, filterBlacklistedReleases } = await import("../search.js");
 const { storage } = await import("../storage.js");
 const { torznabClient } = await import("../torznab.js");
 const { newznabClient } = await import("../newznab.js");
@@ -475,5 +475,43 @@ describe("Search Module - searchAllIndexers", () => {
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0].group).toBe("RELGROUP");
+  });
+});
+
+describe("filterBlacklistedReleases", () => {
+  const makeItem = (title: string) => ({
+    title,
+    link: "http://example.com",
+    downloadType: "torrent" as const,
+  });
+
+  it("returns all items when blacklist is empty", () => {
+    const items = [makeItem("Game-GROUP"), makeItem("Game-OTHER")];
+    expect(filterBlacklistedReleases(items, new Set())).toEqual(items);
+  });
+
+  it("filters out blacklisted titles", () => {
+    const items = [makeItem("Game-GROUP"), makeItem("Game-OTHER")];
+    const result = filterBlacklistedReleases(items, new Set(["Game-GROUP"]));
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Game-OTHER");
+  });
+
+  it("returns empty array when all items are blacklisted", () => {
+    const items = [makeItem("Game-A"), makeItem("Game-B")];
+    const result = filterBlacklistedReleases(items, new Set(["Game-A", "Game-B"]));
+    expect(result).toHaveLength(0);
+  });
+
+  it("is case-sensitive (does not filter non-matching case)", () => {
+    const items = [makeItem("Game-GROUP")];
+    const result = filterBlacklistedReleases(items, new Set(["game-group"]));
+    expect(result).toHaveLength(1);
+  });
+
+  it("returns original array reference when blacklist is empty (fast path)", () => {
+    const items = [makeItem("Game-GROUP")];
+    const result = filterBlacklistedReleases(items, new Set());
+    expect(result).toBe(items);
   });
 });

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -13,6 +13,7 @@ import type {
   InsertIndexer,
   InsertDownloader,
   InsertUserSettings,
+  InsertReleaseBlacklist,
 } from "../../shared/schema";
 import type { MemStorage as MemStorageType } from "../storage.js";
 
@@ -303,6 +304,81 @@ describe("MemStorage", () => {
 
       expect(settings.autoSearchUnreleased).toBe(false); // Default is false
       expect(settings.autoSearchEnabled).toBe(true); // Default is true
+    });
+  });
+
+  describe("Release Blacklist Management", () => {
+    const userId = "bl-user-1";
+    let gameId: string;
+
+    beforeEach(async () => {
+      const game = await storage.addGame({
+        title: "Blacklist Game",
+        igdbId: 9001,
+        status: "wanted",
+        hidden: null,
+        userId,
+      } as InsertGame);
+      gameId = game.id;
+    });
+
+    it("should add a release to the blacklist", async () => {
+      const entry = await storage.addReleaseBlacklist({ gameId, releaseTitle: "Game-SKIDROW" });
+      expect(entry.gameId).toBe(gameId);
+      expect(entry.releaseTitle).toBe("Game-SKIDROW");
+      expect(entry.id).toBeDefined();
+    });
+
+    it("should return existing entry on duplicate add", async () => {
+      const first = await storage.addReleaseBlacklist({ gameId, releaseTitle: "Game-SKIDROW" });
+      const second = await storage.addReleaseBlacklist({ gameId, releaseTitle: "Game-SKIDROW" });
+      expect(second.id).toBe(first.id);
+    });
+
+    it("should list blacklist entries for a game", async () => {
+      await storage.addReleaseBlacklist({ gameId, releaseTitle: "Game-SKIDROW" });
+      await storage.addReleaseBlacklist({ gameId, releaseTitle: "Game-CODEX" });
+      const entries = await storage.getReleaseBlacklist(gameId);
+      expect(entries).toHaveLength(2);
+      expect(entries.map((e) => e.releaseTitle)).toContain("Game-SKIDROW");
+      expect(entries.map((e) => e.releaseTitle)).toContain("Game-CODEX");
+    });
+
+    it("should return all blacklist entries with game titles for a user", async () => {
+      await storage.addReleaseBlacklist({ gameId, releaseTitle: "Game-SKIDROW" });
+      const all = await storage.getAllReleaseBlacklists(userId);
+      expect(all).toHaveLength(1);
+      expect(all[0].gameTitle).toBe("Blacklist Game");
+      expect(all[0].releaseTitle).toBe("Game-SKIDROW");
+    });
+
+    it("should not return entries from other users' games", async () => {
+      await storage.addReleaseBlacklist({ gameId, releaseTitle: "Game-SKIDROW" });
+      const others = await storage.getAllReleaseBlacklists("other-user");
+      expect(others).toHaveLength(0);
+    });
+
+    it("should remove a blacklist entry and return true", async () => {
+      const entry = await storage.addReleaseBlacklist({ gameId, releaseTitle: "Game-SKIDROW" });
+      const removed = await storage.removeReleaseBlacklist(entry.id, gameId);
+      expect(removed).toBe(true);
+      const remaining = await storage.getReleaseBlacklist(gameId);
+      expect(remaining).toHaveLength(0);
+    });
+
+    it("should return false when removing a non-existent entry", async () => {
+      const result = await storage.removeReleaseBlacklist("nonexistent-id", gameId);
+      expect(result).toBe(false);
+    });
+
+    it("should return a Set of release titles for a game", async () => {
+      await storage.addReleaseBlacklist({ gameId, releaseTitle: "Game-SKIDROW" });
+      await storage.addReleaseBlacklist({ gameId, releaseTitle: "Game-CODEX" });
+      const set = await storage.getReleaseBlacklistSet(gameId);
+      expect(set).toBeInstanceOf(Set);
+      expect(set.has("Game-SKIDROW")).toBe(true);
+      expect(set.has("Game-CODEX")).toBe(true);
+      expect(set.size).toBe(2);
     });
   });
 });

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -380,5 +380,45 @@ describe("MemStorage", () => {
       expect(set.has("Game-CODEX")).toBe(true);
       expect(set.size).toBe(2);
     });
+
+    it("should return an empty Set for a game with no blacklist entries", async () => {
+      const set = await storage.getReleaseBlacklistSet(gameId);
+      expect(set).toBeInstanceOf(Set);
+      expect(set.size).toBe(0);
+    });
+
+    it("should store and return indexerName when provided", async () => {
+      const entry = await storage.addReleaseBlacklist({
+        gameId,
+        releaseTitle: "Game-SKIDROW",
+        indexerName: "1337x",
+      });
+      expect(entry.indexerName).toBe("1337x");
+    });
+
+    it("should sort getAllReleaseBlacklists by gameTitle then newest first", async () => {
+      const gameB = await storage.addGame({
+        title: "Zebra Game",
+        igdbId: 9002,
+        status: "wanted",
+        hidden: null,
+        userId,
+      } as InsertGame);
+
+      await storage.addReleaseBlacklist({ gameId, releaseTitle: "Blacklist-1" });
+      await storage.addReleaseBlacklist({ gameId, releaseTitle: "Blacklist-2" });
+      await storage.addReleaseBlacklist({ gameId: gameB.id, releaseTitle: "Zebra-1" });
+
+      const all = await storage.getAllReleaseBlacklists(userId);
+      expect(all).toHaveLength(3);
+      // "Blacklist Game" entries precede "Zebra Game" (alphabetical)
+      expect(all[0].gameTitle).toBe("Blacklist Game");
+      expect(all[1].gameTitle).toBe("Blacklist Game");
+      expect(all[2].gameTitle).toBe("Zebra Game");
+      // Both "Blacklist Game" entries are present (order within same title is stable by creation)
+      const blTitles = [all[0].releaseTitle, all[1].releaseTitle];
+      expect(blTitles).toContain("Blacklist-1");
+      expect(blTitles).toContain("Blacklist-2");
+    });
   });
 });

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -3,7 +3,7 @@ import { igdbClient } from "./igdb.js";
 import { igdbLogger } from "./logger.js";
 import { notifyUser } from "./socket.js";
 import { DownloaderManager } from "./downloaders.js";
-import { searchAllIndexers } from "./search.js";
+import { searchAllIndexers, filterBlacklistedReleases } from "./search.js";
 import { xrelClient, DEFAULT_XREL_BASE } from "./xrel.js";
 import { steamService } from "./steam.js";
 import { downloadRulesSchema, type Game, type InsertNotification } from "../shared/schema.js";
@@ -150,10 +150,7 @@ async function searchAndCategorizeItemsForGame(
 
   // Filter out blacklisted releases
   const blacklisted = await storage.getReleaseBlacklistSet(game.id);
-  const nonBlacklisted =
-    blacklisted.size > 0
-      ? matchedItems.filter((item) => !blacklisted.has(item.title))
-      : matchedItems;
+  const nonBlacklisted = filterBlacklistedReleases(matchedItems, blacklisted);
 
   if (nonBlacklisted.length === 0) {
     igdbLogger.debug(

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -103,7 +103,7 @@ function applyPreferredGroupsFilter(
 }
 
 async function searchAndCategorizeItemsForGame(
-  game: Pick<Game, "title">,
+  game: Pick<Game, "id" | "title">,
   downloadRules: string | null
 ): Promise<AutoSearchCategorizedItems | null> {
   const { items, errors } = await searchAllIndexers({
@@ -148,6 +148,21 @@ async function searchAndCategorizeItemsForGame(
     return null;
   }
 
+  // Filter out blacklisted releases
+  const blacklisted = await storage.getReleaseBlacklistSet(game.id);
+  const nonBlacklisted =
+    blacklisted.size > 0
+      ? matchedItems.filter((item) => !blacklisted.has(item.title))
+      : matchedItems;
+
+  if (nonBlacklisted.length === 0) {
+    igdbLogger.debug(
+      { gameTitle: game.title, matchedCount: matchedItems.length },
+      "All matched items were blacklisted"
+    );
+    return null;
+  }
+
   let rules: AutoSearchRules;
   try {
     rules = getAutoSearchRules(downloadRules);
@@ -156,7 +171,7 @@ async function searchAndCategorizeItemsForGame(
     rules = getAutoSearchRules(null);
   }
 
-  return categorizeSearchItems(matchedItems, rules);
+  return categorizeSearchItems(nonBlacklisted, rules);
 }
 
 export function startCronJobs() {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -14,6 +14,7 @@ import {
   updateUserSettingsSchema,
   updatePasswordSchema,
   insertRssFeedSchema,
+  insertReleaseBlacklistSchema,
   type Config,
   type Game,
   type Indexer,
@@ -121,8 +122,18 @@ async function handleAggregatedIndexerSearch(req: Request, res: Response) {
       offset,
     });
 
+    // Filter out blacklisted releases when a gameId context is provided
+    const gameId = req.query.gameId as string | undefined;
+    let filteredItems = items;
+    if (gameId) {
+      const blacklisted = await storage.getReleaseBlacklistSet(gameId);
+      if (blacklisted.size > 0) {
+        filteredItems = items.filter((item) => !blacklisted.has(item.title));
+      }
+    }
+
     res.json({
-      items,
+      items: filteredItems,
       total,
       offset,
       errors: errors.length > 0 ? errors : undefined,
@@ -1077,6 +1088,95 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
     }
   );
+
+  // ── Release Blacklist routes ──
+
+  // Add release to blacklist for a specific game
+  app.post(
+    "/api/games/:gameId/blacklist",
+    authenticateToken,
+    async (req: Request, res: Response) => {
+      try {
+        const { gameId } = req.params;
+        const userId = req.user!.id;
+
+        const game = await storage.getGame(gameId);
+        if (!game) return res.status(404).json({ error: "Game not found" });
+        if (game.userId !== userId) return res.status(403).json({ error: "Forbidden" });
+
+        const parsed = insertReleaseBlacklistSchema.safeParse({ ...req.body, gameId });
+        if (!parsed.success) {
+          return res.status(400).json({ error: "Invalid data", details: parsed.error.issues });
+        }
+        const { releaseTitle } = parsed.data;
+        if (!releaseTitle || releaseTitle.length > 500) {
+          return res.status(400).json({ error: "releaseTitle required (max 500 chars)" });
+        }
+
+        const entry = await storage.addReleaseBlacklist(parsed.data);
+        res.status(201).json(entry);
+      } catch (error) {
+        routesLogger.error({ error }, "error adding to blacklist");
+        res.status(500).json({ error: "Failed to add to blacklist" });
+      }
+    }
+  );
+
+  // List blacklisted releases for a game
+  app.get(
+    "/api/games/:gameId/blacklist",
+    authenticateToken,
+    async (req: Request, res: Response) => {
+      try {
+        const { gameId } = req.params;
+        const userId = req.user!.id;
+
+        const game = await storage.getGame(gameId);
+        if (!game) return res.status(404).json({ error: "Game not found" });
+        if (game.userId !== userId) return res.status(403).json({ error: "Forbidden" });
+
+        const entries = await storage.getReleaseBlacklist(gameId);
+        res.json(entries);
+      } catch (error) {
+        routesLogger.error({ error }, "error listing blacklist");
+        res.status(500).json({ error: "Failed to list blacklist" });
+      }
+    }
+  );
+
+  // Remove a blacklist entry
+  app.delete(
+    "/api/games/:gameId/blacklist/:id",
+    authenticateToken,
+    async (req: Request, res: Response) => {
+      try {
+        const { gameId, id } = req.params;
+        const userId = req.user!.id;
+
+        const game = await storage.getGame(gameId);
+        if (!game) return res.status(404).json({ error: "Game not found" });
+        if (game.userId !== userId) return res.status(403).json({ error: "Forbidden" });
+
+        await storage.removeReleaseBlacklist(id);
+        res.status(204).send();
+      } catch (error) {
+        routesLogger.error({ error }, "error removing from blacklist");
+        res.status(500).json({ error: "Failed to remove from blacklist" });
+      }
+    }
+  );
+
+  // List all blacklisted releases across all user's games (for Settings page)
+  app.get("/api/blacklist", authenticateToken, async (req: Request, res: Response) => {
+    try {
+      const userId = req.user!.id;
+      const entries = await storage.getAllReleaseBlacklists(userId);
+      res.json(entries);
+    } catch (error) {
+      routesLogger.error({ error }, "error listing all blacklists");
+      res.status(500).json({ error: "Failed to list blacklists" });
+    }
+  });
 
   // IGDB discovery routes
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -61,7 +61,7 @@ const upload = multer({
     fileSize: 5 * 1024 * 1024, // 5MB limit
   },
 });
-import { searchAllIndexers } from "./search.js";
+import { searchAllIndexers, filterBlacklistedReleases } from "./search.js";
 import { xrelClient, DEFAULT_XREL_BASE, ALLOWED_XREL_DOMAINS } from "./xrel.js";
 import { normalizeTitle, cleanReleaseName } from "../shared/title-utils.js";
 import archiver from "archiver";
@@ -129,9 +129,7 @@ async function handleAggregatedIndexerSearch(req: Request, res: Response) {
       const game = await storage.getGame(gameId);
       if (game && game.userId === req.user.id) {
         const blacklisted = await storage.getReleaseBlacklistSet(gameId);
-        if (blacklisted.size > 0) {
-          filteredItems = items.filter((item) => !blacklisted.has(item.title));
-        }
+        filteredItems = filterBlacklistedReleases(items, blacklisted);
       }
     }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -125,10 +125,13 @@ async function handleAggregatedIndexerSearch(req: Request, res: Response) {
     // Filter out blacklisted releases when a gameId context is provided
     const gameId = req.query.gameId as string | undefined;
     let filteredItems = items;
-    if (gameId) {
-      const blacklisted = await storage.getReleaseBlacklistSet(gameId);
-      if (blacklisted.size > 0) {
-        filteredItems = items.filter((item) => !blacklisted.has(item.title));
+    if (gameId && req.user) {
+      const game = await storage.getGame(gameId);
+      if (game && game.userId === req.user.id) {
+        const blacklisted = await storage.getReleaseBlacklistSet(gameId);
+        if (blacklisted.size > 0) {
+          filteredItems = items.filter((item) => !blacklisted.has(item.title));
+        }
       }
     }
 
@@ -1157,7 +1160,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         if (!game) return res.status(404).json({ error: "Game not found" });
         if (game.userId !== userId) return res.status(403).json({ error: "Forbidden" });
 
-        await storage.removeReleaseBlacklist(id);
+        const deleted = await storage.removeReleaseBlacklist(id, gameId);
+        if (!deleted) return res.status(404).json({ error: "Blacklist entry not found" });
         res.status(204).send();
       } catch (error) {
         routesLogger.error({ error }, "error removing from blacklist");

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1092,6 +1092,24 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // ── Release Blacklist routes ──
 
+  /** Resolves a game by id and verifies ownership; sends 404/403 and returns null on failure. */
+  async function resolveOwnedGame(
+    gameId: string,
+    userId: string,
+    res: Response
+  ): Promise<Awaited<ReturnType<typeof storage.getGame>> | null> {
+    const game = await storage.getGame(gameId);
+    if (!game) {
+      res.status(404).json({ error: "Game not found" });
+      return null;
+    }
+    if (game.userId !== userId) {
+      res.status(403).json({ error: "Forbidden" });
+      return null;
+    }
+    return game;
+  }
+
   // Add release to blacklist for a specific game
   app.post(
     "/api/games/:gameId/blacklist",
@@ -1101,9 +1119,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const { gameId } = req.params;
         const userId = req.user!.id;
 
-        const game = await storage.getGame(gameId);
-        if (!game) return res.status(404).json({ error: "Game not found" });
-        if (game.userId !== userId) return res.status(403).json({ error: "Forbidden" });
+        if (!(await resolveOwnedGame(gameId, userId, res))) return;
 
         const parsed = insertReleaseBlacklistSchema.safeParse({ ...req.body, gameId });
         if (!parsed.success) {
@@ -1132,9 +1148,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const { gameId } = req.params;
         const userId = req.user!.id;
 
-        const game = await storage.getGame(gameId);
-        if (!game) return res.status(404).json({ error: "Game not found" });
-        if (game.userId !== userId) return res.status(403).json({ error: "Forbidden" });
+        if (!(await resolveOwnedGame(gameId, userId, res))) return;
 
         const entries = await storage.getReleaseBlacklist(gameId);
         res.json(entries);
@@ -1154,9 +1168,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const { gameId, id } = req.params;
         const userId = req.user!.id;
 
-        const game = await storage.getGame(gameId);
-        if (!game) return res.status(404).json({ error: "Game not found" });
-        if (game.userId !== userId) return res.status(403).json({ error: "Forbidden" });
+        if (!(await resolveOwnedGame(gameId, userId, res))) return;
 
         const deleted = await storage.removeReleaseBlacklist(id, gameId);
         if (!deleted) return res.status(404).json({ error: "Blacklist entry not found" });

--- a/server/search.ts
+++ b/server/search.ts
@@ -184,3 +184,13 @@ export async function searchAllIndexers(
     errors: combinedErrors,
   };
 }
+
+/**
+ * Filters search items by removing any whose title appears in the blacklist set.
+ */
+export function filterBlacklistedReleases(
+  items: SearchItem[],
+  blacklisted: Set<string>
+): SearchItem[] {
+  return blacklisted.size > 0 ? items.filter((item) => !blacklisted.has(item.title)) : items;
+}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -154,7 +154,7 @@ export interface IStorage {
   addReleaseBlacklist(entry: InsertReleaseBlacklist): Promise<ReleaseBlacklist>;
   getReleaseBlacklist(gameId: string): Promise<ReleaseBlacklist[]>;
   getAllReleaseBlacklists(userId: string): Promise<(ReleaseBlacklist & { gameTitle: string })[]>;
-  removeReleaseBlacklist(id: string): Promise<void>;
+  removeReleaseBlacklist(id: string, gameId: string): Promise<boolean>;
   getReleaseBlacklistSet(gameId: string): Promise<Set<string>>;
 }
 
@@ -914,8 +914,11 @@ export class MemStorage implements IStorage {
       });
   }
 
-  async removeReleaseBlacklist(id: string): Promise<void> {
+  async removeReleaseBlacklist(id: string, gameId: string): Promise<boolean> {
+    const entry = this.releaseBlacklists.get(id);
+    if (!entry || entry.gameId !== gameId) return false;
     this.releaseBlacklists.delete(id);
+    return true;
   }
 
   async getReleaseBlacklistSet(gameId: string): Promise<Set<string>> {
@@ -1669,8 +1672,11 @@ export class DatabaseStorage implements IStorage {
       .orderBy(games.title, desc(releaseBlacklist.createdAt));
   }
 
-  async removeReleaseBlacklist(id: string): Promise<void> {
-    await db.delete(releaseBlacklist).where(eq(releaseBlacklist.id, id));
+  async removeReleaseBlacklist(id: string, gameId: string): Promise<boolean> {
+    const result = await db
+      .delete(releaseBlacklist)
+      .where(and(eq(releaseBlacklist.id, id), eq(releaseBlacklist.gameId, gameId)));
+    return result.changes > 0;
   }
 
   async getReleaseBlacklistSet(gameId: string): Promise<Set<string>> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -22,6 +22,8 @@ import {
   type InsertRssFeed,
   type RssFeedItem,
   type InsertRssFeedItem,
+  type ReleaseBlacklist,
+  type InsertReleaseBlacklist,
   users,
   games,
   indexers,
@@ -33,6 +35,7 @@ import {
   xrelNotifiedReleases,
   rssFeeds,
   rssFeedItems,
+  releaseBlacklist,
 } from "../shared/schema.js";
 import { randomUUID } from "crypto";
 import { db } from "./db.js";
@@ -146,6 +149,13 @@ export interface IStorage {
   hasXrelNotifiedRelease(gameId: string, xrelReleaseId: string): Promise<boolean>;
   getGameIdsWithXrelReleases(): Promise<string[]>;
   getWantedGamesGroupedByUser(): Promise<Map<string, Game[]>>;
+
+  // Release blacklist methods
+  addReleaseBlacklist(entry: InsertReleaseBlacklist): Promise<ReleaseBlacklist>;
+  getReleaseBlacklist(gameId: string): Promise<ReleaseBlacklist[]>;
+  getAllReleaseBlacklists(userId: string): Promise<(ReleaseBlacklist & { gameTitle: string })[]>;
+  removeReleaseBlacklist(id: string): Promise<void>;
+  getReleaseBlacklistSet(gameId: string): Promise<Set<string>>;
 }
 
 export class MemStorage implements IStorage {
@@ -160,6 +170,7 @@ export class MemStorage implements IStorage {
   private xrelNotified: Map<string, XrelNotifiedRelease>;
   private rssFeeds: Map<string, RssFeed>;
   private rssFeedItems: Map<string, RssFeedItem>;
+  private releaseBlacklists: Map<string, ReleaseBlacklist>;
 
   constructor() {
     this.users = new Map();
@@ -173,6 +184,7 @@ export class MemStorage implements IStorage {
     this.xrelNotified = new Map();
     this.rssFeeds = new Map();
     this.rssFeedItems = new Map();
+    this.releaseBlacklists = new Map();
   }
 
   // System Config methods
@@ -861,6 +873,56 @@ export class MemStorage implements IStorage {
     const ids = new Set<string>();
     Array.from(this.xrelNotified.values()).forEach((r) => ids.add(r.gameId));
     return Array.from(ids);
+  }
+
+  async addReleaseBlacklist(entry: InsertReleaseBlacklist): Promise<ReleaseBlacklist> {
+    const existing = Array.from(this.releaseBlacklists.values()).find(
+      (r) => r.gameId === entry.gameId && r.releaseTitle === entry.releaseTitle
+    );
+    if (existing) return existing;
+    const id = randomUUID();
+    const record: ReleaseBlacklist = {
+      id,
+      gameId: entry.gameId,
+      releaseTitle: entry.releaseTitle,
+      indexerName: entry.indexerName ?? null,
+      createdAt: new Date(),
+    };
+    this.releaseBlacklists.set(id, record);
+    return record;
+  }
+
+  async getReleaseBlacklist(gameId: string): Promise<ReleaseBlacklist[]> {
+    return Array.from(this.releaseBlacklists.values())
+      .filter((r) => r.gameId === gameId)
+      .sort((a, b) => (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0));
+  }
+
+  async getAllReleaseBlacklists(
+    userId: string
+  ): Promise<(ReleaseBlacklist & { gameTitle: string })[]> {
+    const userGames = Array.from(this.games.values()).filter((g) => g.userId === userId);
+    const gameMap = new Map(userGames.map((g) => [g.id, g.title]));
+    return Array.from(this.releaseBlacklists.values())
+      .filter((r) => gameMap.has(r.gameId))
+      .map((r) => ({ ...r, gameTitle: gameMap.get(r.gameId)! }))
+      .sort((a, b) => {
+        const titleCmp = a.gameTitle.localeCompare(b.gameTitle);
+        return titleCmp !== 0
+          ? titleCmp
+          : (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0);
+      });
+  }
+
+  async removeReleaseBlacklist(id: string): Promise<void> {
+    this.releaseBlacklists.delete(id);
+  }
+
+  async getReleaseBlacklistSet(gameId: string): Promise<Set<string>> {
+    const titles = Array.from(this.releaseBlacklists.values())
+      .filter((r) => r.gameId === gameId)
+      .map((r) => r.releaseTitle);
+    return new Set(titles);
   }
 }
 
@@ -1551,6 +1613,72 @@ export class DatabaseStorage implements IStorage {
       .selectDistinct({ gameId: xrelNotifiedReleases.gameId })
       .from(xrelNotifiedReleases);
     return rows.map((r) => r.gameId);
+  }
+
+  async addReleaseBlacklist(entry: InsertReleaseBlacklist): Promise<ReleaseBlacklist> {
+    const id = randomUUID();
+    const [row] = await db
+      .insert(releaseBlacklist)
+      .values({
+        id,
+        gameId: entry.gameId,
+        releaseTitle: entry.releaseTitle,
+        indexerName: entry.indexerName ?? null,
+        createdAt: new Date(),
+      })
+      .onConflictDoNothing()
+      .returning();
+    if (!row) {
+      const [existing] = await db
+        .select()
+        .from(releaseBlacklist)
+        .where(
+          and(
+            eq(releaseBlacklist.gameId, entry.gameId),
+            eq(releaseBlacklist.releaseTitle, entry.releaseTitle)
+          )
+        );
+      return existing;
+    }
+    return row;
+  }
+
+  async getReleaseBlacklist(gameId: string): Promise<ReleaseBlacklist[]> {
+    return db
+      .select()
+      .from(releaseBlacklist)
+      .where(eq(releaseBlacklist.gameId, gameId))
+      .orderBy(desc(releaseBlacklist.createdAt));
+  }
+
+  async getAllReleaseBlacklists(
+    userId: string
+  ): Promise<(ReleaseBlacklist & { gameTitle: string })[]> {
+    return db
+      .select({
+        id: releaseBlacklist.id,
+        gameId: releaseBlacklist.gameId,
+        releaseTitle: releaseBlacklist.releaseTitle,
+        indexerName: releaseBlacklist.indexerName,
+        createdAt: releaseBlacklist.createdAt,
+        gameTitle: games.title,
+      })
+      .from(releaseBlacklist)
+      .innerJoin(games, eq(releaseBlacklist.gameId, games.id))
+      .where(eq(games.userId, userId))
+      .orderBy(games.title, desc(releaseBlacklist.createdAt));
+  }
+
+  async removeReleaseBlacklist(id: string): Promise<void> {
+    await db.delete(releaseBlacklist).where(eq(releaseBlacklist.id, id));
+  }
+
+  async getReleaseBlacklistSet(gameId: string): Promise<Set<string>> {
+    const rows = await db
+      .select({ releaseTitle: releaseBlacklist.releaseTitle })
+      .from(releaseBlacklist)
+      .where(eq(releaseBlacklist.gameId, gameId));
+    return new Set(rows.map((r) => r.releaseTitle));
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { sqliteTable, text, integer, real } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, uniqueIndex } from "drizzle-orm/sqlite-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -159,6 +159,23 @@ export const xrelNotifiedReleases = sqliteTable("xrel_notified_releases", {
   ),
 });
 
+// Track releases blacklisted by users to hide them from per-game search results
+export const releaseBlacklist = sqliteTable(
+  "release_blacklist",
+  {
+    id: text("id").primaryKey(),
+    gameId: text("game_id")
+      .notNull()
+      .references(() => games.id, { onDelete: "cascade" }),
+    releaseTitle: text("release_title").notNull(),
+    indexerName: text("indexer_name"),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).default(
+      sql`(strftime('%s', 'now') * 1000)`
+    ),
+  },
+  (t) => [uniqueIndex("release_blacklist_game_title_idx").on(t.gameId, t.releaseTitle)]
+);
+
 export const notifications = sqliteTable("notifications", {
   id: text("id").primaryKey(),
   userId: text("user_id").references(() => users.id, { onDelete: "cascade" }),
@@ -260,6 +277,13 @@ export const insertXrelNotifiedReleaseSchema = createInsertSchema(xrelNotifiedRe
   id: true,
   createdAt: true,
 });
+
+export const insertReleaseBlacklistSchema = createInsertSchema(releaseBlacklist).omit({
+  id: true,
+  createdAt: true,
+});
+export type InsertReleaseBlacklist = (typeof insertReleaseBlacklistSchema)["_output"];
+export type ReleaseBlacklist = typeof releaseBlacklist.$inferSelect;
 
 export const insertUserSettingsSchema = createInsertSchema(userSettings).omit({
   id: true,


### PR DESCRIPTION
This pull request introduces a comprehensive "release blacklist" feature, allowing users to hide specific releases from search results and prevent them from being auto-downloaded. The implementation spans database schema changes, backend API endpoints, server logic, and a new UI in the settings page for managing blacklisted releases.

The most important changes are:

**Backend: Release Blacklist Infrastructure**

- Added a new `release_blacklist` table, unique index, and migration to persist blacklisted releases per game. [[1]](diffhunk://#diff-7bd6450540b291191a6889255135c2896b0b881cdb9c4e2f5ca16e77438ef4feR1-R10) [[2]](diffhunk://#diff-4b1c503c046a7a5e68db62d77604227e208e1b9c26e76106a6a002627e958883R60-R66)
- Extended the storage layer (`IStorage` and implementations) with methods to add, remove, fetch, and check blacklisted releases for games and users. [[1]](diffhunk://#diff-6af4f8e34285120717169f57249241ec070dfd0f878e186658aaa341e568c84fR152-R158) [[2]](diffhunk://#diff-6af4f8e34285120717169f57249241ec070dfd0f878e186658aaa341e568c84fR173) [[3]](diffhunk://#diff-6af4f8e34285120717169f57249241ec070dfd0f878e186658aaa341e568c84fR187)

**API Endpoints**

- Added new API routes for managing the blacklist: add to blacklist, remove from blacklist, list blacklisted releases per game, and list all blacklisted releases for a user.
- Updated the search API to filter out blacklisted releases when a `gameId` is provided.

**Server Logic**

- Updated auto-search and download logic to exclude blacklisted releases from consideration, ensuring they are not auto-downloaded. [[1]](diffhunk://#diff-ba75421762c7e2b9cb1f0fa76c848def77f657ddd7b9306cead260d843a10a72L89-R89) [[2]](diffhunk://#diff-ba75421762c7e2b9cb1f0fa76c848def77f657ddd7b9306cead260d843a10a72R134-R148) [[3]](diffhunk://#diff-ba75421762c7e2b9cb1f0fa76c848def77f657ddd7b9306cead260d843a10a72L142-R157)

**Frontend: Game Download Dialog**

- Added a "Blacklist release" option to the download dropdown menu, which calls the new backend API and updates the UI accordingly. [[1]](diffhunk://#diff-c3061fd23700c28750767d9d851897a6c6801155fe27dd016591ba459a8bcf52R370-R389) [[2]](diffhunk://#diff-c3061fd23700c28750767d9d851897a6c6801155fe27dd016591ba459a8bcf52R1047-R1053) [[3]](diffhunk://#diff-3ff4db8d9925962f39ef45b432bae5f9a0322639dbe5219aab456bf12daadafdR54) [[4]](diffhunk://#diff-c3061fd23700c28750767d9d851897a6c6801155fe27dd016591ba459a8bcf52R58) [[5]](diffhunk://#diff-c3061fd23700c28750767d9d851897a6c6801155fe27dd016591ba459a8bcf52R186-R191)

**Frontend: Settings Page**

- Introduced a new "Blacklist" tab that lists all blacklisted releases grouped by game, with the ability to remove entries. [[1]](diffhunk://#diff-ef86b78ab3a2fcb20b1b2b6d4acb9f78241d5b4c4583ea386e82b788f4aa688aR543) [[2]](diffhunk://#diff-ef86b78ab3a2fcb20b1b2b6d4acb9f78241d5b4c4583ea386e82b788f4aa688aR1397-R1465) [[3]](diffhunk://#diff-ef86b78ab3a2fcb20b1b2b6d4acb9f78241d5b4c4583ea386e82b788f4aa688aR91-R109) [[4]](diffhunk://#diff-ef86b78ab3a2fcb20b1b2b6d4acb9f78241d5b4c4583ea386e82b788f4aa688aR21-R22) [[5]](diffhunk://#diff-ef86b78ab3a2fcb20b1b2b6d4acb9f78241d5b4c4583ea386e82b788f4aa688aL43-R45)

These changes provide users with fine-grained control over which releases are visible and eligible for auto-download, improving the overall flexibility and user experience.