### PR TITLE
Bug fixes batch

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,6 @@
 {
   "permissions": {
     "allow": [
-      "Bash(grep -r \"OpenAI\\\\|Stripe\\\\|AWS\\\\|Supabase\\\\|Firebase\\\\|IGDB\\\\|Steam\" /c/Users/Vincent/Repos/Perso/Questarr.main/Questarr/server --include=*.ts)",
-      "Bash(find /c/Users/Vincent/Repos/Perso/Questarr.main/Questarr/migrations -type f -name *.sql)",
       "mcp__Claude_Preview__preview_start",
       "Skill(code-review:code-review)",
       "Skill(code-review:code-review:*)",

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -245,7 +245,7 @@ function StarRatingInput({
         const isHalf = display !== null && display >= halfValue && display < fullValue;
 
         return (
-          <span key={star} className="relative inline-flex w-5 h-5">
+          <span key={star} className="relative inline-flex w-5 h-5 overflow-visible">
             <StarHitTarget
               ratingValue={halfValue}
               currentValue={value}

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -370,9 +370,12 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
       }
       return results;
     },
-    onSuccess: (results) => {
+    onSuccess: (results, variables) => {
       const successfulResults = results.filter((r) => r.success);
       const successCount = successfulResults.length;
+      const failedResults = results
+        .map((r, i) => ({ result: r, download: variables[i] }))
+        .filter(({ result }) => !result.success);
       if (successCount === 0) {
         toast({ title: "Failed to start download", variant: "destructive" });
         return;
@@ -386,6 +389,13 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
         description:
           results.length > 1 ? `Added ${successCount} of ${results.length} downloads` : undefined,
       });
+      if (failedResults.length > 0) {
+        toast({
+          title: `${failedResults.length} download(s) failed`,
+          description: failedResults.map(({ download }) => download.title).join(", "),
+          variant: "destructive",
+        });
+      }
       queryClient.invalidateQueries({ queryKey: ["/api/downloads"] });
       queryClient.invalidateQueries({ queryKey: ["/api/downloads/summary"] });
       onOpenChange(false);
@@ -1155,6 +1165,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                         })()}
                                         <DropdownMenuItem
                                           onClick={() => blacklistMutation.mutate(download)}
+                                          disabled={blacklistMutation.isPending}
                                           className="text-destructive focus:text-destructive"
                                         >
                                           <Ban className="h-4 w-4 mr-2" />

--- a/client/src/lib/auth.tsx
+++ b/client/src/lib/auth.tsx
@@ -74,6 +74,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (res.status === 401 || res.status === 403) {
         localStorage.removeItem("token");
         setToken(null);
+        queryClient.clear();
         return null;
       }
 

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -1449,7 +1449,7 @@ describe("API Routes - Extended Coverage", () => {
       it("should delete RSS feed", async () => {
         vi.mocked(storage.removeRssFeed).mockResolvedValue(true);
         const response = await request(app).delete("/api/rss/feeds/feed-1");
-        expect(response.status).toBe(200);
+        expect(response.status).toBe(204);
       });
 
       it("should return 404 for missing feed", async () => {

--- a/server/__tests__/database_storage_integration.test.ts
+++ b/server/__tests__/database_storage_integration.test.ts
@@ -150,7 +150,7 @@ describe("DatabaseStorage Integration", () => {
       status: "failed",
     });
 
-    const summary = await storage.getDownloadSummaryByGame();
+    const summary = await storage.getDownloadSummaryByGame(userId);
 
     expect(Object.keys(summary)).toHaveLength(2);
 

--- a/server/__tests__/download-summary.test.ts
+++ b/server/__tests__/download-summary.test.ts
@@ -248,6 +248,8 @@ const { storage } = await import("../storage.js");
 import type { MemStorage as MemStorageType } from "../storage.js";
 import type { InsertGameDownload, DownloadSummary } from "../../shared/schema.js";
 
+const USER_ID = "test-user-1";
+
 const makeDownload = (overrides: Partial<InsertGameDownload> = {}): InsertGameDownload => ({
   gameId: "game-1",
   downloaderId: "dl-1",
@@ -258,16 +260,26 @@ const makeDownload = (overrides: Partial<InsertGameDownload> = {}): InsertGameDo
   ...overrides,
 });
 
+// Seed game IDs that tests use directly into MemStorage's internal map (test-only).
+function seedGames(memStorage: MemStorageType, gameIds: string[], userId: string = USER_ID): void {
+  const gamesMap = (memStorage as unknown as { games: Map<string, { id: string; userId: string }> })
+    .games;
+  for (const id of gameIds) {
+    gamesMap.set(id, { id, userId } as unknown as { id: string; userId: string });
+  }
+}
+
 // ─── Storage unit tests ───
 describe("getDownloadSummaryByGame (MemStorage)", () => {
   let memStorage: MemStorageType;
 
   beforeEach(() => {
     memStorage = new MemStorage();
+    seedGames(memStorage, ["game-1", "game-2"]);
   });
 
   it("returns empty object when no downloads exist", async () => {
-    const summary = await memStorage.getDownloadSummaryByGame();
+    const summary = await memStorage.getDownloadSummaryByGame(USER_ID);
     expect(summary).toEqual({});
   });
 
@@ -275,7 +287,7 @@ describe("getDownloadSummaryByGame (MemStorage)", () => {
     await memStorage.addGameDownload(
       makeDownload({ status: "downloading", downloadType: "torrent" })
     );
-    const summary = await memStorage.getDownloadSummaryByGame();
+    const summary = await memStorage.getDownloadSummaryByGame(USER_ID);
     expect(summary["game-1"]).toEqual({
       topStatus: "downloading",
       count: 1,
@@ -287,7 +299,7 @@ describe("getDownloadSummaryByGame (MemStorage)", () => {
     await memStorage.addGameDownload(makeDownload({ downloadHash: "hash-1", status: "completed" }));
     await memStorage.addGameDownload(makeDownload({ downloadHash: "hash-2", status: "completed" }));
     await memStorage.addGameDownload(makeDownload({ downloadHash: "hash-3", status: "completed" }));
-    const summary = await memStorage.getDownloadSummaryByGame();
+    const summary = await memStorage.getDownloadSummaryByGame(USER_ID);
     expect(summary["game-1"].count).toBe(3);
   });
 
@@ -301,7 +313,7 @@ describe("getDownloadSummaryByGame (MemStorage)", () => {
     await memStorage.addGameDownload(
       makeDownload({ downloadHash: "hash-3", downloadType: "torrent" })
     );
-    const summary = await memStorage.getDownloadSummaryByGame();
+    const summary = await memStorage.getDownloadSummaryByGame(USER_ID);
     expect(summary["game-1"].downloadTypes).toHaveLength(2);
     expect(summary["game-1"].downloadTypes).toContain("torrent");
     expect(summary["game-1"].downloadTypes).toContain("usenet");
@@ -309,34 +321,38 @@ describe("getDownloadSummaryByGame (MemStorage)", () => {
 
   it("resolves topStatus with correct priority: failed > downloading > paused > completed", async () => {
     await memStorage.addGameDownload(makeDownload({ downloadHash: "hash-1", status: "completed" }));
-    expect((await memStorage.getDownloadSummaryByGame())["game-1"].topStatus).toBe("completed");
+    expect((await memStorage.getDownloadSummaryByGame(USER_ID))["game-1"].topStatus).toBe(
+      "completed"
+    );
 
     await memStorage.addGameDownload(makeDownload({ downloadHash: "hash-2", status: "paused" }));
-    expect((await memStorage.getDownloadSummaryByGame())["game-1"].topStatus).toBe("paused");
+    expect((await memStorage.getDownloadSummaryByGame(USER_ID))["game-1"].topStatus).toBe("paused");
 
     await memStorage.addGameDownload(
       makeDownload({ downloadHash: "hash-3", status: "downloading" })
     );
-    expect((await memStorage.getDownloadSummaryByGame())["game-1"].topStatus).toBe("downloading");
+    expect((await memStorage.getDownloadSummaryByGame(USER_ID))["game-1"].topStatus).toBe(
+      "downloading"
+    );
 
     await memStorage.addGameDownload(makeDownload({ downloadHash: "hash-4", status: "failed" }));
-    expect((await memStorage.getDownloadSummaryByGame())["game-1"].topStatus).toBe("failed");
+    expect((await memStorage.getDownloadSummaryByGame(USER_ID))["game-1"].topStatus).toBe("failed");
   });
 
   it("does not downgrade topStatus when a lower-priority status is added", async () => {
     await memStorage.addGameDownload(makeDownload({ downloadHash: "hash-1", status: "failed" }));
-    expect((await memStorage.getDownloadSummaryByGame())["game-1"].topStatus).toBe("failed");
+    expect((await memStorage.getDownloadSummaryByGame(USER_ID))["game-1"].topStatus).toBe("failed");
 
     await memStorage.addGameDownload(
       makeDownload({ downloadHash: "hash-2", status: "downloading" })
     );
-    expect((await memStorage.getDownloadSummaryByGame())["game-1"].topStatus).toBe("failed");
+    expect((await memStorage.getDownloadSummaryByGame(USER_ID))["game-1"].topStatus).toBe("failed");
 
     await memStorage.addGameDownload(makeDownload({ downloadHash: "hash-3", status: "paused" }));
-    expect((await memStorage.getDownloadSummaryByGame())["game-1"].topStatus).toBe("failed");
+    expect((await memStorage.getDownloadSummaryByGame(USER_ID))["game-1"].topStatus).toBe("failed");
 
     await memStorage.addGameDownload(makeDownload({ downloadHash: "hash-4", status: "completed" }));
-    expect((await memStorage.getDownloadSummaryByGame())["game-1"].topStatus).toBe("failed");
+    expect((await memStorage.getDownloadSummaryByGame(USER_ID))["game-1"].topStatus).toBe("failed");
   });
 
   it("handles multiple games independently", async () => {
@@ -351,7 +367,7 @@ describe("getDownloadSummaryByGame (MemStorage)", () => {
         downloadType: "usenet",
       })
     );
-    const summary = await memStorage.getDownloadSummaryByGame();
+    const summary = await memStorage.getDownloadSummaryByGame(USER_ID);
     expect(summary["game-1"].topStatus).toBe("downloading");
     expect(summary["game-2"].topStatus).toBe("failed");
     expect(Object.keys(summary)).toHaveLength(2);

--- a/server/__tests__/rss-routes.test.ts
+++ b/server/__tests__/rss-routes.test.ts
@@ -169,8 +169,8 @@ describe("RSS Routes", () => {
 
       const res = await request(app).delete("/api/rss/feeds/1");
 
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual({ success: true });
+      expect(res.status).toBe(204);
+      expect(res.body).toEqual({});
       expect(storage.removeRssFeed).toHaveBeenCalledWith("1");
     });
 

--- a/server/__tests__/steam_routes.test.ts
+++ b/server/__tests__/steam_routes.test.ts
@@ -39,9 +39,9 @@ describe("steamRoutes", () => {
     app.use(steamRoutes);
   });
 
-  describe("PUT /api/user/steam-id", () => {
+  describe("PATCH /api/user/steam-id", () => {
     it("returns 400 when steamId is missing", async () => {
-      const response = await request(app).put("/api/user/steam-id").send({});
+      const response = await request(app).patch("/api/user/steam-id").send({});
 
       expect(response.status).toBe(400);
       expect(response.body).toEqual({ error: "Steam ID is required" });
@@ -50,7 +50,7 @@ describe("steamRoutes", () => {
     it("returns 400 when steamId format is invalid", async () => {
       vi.mocked(steamService.validateSteamId).mockReturnValue(false);
 
-      const response = await request(app).put("/api/user/steam-id").send({ steamId: "123" });
+      const response = await request(app).patch("/api/user/steam-id").send({ steamId: "123" });
 
       expect(response.status).toBe(400);
       expect(response.body.error).toContain("Invalid Steam ID format");
@@ -62,7 +62,7 @@ describe("steamRoutes", () => {
       vi.mocked(storage.updateUserSteamId).mockResolvedValue(undefined);
 
       const steamId = "76561198000000000";
-      const response = await request(app).put("/api/user/steam-id").send({ steamId });
+      const response = await request(app).patch("/api/user/steam-id").send({ steamId });
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual({ success: true, steamId });
@@ -74,7 +74,7 @@ describe("steamRoutes", () => {
       vi.mocked(storage.updateUserSteamId).mockRejectedValue(new Error("db failure"));
 
       const response = await request(app)
-        .put("/api/user/steam-id")
+        .patch("/api/user/steam-id")
         .send({ steamId: "76561198000000000" });
 
       expect(response.status).toBe(500);

--- a/server/downloaders.ts
+++ b/server/downloaders.ts
@@ -119,17 +119,24 @@ interface DownloadRequest {
   downloadType?: "torrent" | "usenet";
 }
 
+interface DownloaderActionResult {
+  success: boolean;
+  message: string;
+}
+
+interface DownloadResult extends DownloaderActionResult {
+  id?: string;
+}
+
 interface DownloaderClient {
-  testConnection(): Promise<{ success: boolean; message: string }>;
-  addDownload(
-    request: DownloadRequest
-  ): Promise<{ success: boolean; id?: string; message: string }>;
+  testConnection(): Promise<DownloaderActionResult>;
+  addDownload(request: DownloadRequest): Promise<DownloadResult>;
   getDownloadStatus(id: string): Promise<DownloadStatus | null>;
   getDownloadDetails(id: string): Promise<DownloadDetails | null>;
   getAllDownloads(): Promise<DownloadStatus[]>;
-  pauseDownload(id: string): Promise<{ success: boolean; message: string }>;
-  resumeDownload(id: string): Promise<{ success: boolean; message: string }>;
-  removeDownload(id: string, deleteFiles?: boolean): Promise<{ success: boolean; message: string }>;
+  pauseDownload(id: string): Promise<DownloaderActionResult>;
+  resumeDownload(id: string): Promise<DownloaderActionResult>;
+  removeDownload(id: string, deleteFiles?: boolean): Promise<DownloaderActionResult>;
   getFreeSpace(): Promise<number>;
 }
 
@@ -3022,9 +3029,7 @@ export class DownloaderManager {
     }
   }
 
-  static async testDownloader(
-    downloader: Downloader
-  ): Promise<{ success: boolean; message: string }> {
+  static async testDownloader(downloader: Downloader): Promise<DownloaderActionResult> {
     try {
       const client = this.createClient(downloader);
       return await client.testConnection();
@@ -3037,7 +3042,7 @@ export class DownloaderManager {
   static async addDownload(
     downloader: Downloader,
     request: DownloadRequest
-  ): Promise<{ success: boolean; id?: string; message: string }> {
+  ): Promise<DownloadResult> {
     try {
       const client = this.createClient(downloader);
       return await client.addDownload(request);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -913,7 +913,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const gameData = insertGameSchema.parse({ ...req.body, userId });
 
         const userGames = await storage.getUserGames(userId, true); // Check against all games including hidden
-        const existingGame = userGames.find((g) => g.igdbId === gameData.igdbId);
+        const existingGame = userGames.find((g) =>
+          gameData.igdbId != null
+            ? g.igdbId === gameData.igdbId
+            : g.title.toLowerCase() === gameData.title.toLowerCase()
+        );
 
         if (existingGame) {
           return res.status(409).json({ error: "Game already in collection", game: existingGame });
@@ -1017,7 +1021,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   );
 
   // Refresh metadata for all games
-  app.post("/api/games/refresh-metadata", async (req, res) => {
+  app.post("/api/games/refresh-metadata", igdbRateLimiter, async (req, res) => {
     try {
       const userId = req.user!.id;
       const userGames = await storage.getUserGames(userId, true);
@@ -1281,9 +1285,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/games/discover", igdbRateLimiter, async (req, res) => {
     try {
       const limit = req.query.limit ? parseInt(req.query.limit as string) : 20;
+      const userId = req.user!.id;
 
       // Get user's current games for recommendations
-      const userGames = await storage.getAllGames();
+      const userGames = await storage.getUserGames(userId, true);
 
       // Get recommendations from IGDB
       const igdbGames = await igdbClient.getRecommendations(
@@ -2288,7 +2293,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Notification routes
-  app.get("/api/notifications", async (req, res) => {
+  app.get("/api/notifications", authenticateToken, async (req, res) => {
     try {
       const limit = req.query.limit ? parseInt(req.query.limit as string) : 50;
       const notifications = await storage.getNotifications(limit);
@@ -2299,7 +2304,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.get("/api/notifications/unread-count", async (req, res) => {
+  app.get("/api/notifications/unread-count", authenticateToken, async (req, res) => {
     try {
       const count = await storage.getUnreadNotificationsCount();
       res.json({ count });
@@ -2309,7 +2314,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.post("/api/notifications", validateRequest, async (req, res) => {
+  app.post("/api/notifications", authenticateToken, validateRequest, async (req, res) => {
     try {
       const notificationData = insertNotificationSchema.parse(req.body);
       const notification = await storage.addNotification(notificationData);
@@ -2331,7 +2336,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.put("/api/notifications/:id/read", async (req, res) => {
+  app.put("/api/notifications/:id/read", authenticateToken, async (req, res) => {
     try {
       const { id } = req.params;
       const notification = await storage.markNotificationAsRead(id);
@@ -2345,7 +2350,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.put("/api/notifications/read-all", async (req, res) => {
+  app.put("/api/notifications/read-all", authenticateToken, async (req, res) => {
     try {
       await storage.markAllNotificationsAsRead();
       res.json({ success: true });
@@ -2355,7 +2360,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.delete("/api/notifications", async (req, res) => {
+  app.delete("/api/notifications", authenticateToken, async (req, res) => {
     try {
       await storage.clearAllNotifications();
       res.status(204).send();
@@ -2779,7 +2784,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       // Check for existing
       const userGames = await storage.getUserGames(userId, true);
-      const existingGame = userGames.find((g) => g.igdbId === gameData.igdbId);
+      const existingGame = userGames.find((g) =>
+        gameData.igdbId != null
+          ? g.igdbId === gameData.igdbId
+          : g.title.toLowerCase() === gameData.title.toLowerCase()
+      );
 
       if (existingGame) {
         return res.status(409).json({ error: "Game already in collection", game: existingGame });
@@ -2866,7 +2875,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (!success) {
         return res.status(404).json({ error: "Feed not found" });
       }
-      res.json({ success: true });
+      res.status(204).send();
     } catch (error) {
       routesLogger.error({ error }, "Failed to delete RSS feed");
       res.status(500).json({ error: "Failed to delete RSS feed" });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2163,9 +2163,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.get("/api/downloads/summary", authenticateToken, async (_req, res) => {
+  app.get("/api/downloads/summary", authenticateToken, async (req, res) => {
     try {
-      const summary = await storage.getDownloadSummaryByGame();
+      const summary = await storage.getDownloadSummaryByGame(req.user!.id);
       res.json(summary);
     } catch (error) {
       routesLogger.error({ module: "routes", error }, "Failed to get download summary");
@@ -2925,6 +2925,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const { image, message } = req.body as { image?: string; message?: string };
       if (!image) return res.status(400).json({ error: "No image data provided" });
+
+      if (!/^data:image\/(png|jpeg|gif|webp);base64,/.test(image)) {
+        return res
+          .status(400)
+          .json({ error: "Invalid image format. Only PNG, JPEG, GIF, and WebP are supported." });
+      }
 
       const base64Data = image.split(",")[1];
       if (!base64Data) return res.status(400).json({ error: "Invalid image data" });

--- a/server/steam-routes.ts
+++ b/server/steam-routes.ts
@@ -8,7 +8,7 @@ import { type User } from "@shared/schema";
 const router = Router();
 
 // Manual Steam ID Update
-router.put("/api/user/steam-id", authenticateToken, async (req, res) => {
+router.patch("/api/user/steam-id", authenticateToken, async (req, res) => {
   try {
     const { steamId } = req.body;
     const user = req.user as User;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -82,7 +82,11 @@ export interface IStorage {
   addGame(game: InsertGame): Promise<Game>;
   updateGameStatus(id: string, statusUpdate: UpdateGameStatus): Promise<Game | undefined>;
   updateGameHidden(id: string, hidden: boolean): Promise<Game | undefined>;
-  updateGameUserRating(id: string, userId: string, userRating: number | null): Promise<Game | undefined>;
+  updateGameUserRating(
+    id: string,
+    userId: string,
+    userRating: number | null
+  ): Promise<Game | undefined>;
   updateGameSearchResultsAvailable(gameId: string, available: boolean): Promise<void>;
   updateGame(id: string, updates: Partial<Game>): Promise<Game | undefined>;
   updateGamesBatch(updates: { id: string; data: Partial<Game> }[]): Promise<void>;
@@ -115,7 +119,7 @@ export interface IStorage {
   ): Promise<(GameDownload & { downloaderName: string | null })[]>;
   updateGameDownloadStatus(id: string, status: string): Promise<void>;
   addGameDownload(gameDownload: InsertGameDownload): Promise<GameDownload>;
-  getDownloadSummaryByGame(): Promise<Record<string, DownloadSummary>>;
+  getDownloadSummaryByGame(userId: string): Promise<Record<string, DownloadSummary>>;
   getTrackedDownloadKeys(): Promise<Set<string>>;
 
   // Notification methods
@@ -383,7 +387,11 @@ export class MemStorage implements IStorage {
     return updatedGame;
   }
 
-  async updateGameUserRating(id: string, userId: string, userRating: number | null): Promise<Game | undefined> {
+  async updateGameUserRating(
+    id: string,
+    userId: string,
+    userRating: number | null
+  ): Promise<Game | undefined> {
     const game = this.games.get(id);
     if (!game || game.userId !== userId) return undefined;
 
@@ -678,10 +686,16 @@ export class MemStorage implements IStorage {
     return keys;
   }
 
-  async getDownloadSummaryByGame(): Promise<Record<string, DownloadSummary>> {
+  async getDownloadSummaryByGame(userId: string): Promise<Record<string, DownloadSummary>> {
+    const userGameIds = new Set(
+      Array.from(this.games.values())
+        .filter((g) => g.userId === userId)
+        .map((g) => g.id)
+    );
     const result: Record<string, DownloadSummary> = {};
     for (const gd of Array.from(this.gameDownloads.values())) {
       const gameId = gd.gameId;
+      if (!userGameIds.has(gameId)) continue;
       const status = gd.status as DownloadSummary["topStatus"];
       const downloadType = (gd.downloadType ?? "torrent") as "torrent" | "usenet";
       if (!result[gameId]) {
@@ -1208,7 +1222,11 @@ export class DatabaseStorage implements IStorage {
     return updatedGame || undefined;
   }
 
-  async updateGameUserRating(id: string, userId: string, userRating: number | null): Promise<Game | undefined> {
+  async updateGameUserRating(
+    id: string,
+    userId: string,
+    userRating: number | null
+  ): Promise<Game | undefined> {
     const [updatedGame] = await db
       .update(games)
       .set({ userRating })
@@ -1493,7 +1511,7 @@ export class DatabaseStorage implements IStorage {
     return new Set(rows.map((r) => `${r.downloaderId}:${r.downloadHash}`));
   }
 
-  async getDownloadSummaryByGame(): Promise<Record<string, DownloadSummary>> {
+  async getDownloadSummaryByGame(userId: string): Promise<Record<string, DownloadSummary>> {
     const rows = await db
       .select({
         gameId: gameDownloads.gameId,
@@ -1509,6 +1527,8 @@ export class DatabaseStorage implements IStorage {
         downloadTypes: sql<string>`group_concat(DISTINCT ${gameDownloads.downloadType})`,
       })
       .from(gameDownloads)
+      .innerJoin(games, eq(gameDownloads.gameId, games.id))
+      .where(eq(games.userId, userId))
       .groupBy(gameDownloads.gameId);
 
     return Object.fromEntries(

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -39,7 +39,7 @@ export const userSettings = sqliteTable("user_settings", {
     .notNull()
     .default(false),
   preferredPlatform: text("preferred_platform"),
-  updatedAt: integer("updated_at", { mode: "timestamp" }).default(
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" }).default(
     sql`(strftime('%s', 'now') * 1000)`
   ),
 });


### PR DESCRIPTION
1. DELETE /api/rss/feeds/:id — 200 → 204 (routes.ts:2869)
  Changed res.json({ success: true }) to res.status(204).send(). Updated the two test files 
  that asserted the old 200 status.

  2. GET /api/games/discover — scope leak (routes.ts:1282)
  Changed storage.getAllGames() to storage.getUserGames(req.user!.id, true) so
  recommendations are seeded from the requesting user's library only.

  3. PUT /api/user/steam-id → PATCH (steam-routes.ts:11)
  This is a partial update of one field, so the verb should be PATCH. Updated the route and 
  all test assertions in steam_routes.test.ts.

  4. Downloader named types (downloaders.ts)
  Extracted DownloaderActionResult and DownloadResult interfaces to replace the repeated    
  inline { success: boolean; message: string } / { success: boolean; id?: string; message:  
  string } across the DownloaderClient interface and the static manager methods.

  5. POST /api/games/refresh-metadata — no rate limit (routes.ts:1020)
  Added igdbRateLimiter to the middleware chain, consistent with all other IGDB-touching    
  endpoints.

  7. Duplicate title without igdbId (routes.ts:916, routes.ts:2787)
  Fixed the conflict check in both POST /api/games and POST /api/games/match-and-add. When  
  igdbId is present, deduplication is by igdbId as before; when absent (null/undefined), it 
  falls back to case-insensitive title matching.

  8. POST /api/notifications — missing explicit auth (routes.ts:2291–2360)
  Added authenticateToken explicitly to all five notification routes (GET, GET unread-count,
   POST, PUT /:id/read, PUT /read-all, DELETE). There is no global
  app.use(authenticateToken) in this codebase, so these routes were genuinely
  unauthenticated.