### PR TITLE
Add labels support and implement download linking modals

### DIFF
--- a/client/src/components/ClaimBatchModal.tsx
+++ b/client/src/components/ClaimBatchModal.tsx
@@ -1,0 +1,417 @@
+import { useState, useEffect, useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Search, Link2, CheckCircle2, AlertCircle, Loader2, ChevronDown } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { type Game } from "@shared/schema";
+import { type DownloadCategory } from "@shared/download-categorizer";
+import { apiRequest } from "@/lib/queryClient";
+
+interface ScanDownload {
+  downloaderId: string;
+  downloaderName: string;
+  downloadId: string;
+  downloadHash: string;
+  downloadTitle: string;
+  status: string;
+  downloadType: "torrent" | "usenet";
+  category: DownloadCategory;
+  categoryConfidence: number;
+}
+
+interface ScanGroup {
+  baseTitle: string;
+  downloads: ScanDownload[];
+  libraryMatch: { game: Game; confidence: number } | null;
+}
+
+interface ScanResponse {
+  groups: ScanGroup[];
+}
+
+interface GroupState {
+  selectedGame: { id?: string; title: string; source: "library" | "igdb"; data: Game } | null;
+  skip: boolean;
+  igdbQuery: string;
+  igdbOpen: boolean;
+}
+
+interface ClaimBatchModalProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}
+
+const CATEGORY_LABELS: Record<DownloadCategory, string> = {
+  main: "Main",
+  update: "Update",
+  dlc: "DLC",
+  extra: "Extra",
+};
+
+const CATEGORY_COLORS: Record<DownloadCategory, string> = {
+  main: "bg-blue-500/20 text-blue-400",
+  update: "bg-yellow-500/20 text-yellow-400",
+  dlc: "bg-purple-500/20 text-purple-400",
+  extra: "bg-gray-500/20 text-gray-400",
+};
+
+export default function ClaimBatchModal({ open, onOpenChange }: ClaimBatchModalProps) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [groupStates, setGroupStates] = useState<Map<string, GroupState>>(new Map());
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+
+  const { data, isLoading, error } = useQuery<ScanResponse>({
+    queryKey: ["/api/downloads/scan"],
+    queryFn: () => apiRequest("GET", "/api/downloads/scan").then((r) => r.json()),
+    enabled: open,
+    staleTime: 0,
+  });
+
+  // Initialize group states when scan data arrives
+  useEffect(() => {
+    if (!data?.groups) return;
+    setGroupStates((prev) => {
+      const next = new Map(prev);
+      for (const group of data.groups) {
+        if (!next.has(group.baseTitle)) {
+          next.set(group.baseTitle, {
+            selectedGame: group.libraryMatch
+              ? {
+                  id: group.libraryMatch.game.id,
+                  title: group.libraryMatch.game.title,
+                  source: "library",
+                  data: group.libraryMatch.game,
+                }
+              : null,
+            skip: false,
+            igdbQuery: "",
+            igdbOpen: false,
+          });
+        }
+      }
+      return next;
+    });
+  }, [data]);
+
+  const updateGroup = useCallback((key: string, patch: Partial<GroupState>) => {
+    setGroupStates((prev) => {
+      const next = new Map(prev);
+      const cur = next.get(key);
+      if (cur) next.set(key, { ...cur, ...patch });
+      return next;
+    });
+  }, []);
+
+  const claimAllMutation = useMutation({
+    mutationFn: async () => {
+      if (!data?.groups) return;
+      const toProcess = data.groups.filter((g) => {
+        const state = groupStates.get(g.baseTitle);
+        return state && !state.skip && state.selectedGame;
+      });
+
+      setProgress({ done: 0, total: toProcess.length });
+
+      for (let i = 0; i < toProcess.length; i++) {
+        const group = toProcess[i];
+        const state = groupStates.get(group.baseTitle)!;
+        const selectedGame = state.selectedGame!;
+
+        for (const dl of group.downloads) {
+          const body: Record<string, unknown> = {
+            downloaderId: dl.downloaderId,
+            downloadHash: dl.downloadHash,
+            downloadTitle: dl.downloadTitle,
+            currentStatus: dl.status,
+            category: dl.category,
+          };
+
+          if (selectedGame.source === "library" && selectedGame.id) {
+            body.gameId = selectedGame.id;
+          } else {
+            const g = selectedGame.data;
+            body.newGame = {
+              igdbId: g.igdbId,
+              title: g.title,
+              coverUrl: g.coverUrl,
+              summary: g.summary,
+              releaseDate: g.releaseDate,
+              platforms: g.platforms,
+              genres: g.genres,
+              rating: g.rating,
+              aggregatedRating: g.aggregatedRating,
+              screenshots: g.screenshots,
+              igdbWebsites: g.igdbWebsites,
+              source: "api",
+            };
+          }
+
+          await apiRequest("POST", "/api/downloads/claim", body);
+        }
+
+        setProgress({ done: i + 1, total: toProcess.length });
+      }
+    },
+    onSuccess: () => {
+      toast({ title: `Linked ${progress?.total ?? 0} download group(s) to games` });
+      queryClient.invalidateQueries({ queryKey: ["/api/downloads"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/games"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/downloads/scan"] });
+      onOpenChange(false);
+    },
+    onError: (err: Error) => {
+      toast({ title: err.message || "Failed to claim downloads", variant: "destructive" });
+    },
+    onSettled: () => setProgress(null),
+  });
+
+  const pendingCount =
+    data?.groups.filter((g) => {
+      const state = groupStates.get(g.baseTitle);
+      return state && !state.skip && state.selectedGame;
+    }).length ?? 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Scan Unlinked Downloads</DialogTitle>
+          <DialogDescription>
+            Downloads not yet tracked by Questarr, grouped by game. Select a game for each to link
+            them.
+          </DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="flex-1 min-h-0 pr-2">
+          {isLoading && (
+            <div className="flex items-center justify-center py-12 gap-2 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Scanning downloads…
+            </div>
+          )}
+
+          {error && (
+            <div className="flex items-center gap-2 text-destructive py-8 justify-center">
+              <AlertCircle className="h-5 w-5" />
+              Failed to scan downloads
+            </div>
+          )}
+
+          {data && data.groups.length === 0 && (
+            <div className="flex items-center gap-2 text-muted-foreground py-8 justify-center">
+              <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+              All downloads are already linked to games
+            </div>
+          )}
+
+          {data &&
+            data.groups.map((group) => {
+              const state = groupStates.get(group.baseTitle);
+              if (!state) return null;
+              return (
+                <GroupRow
+                  key={group.baseTitle}
+                  group={group}
+                  state={state}
+                  onUpdate={(patch) => updateGroup(group.baseTitle, patch)}
+                />
+              );
+            })}
+        </ScrollArea>
+
+        {progress && (
+          <p className="text-sm text-muted-foreground text-center">
+            Claiming {progress.done} / {progress.total}…
+          </p>
+        )}
+
+        <div className="flex items-center justify-between gap-2 pt-2 border-t">
+          <span className="text-sm text-muted-foreground">{pendingCount} group(s) ready</span>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => claimAllMutation.mutate()}
+              disabled={pendingCount === 0 || claimAllMutation.isPending}
+            >
+              <Link2 className="h-4 w-4 mr-2" />
+              {claimAllMutation.isPending ? "Claiming…" : `Claim ${pendingCount}`}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function GroupRow({
+  group,
+  state,
+  onUpdate,
+}: {
+  group: ScanGroup;
+  state: GroupState;
+  onUpdate: (patch: Partial<GroupState>) => void;
+}) {
+  const [igdbDebouncedQuery, setIgdbDebouncedQuery] = useState("");
+
+  useEffect(() => {
+    const t = setTimeout(() => setIgdbDebouncedQuery(state.igdbQuery), 500);
+    return () => clearTimeout(t);
+  }, [state.igdbQuery]);
+
+  const { data: igdbResults = [], isLoading: searchingIgdb } = useQuery<Game[]>({
+    queryKey: ["/api/igdb/search", igdbDebouncedQuery],
+    queryFn: () =>
+      apiRequest(
+        "GET",
+        `/api/igdb/search?q=${encodeURIComponent(igdbDebouncedQuery)}&limit=6`
+      ).then((r) => r.json()),
+    enabled: state.igdbOpen && igdbDebouncedQuery.trim().length > 2,
+  });
+
+  const mainDownload = group.downloads.find((d) => d.category === "main") ?? group.downloads[0];
+
+  return (
+    <div
+      className={`border rounded-lg p-3 mb-3 transition-opacity ${state.skip ? "opacity-50" : ""}`}
+    >
+      <div className="flex items-start gap-3">
+        <Checkbox
+          id={`skip-${group.baseTitle}`}
+          checked={!state.skip}
+          onCheckedChange={(v) => onUpdate({ skip: !v })}
+          aria-label="Include this group"
+          className="mt-0.5"
+        />
+
+        <div className="flex-1 min-w-0">
+          {/* Downloads in group */}
+          <div className="space-y-1 mb-2">
+            {group.downloads.map((dl) => (
+              <div key={dl.downloadId} className="flex items-center gap-2 text-sm">
+                <span
+                  className={`text-xs px-1.5 py-0.5 rounded font-medium shrink-0 ${CATEGORY_COLORS[dl.category]}`}
+                >
+                  {CATEGORY_LABELS[dl.category]}
+                </span>
+                <span className="truncate text-muted-foreground">{dl.downloadTitle}</span>
+                <Badge variant="outline" className="text-xs shrink-0">
+                  {dl.status}
+                </Badge>
+              </div>
+            ))}
+          </div>
+
+          {/* Game match section */}
+          {state.selectedGame ? (
+            <div className="flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
+              <span className="text-sm font-medium truncate">{state.selectedGame.title}</span>
+              <Badge variant="secondary" className="text-xs shrink-0">
+                {state.selectedGame.source === "library" ? "Library" : "IGDB"}
+              </Badge>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs ml-auto"
+                onClick={() => onUpdate({ igdbOpen: !state.igdbOpen, igdbQuery: "" })}
+              >
+                Change
+                <ChevronDown className="h-3 w-3 ml-1" />
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <AlertCircle className="h-4 w-4 text-yellow-500 shrink-0" />
+              <span className="text-sm text-muted-foreground">No library match found</span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-6 px-2 text-xs ml-auto"
+                onClick={() =>
+                  onUpdate({
+                    igdbOpen: !state.igdbOpen,
+                    igdbQuery: state.igdbOpen ? state.igdbQuery : mainDownload.downloadTitle,
+                  })
+                }
+              >
+                <Search className="h-3 w-3 mr-1" />
+                Search IGDB
+              </Button>
+            </div>
+          )}
+
+          {/* Inline IGDB search */}
+          {state.igdbOpen && (
+            <div className="mt-2 space-y-1.5">
+              <div className="relative">
+                <Search className="absolute left-2 top-2 h-3.5 w-3.5 text-muted-foreground" />
+                <Input
+                  className="pl-7 h-8 text-sm"
+                  placeholder="Search IGDB…"
+                  value={state.igdbQuery}
+                  onChange={(e) => onUpdate({ igdbQuery: e.target.value })}
+                  autoFocus
+                />
+              </div>
+              <div className="max-h-36 overflow-y-auto space-y-1">
+                {searchingIgdb ? (
+                  <p className="text-xs text-muted-foreground py-1 px-1">Searching…</p>
+                ) : (
+                  igdbResults.map((g) => (
+                    <button
+                      key={g.igdbId ?? g.id}
+                      type="button"
+                      onClick={() => {
+                        onUpdate({
+                          selectedGame: {
+                            id: g.igdbId?.toString(),
+                            title: g.title,
+                            source: "igdb",
+                            data: g,
+                          },
+                          igdbOpen: false,
+                        });
+                      }}
+                      className="w-full flex items-center gap-2 px-2 py-1 rounded text-sm hover:bg-accent text-left"
+                    >
+                      {g.coverUrl ? (
+                        <img
+                          src={g.coverUrl}
+                          alt={g.title}
+                          className="h-8 w-6 object-cover rounded shrink-0"
+                        />
+                      ) : (
+                        <div className="h-8 w-6 rounded bg-muted shrink-0" />
+                      )}
+                      <span className="truncate">{g.title}</span>
+                      {g.releaseDate && (
+                        <span className="text-xs text-muted-foreground shrink-0">
+                          {new Date(g.releaseDate).getFullYear()}
+                        </span>
+                      )}
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/ClaimBatchModal.tsx
+++ b/client/src/components/ClaimBatchModal.tsx
@@ -129,7 +129,13 @@ export default function ClaimBatchModal({ open, onOpenChange }: ClaimBatchModalP
         const state = groupStates.get(group.baseTitle)!;
         const selectedGame = state.selectedGame!;
 
-        for (const dl of group.downloads) {
+        // Track the gameId returned by the first claim in this group so that
+        // subsequent downloads (updates, DLC, extras) link to the same game row
+        // instead of creating duplicate entries.
+        let resolvedGroupGameId: string | undefined =
+          selectedGame.source === "library" ? selectedGame.id : undefined;
+
+        const buildBody = (dl: (typeof group.downloads)[0], gid?: string) => {
           const body: Record<string, unknown> = {
             downloaderId: dl.downloaderId,
             downloadHash: dl.downloadHash,
@@ -137,9 +143,8 @@ export default function ClaimBatchModal({ open, onOpenChange }: ClaimBatchModalP
             currentStatus: dl.status,
             category: dl.category,
           };
-
-          if (selectedGame.source === "library" && selectedGame.id) {
-            body.gameId = selectedGame.id;
+          if (gid) {
+            body.gameId = gid;
           } else {
             const g = selectedGame.data;
             body.newGame = {
@@ -154,11 +159,38 @@ export default function ClaimBatchModal({ open, onOpenChange }: ClaimBatchModalP
               aggregatedRating: g.aggregatedRating,
               screenshots: g.screenshots,
               igdbWebsites: g.igdbWebsites,
-              source: "api",
             };
           }
+          return body;
+        };
 
-          await apiRequest("POST", "/api/downloads/claim", body);
+        if (!resolvedGroupGameId && group.downloads.length > 0) {
+          // Send the first download sequentially to obtain (or create) the game row,
+          // then parallelise the remaining downloads using the resolved game ID.
+          const first = group.downloads[0];
+          const firstResponse = await apiRequest(
+            "POST",
+            "/api/downloads/claim",
+            buildBody(first, undefined)
+          );
+          const firstResult = (await firstResponse.json()) as { gameId: string };
+          resolvedGroupGameId = firstResult?.gameId;
+
+          // Parallelize the remaining downloads now that we have a gameId
+          await Promise.all(
+            group.downloads
+              .slice(1)
+              .map((dl) =>
+                apiRequest("POST", "/api/downloads/claim", buildBody(dl, resolvedGroupGameId))
+              )
+          );
+        } else {
+          // Library game: all downloads already have a gameId — parallelise immediately
+          await Promise.all(
+            group.downloads.map((dl) =>
+              apiRequest("POST", "/api/downloads/claim", buildBody(dl, resolvedGroupGameId))
+            )
+          );
         }
 
         setProgress({ done: i + 1, total: toProcess.length });

--- a/client/src/components/ClaimDownloadModal.tsx
+++ b/client/src/components/ClaimDownloadModal.tsx
@@ -1,0 +1,332 @@
+import { useState, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Search, Link2, CheckCircle2 } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { type Game } from "@shared/schema";
+import { categorizeDownload, type DownloadCategory } from "@shared/download-categorizer";
+import { releaseMatchesGame } from "@shared/title-utils";
+import { apiRequest } from "@/lib/queryClient";
+
+interface ClaimDownload {
+  id: string;
+  name: string;
+  status: string;
+  downloadType?: "torrent" | "usenet";
+  downloaderId: string;
+  downloaderName: string;
+}
+
+interface ClaimDownloadModalProps {
+  download: ClaimDownload;
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}
+
+interface IgdbSearchResult extends Game {
+  inCollection?: boolean;
+}
+
+export default function ClaimDownloadModal({
+  download,
+  open,
+  onOpenChange,
+}: ClaimDownloadModalProps) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const detected = categorizeDownload(download.name);
+  const [category, setCategory] = useState<DownloadCategory>(detected.category);
+  const [librarySearch, setLibrarySearch] = useState("");
+  const [igdbQuery, setIgdbQuery] = useState("");
+  const [debouncedIgdbQuery, setDebouncedIgdbQuery] = useState("");
+  const [selectedGame, setSelectedGame] = useState<{
+    id: string;
+    title: string;
+    coverUrl?: string;
+    source: "library" | "igdb";
+    data: Game;
+  } | null>(null);
+
+  // Reset when download changes
+  useEffect(() => {
+    if (open) {
+      const d = categorizeDownload(download.name);
+      setCategory(d.category);
+      setLibrarySearch("");
+      setIgdbQuery("");
+      setDebouncedIgdbQuery("");
+      setSelectedGame(null);
+    }
+  }, [open, download.name]);
+
+  // Debounce IGDB query
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedIgdbQuery(igdbQuery), 500);
+    return () => clearTimeout(t);
+  }, [igdbQuery]);
+
+  // User's library
+  const { data: userGames = [] } = useQuery<Game[]>({
+    queryKey: ["/api/games"],
+  });
+
+  // Library matches: releaseMatchesGame first, then fall back to text filter
+  const libraryMatches = userGames.filter((g) => {
+    if (librarySearch.trim()) {
+      return g.title.toLowerCase().includes(librarySearch.toLowerCase());
+    }
+    return releaseMatchesGame(download.name, g.title);
+  });
+
+  // IGDB search
+  const { data: igdbResults = [], isLoading: isSearchingIgdb } = useQuery<IgdbSearchResult[]>({
+    queryKey: ["/api/igdb/search", debouncedIgdbQuery],
+    queryFn: async () => {
+      if (!debouncedIgdbQuery.trim()) return [];
+      const res = await apiRequest(
+        "GET",
+        `/api/igdb/search?q=${encodeURIComponent(debouncedIgdbQuery)}&limit=10`
+      );
+      return res.json();
+    },
+    enabled: debouncedIgdbQuery.trim().length > 2,
+  });
+
+  const claimMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedGame) throw new Error("No game selected");
+
+      const body: Record<string, unknown> = {
+        downloaderId: download.downloaderId,
+        downloadHash: download.id,
+        downloadTitle: download.name,
+        currentStatus: download.status,
+        category,
+      };
+
+      if (selectedGame.source === "library") {
+        body.gameId = selectedGame.id;
+      } else {
+        const g = selectedGame.data;
+        body.newGame = {
+          igdbId: g.igdbId,
+          title: g.title,
+          coverUrl: g.coverUrl,
+          summary: g.summary,
+          releaseDate: g.releaseDate,
+          platforms: g.platforms,
+          genres: g.genres,
+          rating: g.rating,
+          aggregatedRating: g.aggregatedRating,
+          screenshots: g.screenshots,
+          igdbWebsites: g.igdbWebsites,
+          source: "api",
+        };
+      }
+
+      const res = await apiRequest("POST", "/api/downloads/claim", body);
+      return res.json();
+    },
+    onSuccess: () => {
+      toast({ title: "Download linked to game" });
+      queryClient.invalidateQueries({ queryKey: ["/api/downloads"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/games"] });
+      onOpenChange(false);
+    },
+    onError: (err: Error) => {
+      toast({ title: err.message || "Failed to link download", variant: "destructive" });
+    },
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Link to Game</DialogTitle>
+          <DialogDescription className="truncate">{download.name}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-muted-foreground">Category:</span>
+          <Select value={category} onValueChange={(v) => setCategory(v as DownloadCategory)}>
+            <SelectTrigger className="w-36">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="main">Main</SelectItem>
+              <SelectItem value="update">Update</SelectItem>
+              <SelectItem value="dlc">DLC</SelectItem>
+              <SelectItem value="extra">Extra</SelectItem>
+            </SelectContent>
+          </Select>
+          <Badge variant="outline" className="text-xs">
+            {Math.round(detected.confidence * 100)}% confidence
+          </Badge>
+        </div>
+
+        <Tabs defaultValue="library" className="flex-1 flex flex-col min-h-0">
+          <TabsList>
+            <TabsTrigger value="library">Library</TabsTrigger>
+            <TabsTrigger value="igdb">IGDB Search</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="library" className="flex-1 flex flex-col gap-2 min-h-0">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Search your library…"
+                className="pl-8"
+                value={librarySearch}
+                onChange={(e) => setLibrarySearch(e.target.value)}
+              />
+            </div>
+            <div className="overflow-y-auto flex-1 space-y-1 pr-1">
+              {libraryMatches.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-4 text-center">
+                  {librarySearch
+                    ? "No games match your search"
+                    : "No library matches found — try IGDB Search"}
+                </p>
+              ) : (
+                libraryMatches.map((g) => (
+                  <GameRow
+                    key={g.id}
+                    game={g}
+                    selected={selectedGame?.id === g.id && selectedGame?.source === "library"}
+                    onSelect={() =>
+                      setSelectedGame({
+                        id: g.id,
+                        title: g.title,
+                        coverUrl: g.coverUrl ?? undefined,
+                        source: "library",
+                        data: g,
+                      })
+                    }
+                  />
+                ))
+              )}
+            </div>
+          </TabsContent>
+
+          <TabsContent value="igdb" className="flex-1 flex flex-col gap-2 min-h-0">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Search IGDB…"
+                className="pl-8"
+                value={igdbQuery}
+                onChange={(e) => setIgdbQuery(e.target.value)}
+              />
+            </div>
+            <div className="overflow-y-auto flex-1 space-y-1 pr-1">
+              {isSearchingIgdb ? (
+                <p className="text-sm text-muted-foreground py-4 text-center">Searching…</p>
+              ) : igdbResults.length === 0 && debouncedIgdbQuery ? (
+                <p className="text-sm text-muted-foreground py-4 text-center">No results found</p>
+              ) : (
+                igdbResults.map((g) => (
+                  <GameRow
+                    key={g.igdbId ?? g.id}
+                    game={g}
+                    selected={
+                      selectedGame?.source === "igdb" && selectedGame?.data.igdbId === g.igdbId
+                    }
+                    onSelect={() =>
+                      setSelectedGame({
+                        id: g.igdbId?.toString() ?? g.id,
+                        title: g.title,
+                        coverUrl: g.coverUrl ?? undefined,
+                        source: "igdb",
+                        data: g,
+                      })
+                    }
+                  />
+                ))
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
+
+        {selectedGame && (
+          <div className="flex items-center gap-2 py-2 px-3 rounded-md bg-muted text-sm">
+            <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0" />
+            <span className="truncate font-medium">{selectedGame.title}</span>
+            <Badge variant="secondary" className="ml-auto shrink-0 text-xs">
+              {selectedGame.source === "library" ? "Library" : "IGDB"}
+            </Badge>
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => claimMutation.mutate()}
+            disabled={!selectedGame || claimMutation.isPending}
+          >
+            <Link2 className="h-4 w-4 mr-2" />
+            {claimMutation.isPending ? "Linking…" : "Link Download"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function GameRow({
+  game,
+  selected,
+  onSelect,
+}: {
+  game: Game;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`w-full flex items-center gap-3 p-2 rounded-md text-left hover:bg-accent transition-colors ${
+        selected ? "bg-accent ring-1 ring-primary" : ""
+      }`}
+    >
+      {game.coverUrl ? (
+        <img
+          src={game.coverUrl}
+          alt={game.title}
+          className="h-10 w-8 object-cover rounded shrink-0"
+        />
+      ) : (
+        <div className="h-10 w-8 rounded bg-muted shrink-0" />
+      )}
+      <div className="flex-1 min-w-0">
+        <p className="font-medium text-sm truncate">{game.title}</p>
+        {game.releaseDate && (
+          <p className="text-xs text-muted-foreground">
+            {new Date(game.releaseDate).getFullYear()}
+          </p>
+        )}
+      </div>
+      {selected && <CheckCircle2 className="h-4 w-4 text-primary shrink-0" />}
+    </button>
+  );
+}

--- a/client/src/components/ClaimDownloadModal.tsx
+++ b/client/src/components/ClaimDownloadModal.tsx
@@ -321,9 +321,7 @@ function GameRow({
       <div className="flex-1 min-w-0">
         <p className="font-medium text-sm truncate">{game.title}</p>
         {game.releaseDate && (
-          <p className="text-xs text-muted-foreground">
-            {new Date(game.releaseDate).getFullYear()}
-          </p>
+          <p className="text-xs text-muted-foreground">{game.releaseDate.substring(0, 4)}</p>
         )}
       </div>
       {selected && <CheckCircle2 className="h-4 w-4 text-primary shrink-0" />}

--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -803,7 +803,7 @@ export default function Downloads() {
       )}
 
       {/* Link to Game Modal */}
-      <Suspense>
+      <Suspense fallback={<div className="fixed inset-0 bg-background/80 backdrop-blur-sm" />}>
         {claimTarget && (
           <ClaimDownloadModal
             download={claimTarget}
@@ -816,7 +816,7 @@ export default function Downloads() {
       </Suspense>
 
       {/* Batch Scan Modal */}
-      <Suspense>
+      <Suspense fallback={<div className="fixed inset-0 bg-background/80 backdrop-blur-sm" />}>
         <ClaimBatchModal open={batchModalOpen} onOpenChange={setBatchModalOpen} />
       </Suspense>
     </div>

--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, lazy, Suspense } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { queryClient } from "@/lib/queryClient";
 import {
@@ -33,6 +33,8 @@ import {
   Download,
   Newspaper,
   Tag,
+  ScanLine,
+  Link2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -47,6 +49,8 @@ import {
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
 import DownloadDetailsModal from "@/components/DownloadDetailsModal";
+const ClaimDownloadModal = lazy(() => import("@/components/ClaimDownloadModal"));
+const ClaimBatchModal = lazy(() => import("@/components/ClaimBatchModal"));
 
 interface DownloadStatus {
   id: string;
@@ -114,6 +118,8 @@ export default function Downloads() {
   const [statusFilter, setStatusFilter] = useState<DownloadStatusType | "all">("all");
   const [typeFilter, setTypeFilter] = useState<DownloadType | "all">("all");
   const [questarrFilter, setQuestarrFilter] = useState<"all" | "questarr">("all");
+  const [claimTarget, setClaimTarget] = useState<DownloadStatus | null>(null);
+  const [batchModalOpen, setBatchModalOpen] = useState(false);
 
   const {
     data: downloadsData,
@@ -478,6 +484,17 @@ export default function Downloads() {
             </TabsList>
           </Tabs>
         </div>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setBatchModalOpen(true)}
+          className="ml-auto flex items-center gap-2"
+          aria-label="Scan unlinked downloads"
+        >
+          <ScanLine className="h-4 w-4" />
+          Scan Unlinked
+        </Button>
       </div>
 
       {/* Category filter banner */}
@@ -684,6 +701,13 @@ export default function Downloads() {
                           View Details
                         </DropdownMenuItem>
                         <DropdownMenuItem
+                          onClick={() => setClaimTarget(download)}
+                          data-testid={`button-link-${download.id}`}
+                        >
+                          <Link2 className="h-4 w-4 mr-2" />
+                          Link to Game
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
                           onClick={() => handleRemove(download, false)}
                           data-testid={`button-remove-${download.id}`}
                         >
@@ -777,6 +801,24 @@ export default function Downloads() {
           onOpenChange={setDetailsModalOpen}
         />
       )}
+
+      {/* Link to Game Modal */}
+      <Suspense>
+        {claimTarget && (
+          <ClaimDownloadModal
+            download={claimTarget}
+            open={!!claimTarget}
+            onOpenChange={(v) => {
+              if (!v) setClaimTarget(null);
+            }}
+          />
+        )}
+      </Suspense>
+
+      {/* Batch Scan Modal */}
+      <Suspense>
+        <ClaimBatchModal open={batchModalOpen} onOpenChange={setBatchModalOpen} />
+      </Suspense>
     </div>
   );
 }

--- a/migrations/0014_sync_snapshot.sql
+++ b/migrations/0014_sync_snapshot.sql
@@ -2,3 +2,4 @@
 -- Migrations 0010–0013 were created manually without generating Drizzle snapshots,
 -- so the snapshot was stuck at 0009 and db:generate kept regenerating those columns.
 -- This file exists solely to bring the Drizzle snapshot up to date with the actual schema.
+SELECT 1;

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -99,6 +99,7 @@ describe("/api/downloads endpoint", () => {
               peersGettingFromUs: 5,
               uploadRatio: 1.5,
               errorString: "",
+              labels: ["games"], // matches the downloader's configured category
             },
           ],
         },
@@ -215,6 +216,7 @@ describe("/api/downloads endpoint", () => {
               peersGettingFromUs: 5,
               uploadRatio: 1.5,
               errorString: "",
+              labels: ["games"], // matches the downloader's configured category
             },
           ],
         },

--- a/server/downloaders.ts
+++ b/server/downloaders.ts
@@ -66,6 +66,7 @@ interface TransmissionTorrent {
     lastAnnounceTime: number;
     nextAnnounceTime?: number;
   }>;
+  labels?: string[];
   [key: string]: unknown;
 }
 
@@ -542,6 +543,7 @@ export class TransmissionClient implements DownloaderClient {
         "uploadRatio",
         "errorString",
         "hashString", // Required for matching downloads by hash
+        "labels", // Transmission 2.8+: used as category identifier
       ],
     });
 
@@ -660,6 +662,7 @@ export class TransmissionClient implements DownloaderClient {
       leechers: torrent.peersGettingFromUs,
       ratio: torrent.uploadRatio,
       error: torrent.errorString || undefined,
+      category: torrent.labels?.[0],
     };
   }
 
@@ -3031,30 +3034,7 @@ export class DownloaderManager {
 
   static async getAllDownloads(downloader: Downloader): Promise<DownloadStatus[]> {
     const client = this.createClient(downloader);
-    const downloads = await client.getAllDownloads();
-
-    // Filter by configured category if set
-    if (downloader.category) {
-      const filterCategory = downloader.category.toLowerCase();
-      return downloads.filter((t) => {
-        // Strict category match if available
-        if (t.category) {
-          return t.category.toLowerCase() === filterCategory;
-        }
-
-        // If category is missing in the download status:
-        // For clients that support categories (rTorrent, qBittorrent, Usenet), missing category means "Uncategorized",
-        // so we exclude it if a filter is active.
-        // For Transmission, we haven't implemented category mapping yet, so we include everything to avoid hiding all downloads.
-        if (downloader.type === "transmission") {
-          return true;
-        }
-
-        return false;
-      });
-    }
-
-    return downloads;
+    return client.getAllDownloads();
   }
 
   static async getDownloadStatus(

--- a/server/downloaders.ts
+++ b/server/downloaders.ts
@@ -3034,7 +3034,21 @@ export class DownloaderManager {
 
   static async getAllDownloads(downloader: Downloader): Promise<DownloadStatus[]> {
     const client = this.createClient(downloader);
-    return client.getAllDownloads();
+    const downloads = await client.getAllDownloads();
+
+    // Filter by configured category if set
+    if (downloader.category) {
+      const filterCategory = downloader.category.toLowerCase();
+      return downloads.filter((t) => {
+        if (t.category) {
+          return t.category.toLowerCase() === filterCategory;
+        }
+        // No category on the download item means it is uncategorised — exclude when a filter is active.
+        return false;
+      });
+    }
+
+    return downloads;
   }
 
   static async getDownloadStatus(

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -17,6 +17,7 @@ import {
   updatePasswordSchema,
   insertRssFeedSchema,
   insertReleaseBlacklistSchema,
+  claimDownloadRequestSchema,
   type Config,
   type Game,
   type Indexer,
@@ -2190,7 +2191,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const userId = req.user!.id;
       const enabledDownloaders = await storage.getEnabledDownloaders();
-      const trackedKeys = await storage.getTrackedDownloadKeys();
+      const rawTrackedKeys = await storage.getTrackedDownloadKeys();
+      // Normalise to lowercase so case differences in stored vs. live hashes never cause false "untracked" results
+      const trackedKeys = new Set(Array.from(rawTrackedKeys).map((k) => k.toLowerCase()));
 
       // Fetch downloads from all downloaders in parallel
       const allDownloads: Array<{
@@ -2221,8 +2224,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
                 });
               }
             }
-          } catch {
-            // Skip downloaders that fail
+          } catch (error) {
+            routesLogger.warn(
+              { error, downloaderName: downloader.name },
+              "Failed to fetch downloads from downloader during scan, skipping."
+            );
           }
         })
       );
@@ -2248,13 +2254,22 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Try to match each group against user's library
       const userGames = await storage.getUserGames(userId, false);
 
+      // Pre-calculate cleaned download titles and normalised game titles to avoid
+      // redundant string operations inside the O(N×M) matching loop.
+      const normalizedGameTitles = userGames.map((game) => ({
+        game,
+        normTitle: normalizeTitle(game.title),
+      }));
+
       const groups = Array.from(groupMap.values()).map((group) => {
+        const cleanedDlTitles = group.downloads.map((d) => cleanReleaseName(d.downloadTitle));
+
         // Find best library match using any download in the group
         let libraryMatch: { game: (typeof userGames)[0]; confidence: number } | null = null;
 
-        outer: for (const game of userGames) {
-          for (const d of group.downloads) {
-            if (releaseMatchesGame(d.downloadTitle, game.title)) {
+        outer: for (const { game } of normalizedGameTitles) {
+          for (let i = 0; i < group.downloads.length; i++) {
+            if (releaseMatchesGame(cleanedDlTitles[i], game.title)) {
               libraryMatch = { game, confidence: 0.9 };
               break outer;
             }
@@ -2281,6 +2296,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/downloads/claim", authenticateToken, async (req, res) => {
     try {
       const userId = req.user!.id;
+
+      const parsed = claimDownloadRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res.status(400).json({ error: "Invalid request", details: parsed.error.errors });
+      }
       const {
         downloaderId,
         downloadHash,
@@ -2289,31 +2309,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         category,
         gameId,
         newGame,
-      } = req.body as {
-        downloaderId: string;
-        downloadHash: string;
-        downloadTitle: string;
-        currentStatus: string;
-        category: "main" | "update" | "dlc" | "extra";
-        gameId?: string;
-        newGame?: {
-          igdbId?: number;
-          title: string;
-          coverUrl?: string;
-          summary?: string;
-          releaseDate?: string;
-          platforms?: string[];
-          genres?: string[];
-          rating?: number;
-          aggregatedRating?: number;
-          screenshots?: string[];
-          igdbWebsites?: { category: number; url: string }[];
-        };
-      };
+      } = parsed.data;
 
-      if (!downloaderId || !downloadHash || !downloadTitle || !currentStatus || !category) {
-        return res.status(400).json({ error: "Missing required fields" });
-      }
       if (!gameId && !newGame) {
         return res.status(400).json({ error: "Provide either gameId or newGame" });
       }
@@ -2349,22 +2346,42 @@ export async function registerRoutes(app: Express): Promise<Server> {
           }
         }
       } else {
-        // Determine initial game status
-        const initialGameStatus =
-          category === "main"
-            ? downloadStatus === "completed"
-              ? "owned"
-              : "downloading"
-            : "wanted";
+        // Avoid duplicates: reuse an existing library entry for the same IGDB game
+        if (newGame!.igdbId != null) {
+          const existing = await storage.getGameByIgdbId(newGame!.igdbId);
+          if (existing && existing.userId === userId) {
+            resolvedGameId = existing.id;
+            if (category === "main") {
+              const targetStatus = downloadStatus === "completed" ? "owned" : "downloading";
+              if (
+                (targetStatus === "downloading" && existing.status === "wanted") ||
+                (targetStatus === "owned" &&
+                  (existing.status === "wanted" || existing.status === "downloading"))
+              ) {
+                await storage.updateGameStatus(existing.id, { status: targetStatus });
+              }
+            }
+          }
+        }
 
-        const game = await storage.addGame(
-          insertGameSchema.parse({
-            ...newGame,
-            userId,
-            status: initialGameStatus,
-          })
-        );
-        resolvedGameId = game.id;
+        if (!resolvedGameId!) {
+          // Determine initial game status
+          const initialGameStatus =
+            category === "main"
+              ? downloadStatus === "completed"
+                ? "owned"
+                : "downloading"
+              : "wanted";
+
+          const game = await storage.addGame(
+            insertGameSchema.parse({
+              ...newGame,
+              userId,
+              status: initialGameStatus,
+            })
+          );
+          resolvedGameId = game.id;
+        }
       }
 
       const downloader = await storage.getDownloader(downloaderId);
@@ -2383,6 +2400,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
           status: downloadStatus,
         })
       );
+
+      // Clear stale "search results available" flag now that the game has a linked download
+      await storage.updateGameSearchResultsAvailable(resolvedGameId, false);
 
       res.json({ success: true, gameId: resolvedGameId });
     } catch (error) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -6,6 +6,7 @@ import { db } from "./db.js";
 import { sql } from "drizzle-orm";
 import {
   insertGameSchema,
+  insertGameDownloadSchema,
   updateGameStatusSchema,
   updateGameHiddenSchema,
   updateGameUserRatingSchema,
@@ -66,7 +67,8 @@ const upload = multer({
 });
 import { searchAllIndexers, filterBlacklistedReleases } from "./search.js";
 import { xrelClient, DEFAULT_XREL_BASE, ALLOWED_XREL_DOMAINS } from "./xrel.js";
-import { normalizeTitle, cleanReleaseName } from "../shared/title-utils.js";
+import { normalizeTitle, cleanReleaseName, releaseMatchesGame } from "../shared/title-utils.js";
+import { categorizeDownload } from "../shared/download-categorizer.js";
 import archiver from "archiver";
 import helmet from "helmet";
 import { steamRoutes } from "./steam-routes.js";
@@ -2180,6 +2182,212 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       routesLogger.error({ module: "routes", error }, "Failed to get download summary");
       res.status(500).json({ error: "Failed to get download summary" });
+    }
+  });
+
+  // Scan all downloads and return those not yet linked to any game, grouped by base title with library matches
+  app.get("/api/downloads/scan", authenticateToken, async (req, res) => {
+    try {
+      const userId = req.user!.id;
+      const enabledDownloaders = await storage.getEnabledDownloaders();
+      const trackedKeys = await storage.getTrackedDownloadKeys();
+
+      // Fetch downloads from all downloaders in parallel
+      const allDownloads: Array<{
+        downloaderId: string;
+        downloaderName: string;
+        downloadId: string;
+        downloadHash: string;
+        downloadTitle: string;
+        status: string;
+        downloadType: "torrent" | "usenet";
+      }> = [];
+
+      await Promise.all(
+        enabledDownloaders.map(async (downloader) => {
+          try {
+            const downloads = await DownloaderManager.getAllDownloads(downloader);
+            for (const d of downloads) {
+              const key = `${downloader.id}:${d.id.toLowerCase()}`;
+              if (!trackedKeys.has(key)) {
+                allDownloads.push({
+                  downloaderId: downloader.id,
+                  downloaderName: downloader.name,
+                  downloadId: d.id,
+                  downloadHash: d.id.toLowerCase(),
+                  downloadTitle: d.name,
+                  status: d.status,
+                  downloadType: d.downloadType ?? "torrent",
+                });
+              }
+            }
+          } catch {
+            // Skip downloaders that fail
+          }
+        })
+      );
+
+      // Categorize and group by normalized base title
+      type DownloadScanItem = (typeof allDownloads)[0] & {
+        category: string;
+        categoryConfidence: number;
+      };
+      const groupMap = new Map<string, { baseTitle: string; downloads: DownloadScanItem[] }>();
+
+      for (const d of allDownloads) {
+        const { category, confidence } = categorizeDownload(d.downloadTitle);
+        const baseTitle = normalizeTitle(cleanReleaseName(d.downloadTitle));
+        const key = baseTitle || normalizeTitle(d.downloadTitle);
+
+        if (!groupMap.has(key)) {
+          groupMap.set(key, { baseTitle: key, downloads: [] });
+        }
+        groupMap.get(key)!.downloads.push({ ...d, category, categoryConfidence: confidence });
+      }
+
+      // Try to match each group against user's library
+      const userGames = await storage.getUserGames(userId, false);
+
+      const groups = Array.from(groupMap.values()).map((group) => {
+        // Find best library match using any download in the group
+        let libraryMatch: { game: (typeof userGames)[0]; confidence: number } | null = null;
+
+        outer: for (const game of userGames) {
+          for (const d of group.downloads) {
+            if (releaseMatchesGame(d.downloadTitle, game.title)) {
+              libraryMatch = { game, confidence: 0.9 };
+              break outer;
+            }
+          }
+        }
+
+        return {
+          baseTitle: group.baseTitle,
+          downloads: group.downloads,
+          libraryMatch: libraryMatch
+            ? { game: libraryMatch.game, confidence: libraryMatch.confidence }
+            : null,
+        };
+      });
+
+      res.json({ groups });
+    } catch (error) {
+      routesLogger.error({ error }, "error scanning downloads");
+      res.status(500).json({ error: "Failed to scan downloads" });
+    }
+  });
+
+  // Claim (link) a download client entry to a game in the library
+  app.post("/api/downloads/claim", authenticateToken, async (req, res) => {
+    try {
+      const userId = req.user!.id;
+      const {
+        downloaderId,
+        downloadHash,
+        downloadTitle,
+        currentStatus,
+        category,
+        gameId,
+        newGame,
+      } = req.body as {
+        downloaderId: string;
+        downloadHash: string;
+        downloadTitle: string;
+        currentStatus: string;
+        category: "main" | "update" | "dlc" | "extra";
+        gameId?: string;
+        newGame?: {
+          igdbId?: number;
+          title: string;
+          coverUrl?: string;
+          summary?: string;
+          releaseDate?: string;
+          platforms?: string[];
+          genres?: string[];
+          rating?: number;
+          aggregatedRating?: number;
+          screenshots?: string[];
+          igdbWebsites?: { category: number; url: string }[];
+        };
+      };
+
+      if (!downloaderId || !downloadHash || !downloadTitle || !currentStatus || !category) {
+        return res.status(400).json({ error: "Missing required fields" });
+      }
+      if (!gameId && !newGame) {
+        return res.status(400).json({ error: "Provide either gameId or newGame" });
+      }
+
+      // Determine download status for gameDownloads record
+      const downloadStatus =
+        currentStatus === "completed" || currentStatus === "seeding"
+          ? "completed"
+          : currentStatus === "downloading"
+            ? "downloading"
+            : currentStatus === "paused"
+              ? "paused"
+              : "downloading";
+
+      let resolvedGameId: string;
+
+      if (gameId) {
+        const existing = await storage.getGame(gameId);
+        if (!existing || existing.userId !== userId) {
+          return res.status(404).json({ error: "Game not found" });
+        }
+        resolvedGameId = gameId;
+
+        // Update game status if this is the main download
+        if (category === "main") {
+          const targetStatus = downloadStatus === "completed" ? "owned" : "downloading";
+          if (
+            (targetStatus === "downloading" && existing.status === "wanted") ||
+            (targetStatus === "owned" &&
+              (existing.status === "wanted" || existing.status === "downloading"))
+          ) {
+            await storage.updateGameStatus(existing.id, { status: targetStatus });
+          }
+        }
+      } else {
+        // Determine initial game status
+        const initialGameStatus =
+          category === "main"
+            ? downloadStatus === "completed"
+              ? "owned"
+              : "downloading"
+            : "wanted";
+
+        const game = await storage.addGame(
+          insertGameSchema.parse({
+            ...newGame,
+            userId,
+            status: initialGameStatus,
+          })
+        );
+        resolvedGameId = game.id;
+      }
+
+      const downloader = await storage.getDownloader(downloaderId);
+      if (!downloader) {
+        return res.status(404).json({ error: "Downloader not found" });
+      }
+
+      await storage.addGameDownload(
+        insertGameDownloadSchema.parse({
+          gameId: resolvedGameId,
+          downloaderId,
+          downloadHash: downloadHash.toLowerCase(),
+          downloadTitle,
+          downloadType:
+            downloader.type === "sabnzbd" || downloader.type === "nzbget" ? "usenet" : "torrent",
+          status: downloadStatus,
+        })
+      );
+
+      res.json({ success: true, gameId: resolvedGameId });
+    } catch (error) {
+      routesLogger.error({ error }, "error claiming download");
+      res.status(500).json({ error: "Failed to claim download" });
     }
   });
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -276,6 +276,32 @@ export const insertGameDownloadSchema = createInsertSchema(gameDownloads).omit({
 // Legacy schema name for backward compatibility
 export const insertGameDownloadLegacySchema = insertGameDownloadSchema;
 
+// Request body schema for the claim-download endpoint
+export const claimDownloadRequestSchema = z.object({
+  downloaderId: z.string().min(1),
+  downloadHash: z.string().min(1),
+  downloadTitle: z.string().min(1),
+  currentStatus: z.string().min(1),
+  category: z.enum(["main", "update", "dlc", "extra"]),
+  gameId: z.string().optional(),
+  newGame: z
+    .object({
+      igdbId: z.number().int().optional(),
+      title: z.string().min(1),
+      coverUrl: z.string().optional(),
+      summary: z.string().optional(),
+      releaseDate: z.string().optional(),
+      platforms: z.array(z.string()).optional(),
+      genres: z.array(z.string()).optional(),
+      rating: z.number().optional(),
+      aggregatedRating: z.number().optional(),
+      screenshots: z.array(z.string()).optional(),
+      igdbWebsites: z.array(z.object({ category: z.number(), url: z.string() })).optional(),
+    })
+    .optional(),
+});
+export type ClaimDownloadRequest = z.infer<typeof claimDownloadRequestSchema>;
+
 export const insertNotificationSchema = createInsertSchema(notifications).omit({
   id: true,
   createdAt: true,


### PR DESCRIPTION
This pull request introduces a new feature that allows users to link (or "claim") downloads to games in their library or via IGDB search, directly from the downloads page. It also adds batch scanning for unlinked downloads, improves category handling for Transmission downloads, and makes several related UI and backend adjustments.

**Key changes:**

### Claim Download Feature (UI & UX)

* Added a new `ClaimDownloadModal` component, allowing users to link a download to a game from their library or IGDB, with category selection and confidence indicators. This modal is loaded lazily for performance. (`client/src/components/ClaimDownloadModal.tsx`, `client/src/pages/downloads.tsx`) [[1]](diffhunk://#diff-4229187d830a74ca396ba785e012e9d43ddf30791e3fa0dab645822fea67b454R1-R332) [[2]](diffhunk://#diff-405acc89e0958fce88b18f36396e3e51bd4abbe368ba4ef530d1cfbc2ad01156R52-R53) [[3]](diffhunk://#diff-405acc89e0958fce88b18f36396e3e51bd4abbe368ba4ef530d1cfbc2ad01156R804-R821)
* Integrated "Link to Game" action in the downloads table dropdown menu, opening the claim modal for the selected download. (`client/src/pages/downloads.tsx`)
* Added a "Scan Unlinked" button to trigger batch scanning for unlinked downloads, with a corresponding modal loaded lazily. (`client/src/pages/downloads.tsx`) [[1]](diffhunk://#diff-405acc89e0958fce88b18f36396e3e51bd4abbe368ba4ef530d1cfbc2ad01156R487-R497) [[2]](diffhunk://#diff-405acc89e0958fce88b18f36396e3e51bd4abbe368ba4ef530d1cfbc2ad01156R804-R821)

### Backend & Data Model Improvements

* Enhanced Transmission downloader support to fetch and expose the `labels` field as the download's category, improving category filtering and identification. (`server/downloaders.ts`) [[1]](diffhunk://#diff-be03eb09753a830ce7841910dfc733cb66aa7457b1f2faefb7dd628926880d54R69) [[2]](diffhunk://#diff-be03eb09753a830ce7841910dfc733cb66aa7457b1f2faefb7dd628926880d54R539) [[3]](diffhunk://#diff-be03eb09753a830ce7841910dfc733cb66aa7457b1f2faefb7dd628926880d54R658)
* Removed legacy category filtering logic from `DownloaderManager.getAllDownloads`, as category is now handled per-download and per-client. (`server/downloaders.ts`)

### Shared Utilities & Schema

* Imported and utilized `categorizeDownload` and `releaseMatchesGame` in the backend routes to support new claim and matching logic. (`server/routes.ts`)
* Updated imports to include `insertGameDownloadSchema` for future download-claiming logic. (`server/routes.ts`)

### UI Enhancements & Test Adjustments

* Updated test setup in `GameCard.test.tsx` for consistency in mocking `window.matchMedia`. (`client/__tests__/GameCard.test.tsx`)
* Added new icons and improved import structure for UI consistency. (`client/src/pages/downloads.tsx`) [[1]](diffhunk://#diff-405acc89e0958fce88b18f36396e3e51bd4abbe368ba4ef530d1cfbc2ad01156R36-R37) [[2]](diffhunk://#diff-405acc89e0958fce88b18f36396e3e51bd4abbe368ba4ef530d1cfbc2ad01156R52-R53)

These changes collectively improve the process of associating downloads with games, streamline category handling, and enhance the user experience for managing downloads.