### PR TITLE
Add PCGamingWiki API support for game URL retrieval

### DIFF
--- a/client/__tests__/GameCard.test.tsx
+++ b/client/__tests__/GameCard.test.tsx
@@ -66,9 +66,9 @@ describe("GameCard", () => {
   let queryClient: QueryClient;
 
   beforeEach(() => {
-    Object.defineProperty(window, 'matchMedia', {
+    Object.defineProperty(window, "matchMedia", {
       writable: true,
-      value: vi.fn().mockImplementation(query => ({
+      value: vi.fn().mockImplementation((query) => ({
         matches: false,
         media: query,
         onchange: null,

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -127,9 +127,8 @@ function getDerivedLinks(
 ): Array<SiteLinkConfig & { href: string }> {
   const t = encodeURIComponent(game.title);
 
-  const pcgwEntry: Array<SiteLinkConfig & { href: string }> = [];
-  if (pcgwUrl !== null) {
-    pcgwEntry.push({
+  return [
+    {
       label: "PCGamingWiki",
       Icon: SiPcgamingwiki as IconComponent,
       colorClass: "text-teal-400",
@@ -138,11 +137,7 @@ function getDerivedLinks(
         (game.steamAppId
           ? `https://www.pcgamingwiki.com/api/redirect?steamappid=${game.steamAppId}`
           : `https://www.pcgamingwiki.com/w/index.php?search=${t}`),
-    });
-  }
-
-  return [
-    ...pcgwEntry,
+    },
     {
       label: "HowLongToBeat",
       Icon: Clock as IconComponent,
@@ -387,11 +382,9 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
 
   const { data: pcgwData } = useQuery<{ url: string | null }>({
     queryKey: ["/api/external/pcgamingwiki", game?.steamAppId],
-    queryFn: async () => {
-      const res = await apiRequest(
-        "GET",
-        `/api/external/pcgamingwiki?steamAppId=${game!.steamAppId}`
-      );
+    queryFn: async ({ queryKey }) => {
+      const [, steamAppId] = queryKey;
+      const res = await apiRequest("GET", `/api/external/pcgamingwiki?steamAppId=${steamAppId}`);
       return res.json();
     },
     enabled: open && !!game?.steamAppId,

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -120,17 +120,29 @@ function resolveWebsiteConfig(w: { category?: number; url: string }): SiteLinkCo
   return null;
 }
 
-function getDerivedLinks(game: Game, hltbUrl?: string): Array<SiteLinkConfig & { href: string }> {
+function getDerivedLinks(
+  game: Game,
+  hltbUrl?: string,
+  pcgwUrl?: string | null
+): Array<SiteLinkConfig & { href: string }> {
   const t = encodeURIComponent(game.title);
-  return [
-    {
+
+  const pcgwEntry: Array<SiteLinkConfig & { href: string }> = [];
+  if (pcgwUrl !== null) {
+    pcgwEntry.push({
       label: "PCGamingWiki",
       Icon: SiPcgamingwiki as IconComponent,
       colorClass: "text-teal-400",
-      href: game.steamAppId
-        ? `https://www.pcgamingwiki.com/api/redirect?steamappid=${game.steamAppId}`
-        : `https://www.pcgamingwiki.com/w/index.php?search=${t}`,
-    },
+      href:
+        pcgwUrl ??
+        (game.steamAppId
+          ? `https://www.pcgamingwiki.com/api/redirect?steamappid=${game.steamAppId}`
+          : `https://www.pcgamingwiki.com/w/index.php?search=${t}`),
+    });
+  }
+
+  return [
+    ...pcgwEntry,
     {
       label: "HowLongToBeat",
       Icon: Clock as IconComponent,
@@ -373,6 +385,19 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
     errorMessage: "Failed to update game visibility",
   });
 
+  const { data: pcgwData } = useQuery<{ url: string | null }>({
+    queryKey: ["/api/external/pcgamingwiki", game?.steamAppId],
+    queryFn: async () => {
+      const res = await apiRequest(
+        "GET",
+        `/api/external/pcgamingwiki?steamAppId=${game!.steamAppId}`
+      );
+      return res.json();
+    },
+    enabled: open && !!game?.steamAppId,
+    staleTime: 24 * 60 * 60 * 1000,
+  });
+
   if (!game) return null;
 
   const handleUserRatingChange = (rating: number | null) => {
@@ -387,7 +412,8 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
       : game.summary;
 
   const igdbWebsites = (game.igdbWebsites ?? []) as Array<{ category: number; url: string }>;
-  const derivedLinks = getDerivedLinks(game, hltbData?.url);
+
+  const derivedLinks = getDerivedLinks(game, hltbData?.url, pcgwData?.url);
   // Optimistic display: show pending value immediately while the mutation is in flight.
   const currentUserRating = userRatingMutation.isPending
     ? (userRatingMutation.variables?.userRating ?? null)

--- a/server/__tests__/pcgamingwiki_routes.test.ts
+++ b/server/__tests__/pcgamingwiki_routes.test.ts
@@ -117,4 +117,30 @@ describe("lookupPcgwUrl (unit)", () => {
 
     expect(url).toBe("https://www.pcgamingwiki.com/wiki/Red_Dead_Redemption_2");
   });
+
+  it("caches failures with a short TTL so transient errors are retried sooner", async () => {
+    vi.mocked(safeFetch).mockRejectedValue(new Error("network error"));
+    const before = Date.now();
+
+    await lookupPcgwUrl(1733240);
+
+    const entry = pcgwCache.get(1733240);
+    expect(entry).toBeDefined();
+    expect(entry!.url).toBeNull();
+    // Failure TTL should be ≤ 5 minutes, well below the 24-hour success TTL
+    expect(entry!.expires).toBeLessThan(before + 6 * 60 * 1000);
+  });
+
+  it("caches successful results with the full 24-hour TTL", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(makeCargoResponse("Phantom Fury") as never);
+    const before = Date.now();
+
+    await lookupPcgwUrl(1733240);
+
+    const entry = pcgwCache.get(1733240);
+    expect(entry).toBeDefined();
+    expect(entry!.url).not.toBeNull();
+    // Success TTL should be close to 24 hours
+    expect(entry!.expires).toBeGreaterThan(before + 23 * 60 * 60 * 1000);
+  });
 });

--- a/server/__tests__/pcgamingwiki_routes.test.ts
+++ b/server/__tests__/pcgamingwiki_routes.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import express, { type NextFunction, type Request, type Response } from "express";
+import request from "supertest";
+import { pcgamingwikiRouter, pcgwCache, lookupPcgwUrl } from "../pcgamingwiki-router.js";
+
+vi.mock("../ssrf.js", () => ({
+  safeFetch: vi.fn(),
+  isSafeUrl: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../auth.js", () => ({
+  authenticateToken: (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+vi.mock("../logger.js", () => ({
+  routesLogger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { safeFetch } from "../ssrf.js";
+
+function makeCargoResponse(pageName: string | null) {
+  const cargoquery = pageName ? [{ title: { _pageName: pageName } }] : [];
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue({ cargoquery }),
+  };
+}
+
+describe("GET /api/external/pcgamingwiki", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pcgwCache.clear();
+    app = express();
+    app.use(express.json());
+    app.use(pcgamingwikiRouter);
+  });
+
+  it("returns direct wiki URL when page is found", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(makeCargoResponse("Phantom Fury") as never);
+
+    const res = await request(app).get("/api/external/pcgamingwiki?steamAppId=1733240");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ url: "https://www.pcgamingwiki.com/wiki/Phantom_Fury" });
+    expect(safeFetch).toHaveBeenCalledOnce();
+  });
+
+  it("returns null url when cargoquery is empty", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(makeCargoResponse(null) as never);
+
+    const res = await request(app).get("/api/external/pcgamingwiki?steamAppId=9999999");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ url: null });
+  });
+
+  it("returns 400 when steamAppId is missing", async () => {
+    const res = await request(app).get("/api/external/pcgamingwiki");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/steamAppId/);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when steamAppId is not a positive integer", async () => {
+    const [resZero, resNeg, resFloat, resStr] = await Promise.all([
+      request(app).get("/api/external/pcgamingwiki?steamAppId=0"),
+      request(app).get("/api/external/pcgamingwiki?steamAppId=-1"),
+      request(app).get("/api/external/pcgamingwiki?steamAppId=1.5"),
+      request(app).get("/api/external/pcgamingwiki?steamAppId=abc"),
+    ]);
+
+    expect(resZero.status).toBe(400);
+    expect(resNeg.status).toBe(400);
+    expect(resFloat.status).toBe(400);
+    expect(resStr.status).toBe(400);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null url gracefully when safeFetch throws", async () => {
+    vi.mocked(safeFetch).mockRejectedValue(new Error("network error"));
+
+    const res = await request(app).get("/api/external/pcgamingwiki?steamAppId=1733240");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ url: null });
+  });
+
+  it("uses cache on second request — safeFetch called only once", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(makeCargoResponse("Phantom Fury") as never);
+
+    await request(app).get("/api/external/pcgamingwiki?steamAppId=1733240");
+    const res = await request(app).get("/api/external/pcgamingwiki?steamAppId=1733240");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ url: "https://www.pcgamingwiki.com/wiki/Phantom_Fury" });
+    expect(safeFetch).toHaveBeenCalledOnce();
+  });
+});
+
+describe("lookupPcgwUrl (unit)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pcgwCache.clear();
+  });
+
+  it("encodes page names with spaces using underscores", async () => {
+    vi.mocked(safeFetch).mockResolvedValue(makeCargoResponse("Red Dead Redemption 2") as never);
+
+    const url = await lookupPcgwUrl(1174180);
+
+    expect(url).toBe("https://www.pcgamingwiki.com/wiki/Red_Dead_Redemption_2");
+  });
+});

--- a/server/pcgamingwiki-router.ts
+++ b/server/pcgamingwiki-router.ts
@@ -1,0 +1,57 @@
+import { Router } from "express";
+import { authenticateToken } from "./auth.js";
+import { safeFetch } from "./ssrf.js";
+import { routesLogger } from "./logger.js";
+
+interface CargoQueryResult {
+  cargoquery: Array<{ title: { _pageName: string } }>;
+}
+
+const PCGW_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+const pcgwCache = new Map<number, { url: string | null; expires: number }>();
+
+async function lookupPcgwUrl(steamAppId: number): Promise<string | null> {
+  const cached = pcgwCache.get(steamAppId);
+  if (cached && Date.now() < cached.expires) {
+    return cached.url;
+  }
+
+  const where = `Infobox_game.Steam_AppID HOLDS "${steamAppId}"`;
+  const apiUrl =
+    `https://www.pcgamingwiki.com/w/api.php?action=cargoquery` +
+    `&tables=Infobox_game&fields=Infobox_game._pageName` +
+    `&where=${encodeURIComponent(where)}&format=json`;
+
+  let url: string | null = null;
+  try {
+    const response = await safeFetch(apiUrl);
+    const data = (await response.json()) as CargoQueryResult;
+    const pageName = data?.cargoquery?.[0]?.title?._pageName;
+    if (pageName) {
+      url = `https://www.pcgamingwiki.com/wiki/${encodeURIComponent(pageName).replace(/%20/g, "_")}`;
+    }
+  } catch (err) {
+    routesLogger.warn({ err, steamAppId }, "PCGamingWiki lookup failed");
+  }
+
+  pcgwCache.set(steamAppId, { url, expires: Date.now() + PCGW_CACHE_TTL_MS });
+  return url;
+}
+
+const router = Router();
+
+router.get("/api/external/pcgamingwiki", authenticateToken, async (req, res) => {
+  const raw = req.query.steamAppId;
+  const steamAppId = Number(raw);
+
+  if (!raw || !Number.isInteger(steamAppId) || steamAppId <= 0) {
+    return res.status(400).json({ error: "steamAppId must be a positive integer" });
+  }
+
+  const url = await lookupPcgwUrl(steamAppId);
+  return res.json({ url });
+});
+
+export { pcgwCache, lookupPcgwUrl };
+export const pcgamingwikiRouter = router;

--- a/server/pcgamingwiki-router.ts
+++ b/server/pcgamingwiki-router.ts
@@ -7,7 +7,8 @@ interface CargoQueryResult {
   cargoquery: Array<{ title: { _pageName: string } }>;
 }
 
-const PCGW_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const PCGW_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours for confirmed results
+const PCGW_FAILURE_TTL_MS = 5 * 60 * 1000; // 5 minutes for transient failures
 
 const pcgwCache = new Map<number, { url: string | null; expires: number }>();
 
@@ -23,20 +24,20 @@ async function lookupPcgwUrl(steamAppId: number): Promise<string | null> {
     `&tables=Infobox_game&fields=Infobox_game._pageName` +
     `&where=${encodeURIComponent(where)}&format=json`;
 
-  let url: string | null = null;
   try {
     const response = await safeFetch(apiUrl);
     const data = (await response.json()) as CargoQueryResult;
     const pageName = data?.cargoquery?.[0]?.title?._pageName;
-    if (pageName) {
-      url = `https://www.pcgamingwiki.com/wiki/${encodeURIComponent(pageName).replace(/%20/g, "_")}`;
-    }
+    const url = pageName
+      ? `https://www.pcgamingwiki.com/wiki/${encodeURIComponent(pageName).replace(/%20/g, "_")}`
+      : null;
+    pcgwCache.set(steamAppId, { url, expires: Date.now() + PCGW_CACHE_TTL_MS });
+    return url;
   } catch (err) {
     routesLogger.warn({ err, steamAppId }, "PCGamingWiki lookup failed");
+    pcgwCache.set(steamAppId, { url: null, expires: Date.now() + PCGW_FAILURE_TTL_MS });
+    return null;
   }
-
-  pcgwCache.set(steamAppId, { url, expires: Date.now() + PCGW_CACHE_TTL_MS });
-  return url;
 }
 
 const router = Router();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -69,6 +69,7 @@ import { normalizeTitle, cleanReleaseName } from "../shared/title-utils.js";
 import archiver from "archiver";
 import helmet from "helmet";
 import { steamRoutes } from "./steam-routes.js";
+import { pcgamingwikiRouter } from "./pcgamingwiki-router.js";
 
 // Cache-Control header values for IGDB discovery endpoints
 const CC_IGDB_GAME_LIST = "public, max-age=3600, stale-while-revalidate=600";
@@ -198,6 +199,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   );
   // Use Steam Routes
   app.use(steamRoutes);
+  // Use PCGamingWiki Routes
+  app.use(pcgamingwikiRouter);
 
   // Auth Routes
   app.get("/api/auth/status", async (_req, res) => {


### PR DESCRIPTION
This pull request introduces a new backend route for fetching direct PCGamingWiki URLs for games via their Steam App IDs, integrates this route into the frontend to display more accurate links, and adds comprehensive tests for the new functionality. It also includes minor refactoring and formatting changes in several files.

**Backend: PCGamingWiki Integration**

- Adds a new Express router (`pcgamingwiki-router.ts`) that exposes a `/api/external/pcgamingwiki` endpoint. This endpoint takes a `steamAppId`, queries PCGamingWiki via their Cargo API, caches results for 24 hours, and returns the direct wiki page URL if found.
- Integrates the new router into the main server routes (`routes.ts`) so the endpoint is accessible to clients. [[1]](diffhunk://#diff-a063e361b4700c847d46e6e6384d6b8c8b6f20ea277f3f5c43cbf4d28737de11R71) [[2]](diffhunk://#diff-a063e361b4700c847d46e6e6384d6b8c8b6f20ea277f3f5c43cbf4d28737de11R201-R202)
- Provides unit and integration tests for the PCGamingWiki route, covering cache behavior, error handling, and URL formatting.

**Frontend: Use Direct PCGamingWiki Links**

- Updates `GameDetailsModal.tsx` to call the new backend endpoint using React Query, fetch the direct PCGamingWiki URL for the current game, and pass it to the link rendering logic. [[1]](diffhunk://#diff-5fd1e1cfb4fe8cbc1120534cf887e0566b846da231be4c51687e1045bf7a455dR364-R376) [[2]](diffhunk://#diff-5fd1e1cfb4fe8cbc1120534cf887e0566b846da231be4c51687e1045bf7a455dL367-R392)
- Refactors the `getDerivedLinks` function to accept an optional PCGamingWiki URL, ensuring that the most accurate link is shown to users.

**Other Minor Changes**

- Minor code formatting and consistency improvements in tests and storage interface implementations. [[1]](diffhunk://#diff-1103bf191cff66b6663c381394e3877378aaf8c805eb17dee6d3ad602b554ad3L69-R71) [[2]](diffhunk://#diff-6af4f8e34285120717169f57249241ec070dfd0f878e186658aaa341e568c84fL85-R89) [[3]](diffhunk://#diff-6af4f8e34285120717169f57249241ec070dfd0f878e186658aaa341e568c84fL386-R394) [[4]](diffhunk://#diff-6af4f8e34285120717169f57249241ec070dfd0f878e186658aaa341e568c84fL1211-R1223)