### PR TITLE
⚡ Bolt: Add missing memoization to search results sorting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-03-18 - Missing memoization in frequently rendered components
 **Learning:** Found that multiple components like `AppSidebar`, `library.tsx`, and `wishlist.tsx` were performing O(n) array filtering (`games.filter(...)`) on every render. Because `AppSidebar` renders on every page and updates frequently (e.g. from active downloads polling), these unmemoized calculations could cause noticeable jank as the library grows.
 **Action:** Always check if derived array data (like filtering or sorting) in top-level or frequently updated components is properly wrapped in `useMemo`, especially when the source array comes from a global query cache like React Query.
+
+## 2025-05-23 - Unmemoized React Query array data transformations
+**Learning:** React Query frequently triggers re-renders on components. Any heavy transformation derived from query results (e.g. filtering, O(N log N) sorting, date parsing) directly inside the component body will fire on every re-render and degrade performance.
+**Action:** Extract list transformations or sorting using results from React Query into `useMemo`, ensuring `searchResults?.items` or equivalent array paths are added to the dependency array.

--- a/client/src/pages/search.tsx
+++ b/client/src/pages/search.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useDebounce } from "@/hooks/use-debounce";
 import { queryClient } from "@/lib/queryClient";
@@ -107,9 +107,14 @@ export default function SearchPage() {
     enabled: debouncedSearchQuery.trim().length > 0,
   });
 
-  const sortedItems = (searchResults?.items || []).slice().sort((a, b) => {
-    return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
-  });
+  // ⚡ Bolt: Memoize the sorted search results to avoid O(n log n) date parsing
+  // and sorting on every render when interacting with the search page state
+  // (like opening the download dialog or typing).
+  const sortedItems = useMemo(() => {
+    return (searchResults?.items || []).slice().sort((a, b) => {
+      return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
+    });
+  }, [searchResults?.items]);
 
   // Show toast notification when search completes
   useEffect(() => {

--- a/client/src/pages/search.tsx
+++ b/client/src/pages/search.tsx
@@ -109,11 +109,14 @@ export default function SearchPage() {
 
   // ⚡ Bolt: Memoize the sorted search results to avoid O(n log n) date parsing
   // and sorting on every render when interacting with the search page state
-  // (like opening the download dialog or typing).
+  // (like opening the download dialog or typing). Dates are pre-parsed into
+  // timestamps once per item before sorting to avoid redundant Date instantiations
+  // inside the comparator.
   const sortedItems = useMemo(() => {
-    return (searchResults?.items || []).slice().sort((a, b) => {
-      return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
-    });
+    return (searchResults?.items || [])
+      .map(item => ({ item, time: new Date(item.pubDate).getTime() }))
+      .sort((a, b) => b.time - a.time)
+      .map(({ item }) => item);
   }, [searchResults?.items]);
 
   // Show toast notification when search completes


### PR DESCRIPTION
💡 What: Wrapped the `sortedItems` calculation in `client/src/pages/search.tsx` inside a `useMemo` hook, adding `searchResults?.items` as the dependency.
🎯 Why: React Query triggers re-renders on components when queries fetch or update. The component also has local state. Previously, the `O(N log N)` date parsing and array sorting ran on every single render.
📊 Impact: Prevents expensive sorting and date parsing calculations on state changes, reducing CPU usage and potentially noticeable jank, especially when searching across many indexers returning hundreds of results.
🔬 Measurement: Verify by typing in the search bar or opening the download dialog; the `sortedItems` array will no longer be recreated unless the underlying `searchResults` change.

---

*PR created automatically by Jules for task [8408208740053753748](https://jules.google.com/task/8408208740053753748) started by @Doezer*