### PR TITLE
⚡ Bolt: Memoize sorted game lists in WishlistPage

### DIFF
--- a/client/__tests__/wishlist-sort.test.ts
+++ b/client/__tests__/wishlist-sort.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { sortGames } from "../src/pages/wishlist";
+import { type Game } from "../../shared/schema";
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    igdbId: 1,
+    title: "Game",
+    status: "wanted",
+    coverUrl: null,
+    releaseDate: null,
+    addedAt: null,
+    summary: null,
+    rating: null,
+    platforms: null,
+    genres: null,
+    screenshots: null,
+    steamAppId: null,
+    ...overrides,
+  } as Game;
+}
+
+describe("sortGames", () => {
+  describe("release-asc", () => {
+    it("sorts by release date ascending", () => {
+      const a = makeGame({ id: "a", releaseDate: "2022-01-01" });
+      const b = makeGame({ id: "b", releaseDate: "2024-06-15" });
+      expect(sortGames([b, a], "release-asc").map((g) => g.id)).toEqual(["a", "b"]);
+    });
+
+    it("pushes games with no release date to the end", () => {
+      const a = makeGame({ id: "a", releaseDate: "2022-01-01" });
+      const noDate = makeGame({ id: "noDate", releaseDate: null });
+      expect(sortGames([noDate, a], "release-asc").map((g) => g.id)).toEqual(["a", "noDate"]);
+    });
+
+    it("is stable when both games have no release date (returns 0)", () => {
+      const a = makeGame({ id: "a", releaseDate: null });
+      const b = makeGame({ id: "b", releaseDate: null });
+      const result = sortGames([a, b], "release-asc");
+      expect(result.map((g) => g.id)).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("release-desc", () => {
+    it("sorts by release date descending", () => {
+      const a = makeGame({ id: "a", releaseDate: "2022-01-01" });
+      const b = makeGame({ id: "b", releaseDate: "2024-06-15" });
+      expect(sortGames([a, b], "release-desc").map((g) => g.id)).toEqual(["b", "a"]);
+    });
+
+    it("is stable when both games have no release date (returns 0)", () => {
+      const a = makeGame({ id: "a", releaseDate: null });
+      const b = makeGame({ id: "b", releaseDate: null });
+      const result = sortGames([a, b], "release-desc");
+      expect(result.map((g) => g.id)).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("added-desc", () => {
+    it("sorts by addedAt descending", () => {
+      const old = makeGame({ id: "old", addedAt: new Date("2023-01-01") });
+      const recent = makeGame({ id: "recent", addedAt: new Date("2024-06-15") });
+      expect(sortGames([old, recent], "added-desc").map((g) => g.id)).toEqual(["recent", "old"]);
+    });
+
+    it("is stable when both games have no addedAt (returns 0)", () => {
+      const a = makeGame({ id: "a", addedAt: null });
+      const b = makeGame({ id: "b", addedAt: null });
+      const result = sortGames([a, b], "added-desc");
+      expect(result.map((g) => g.id)).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("title-asc", () => {
+    it("sorts by title alphabetically", () => {
+      const z = makeGame({ id: "z", title: "Zelda" });
+      const a = makeGame({ id: "a", title: "Abe's Odyssey" });
+      expect(sortGames([z, a], "title-asc").map((g) => g.id)).toEqual(["a", "z"]);
+    });
+  });
+
+  it("does not mutate the original array", () => {
+    const games = [makeGame({ id: "b", title: "B" }), makeGame({ id: "a", title: "A" })];
+    const original = [...games];
+    sortGames(games, "title-asc");
+    expect(games.map((g) => g.id)).toEqual(original.map((g) => g.id));
+  });
+});

--- a/client/src/pages/wishlist.tsx
+++ b/client/src/pages/wishlist.tsx
@@ -34,30 +34,32 @@ type SortOption = "release-asc" | "release-desc" | "added-desc" | "title-asc";
 const sortGames = (gameList: Game[], currentSortBy: SortOption): Game[] => {
   const sorted = [...gameList];
 
-  switch (currentSortBy) {
-    case "release-asc":
-      return sorted.sort((a, b) => {
+  return sorted.sort((a, b) => {
+    switch (currentSortBy) {
+      case "release-asc": {
+        if (!a.releaseDate && !b.releaseDate) return 0;
         if (!a.releaseDate) return 1;
         if (!b.releaseDate) return -1;
         return new Date(a.releaseDate).getTime() - new Date(b.releaseDate).getTime();
-      });
-    case "release-desc":
-      return sorted.sort((a, b) => {
+      }
+      case "release-desc": {
+        if (!a.releaseDate && !b.releaseDate) return 0;
         if (!a.releaseDate) return 1;
         if (!b.releaseDate) return -1;
         return new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime();
-      });
-    case "added-desc":
-      return sorted.sort((a, b) => {
+      }
+      case "added-desc": {
+        if (!a.addedAt && !b.addedAt) return 0;
         if (!a.addedAt) return 1;
         if (!b.addedAt) return -1;
         return new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime();
-      });
-    case "title-asc":
-      return sorted.sort((a, b) => a.title.localeCompare(b.title));
-    default:
-      return sorted;
-  }
+      }
+      case "title-asc":
+        return a.title.localeCompare(b.title);
+      default:
+        return 0;
+    }
+  });
 };
 
 export default function WishlistPage() {

--- a/client/src/pages/wishlist.tsx
+++ b/client/src/pages/wishlist.tsx
@@ -87,35 +87,19 @@ export default function WishlistPage() {
     return { releasedGames: released, upcomingGames: upcoming, tbaGames: tba };
   }, [wishlistGames]);
 
-  // Sort games based on selected option
-  const sortGames = (gameList: Game[]): Game[] => {
-    const sorted = [...gameList];
+  // ⚡ Bolt: Memoize the sorted arrays to prevent re-sorting on every render
+  // previously, `sortGames()` was called directly in the JSX render function
+  const sortedUpcomingGames = useMemo(() => {
+    return sortGames(upcomingGames, sortBy);
+  }, [upcomingGames, sortBy]);
 
-    switch (sortBy) {
-      case "release-asc":
-        return sorted.sort((a, b) => {
-          if (!a.releaseDate) return 1;
-          if (!b.releaseDate) return -1;
-          return new Date(a.releaseDate).getTime() - new Date(b.releaseDate).getTime();
-        });
-      case "release-desc":
-        return sorted.sort((a, b) => {
-          if (!a.releaseDate) return 1;
-          if (!b.releaseDate) return -1;
-          return new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime();
-        });
-      case "added-desc":
-        return sorted.sort((a, b) => {
-          if (!a.addedAt) return 1;
-          if (!b.addedAt) return -1;
-          return new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime();
-        });
-      case "title-asc":
-        return sorted.sort((a, b) => a.title.localeCompare(b.title));
-      default:
-        return sorted;
-    }
-  };
+  const sortedReleasedGames = useMemo(() => {
+    return sortGames(releasedGames, sortBy);
+  }, [releasedGames, sortBy]);
+
+  const sortedTbaGames = useMemo(() => {
+    return sortGames(tbaGames, sortBy);
+  }, [tbaGames, sortBy]);
 
   const statusMutation = useMutation({
     mutationFn: async ({ gameId, status }: { gameId: string; status: GameStatus }) => {
@@ -227,7 +211,7 @@ export default function WishlistPage() {
                 <Badge variant="default">{upcomingGames.length}</Badge>
               </div>
               <GameGrid
-                games={sortGames(upcomingGames)}
+                games={sortedUpcomingGames}
                 onStatusChange={(id, status) => statusMutation.mutate({ gameId: id, status })}
                 isLoading={isLoading}
                 viewMode={viewMode}
@@ -247,7 +231,7 @@ export default function WishlistPage() {
                 </Badge>
               </div>
               <GameGrid
-                games={sortGames(releasedGames)}
+                games={sortedReleasedGames}
                 onStatusChange={(id, status) => statusMutation.mutate({ gameId: id, status })}
                 isLoading={isLoading}
                 viewMode={viewMode}
@@ -265,7 +249,7 @@ export default function WishlistPage() {
                 <Badge variant="secondary">{tbaGames.length}</Badge>
               </div>
               <GameGrid
-                games={sortGames(tbaGames)}
+                games={sortedTbaGames}
                 onStatusChange={(id, status) => statusMutation.mutate({ gameId: id, status })}
                 isLoading={isLoading}
                 viewMode={viewMode}

--- a/client/src/pages/wishlist.tsx
+++ b/client/src/pages/wishlist.tsx
@@ -28,6 +28,38 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
 type SortOption = "release-asc" | "release-desc" | "added-desc" | "title-asc";
 
+// ⚡ Bolt: Move sortGames outside of the component to prevent it from being recreated
+// on every render, which would break the `useMemo` dependencies below if it were
+// included in the dependency array.
+const sortGames = (gameList: Game[], currentSortBy: SortOption): Game[] => {
+  const sorted = [...gameList];
+
+  switch (currentSortBy) {
+    case "release-asc":
+      return sorted.sort((a, b) => {
+        if (!a.releaseDate) return 1;
+        if (!b.releaseDate) return -1;
+        return new Date(a.releaseDate).getTime() - new Date(b.releaseDate).getTime();
+      });
+    case "release-desc":
+      return sorted.sort((a, b) => {
+        if (!a.releaseDate) return 1;
+        if (!b.releaseDate) return -1;
+        return new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime();
+      });
+    case "added-desc":
+      return sorted.sort((a, b) => {
+        if (!a.addedAt) return 1;
+        if (!b.addedAt) return -1;
+        return new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime();
+      });
+    case "title-asc":
+      return sorted.sort((a, b) => a.title.localeCompare(b.title));
+    default:
+      return sorted;
+  }
+};
+
 export default function WishlistPage() {
   const { toast } = useToast();
   const queryClient = useQueryClient();

--- a/client/src/pages/wishlist.tsx
+++ b/client/src/pages/wishlist.tsx
@@ -31,7 +31,7 @@ type SortOption = "release-asc" | "release-desc" | "added-desc" | "title-asc";
 // ⚡ Bolt: Move sortGames outside of the component to prevent it from being recreated
 // on every render, which would break the `useMemo` dependencies below if it were
 // included in the dependency array.
-const sortGames = (gameList: Game[], currentSortBy: SortOption): Game[] => {
+export const sortGames = (gameList: Game[], currentSortBy: SortOption): Game[] => {
   const sorted = [...gameList];
 
   return sorted.sort((a, b) => {


### PR DESCRIPTION
💡 **What:** Added `useMemo` hooks around the sorted game arrays (`upcomingGames`, `releasedGames`, `tbaGames`) in `client/src/pages/wishlist.tsx`, and moved the `sortGames` pure function outside the component.
🎯 **Why:** To eliminate an O(N log N) performance bottleneck where the `sortGames` function was called directly in the JSX, meaning the arrays were re-sorted and re-allocated on *every single render* of the `WishlistPage` component.
📊 **Impact:** Reduces main thread blocking by avoiding unnecessary sorting and allocation, leading to a smoother experience when navigating or interacting with the Wishlist page, especially for users with large wishlists. Reduces re-renders.
🔬 **Measurement:** Open React DevTools Profiler, interact with the page (e.g. toggling view density), and observe that the `sortGames` logic no longer executes during unrelated renders.

---

*PR created automatically by Jules for task [8136281387632788946](https://jules.google.com/task/8136281387632788946) started by @Doezer*