### PR TITLE
fix bugs:

### DIFF
--- a/client/__tests__/GameCard.test.tsx
+++ b/client/__tests__/GameCard.test.tsx
@@ -102,7 +102,7 @@ describe("GameCard", () => {
     renderComponent();
     expect(screen.getByTestId("text-title-1")).toHaveTextContent("Test Game");
     expect(screen.getByTestId("text-rating-1")).toHaveTextContent("8.5/10");
-    expect(screen.getByTestId("text-release-1")).toHaveTextContent("2024-01-01");
+    expect(screen.getByTestId("text-release-1")).toHaveTextContent("2024");
   });
 
   it("displays a rating of 0 as 'N/A' since 0 is unrated", () => {

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -252,12 +252,13 @@ describe("GameDetailsModal", () => {
     renderComponent(longSummaryGame);
 
     const summaryText = screen.getByTestId(`text-summary-${mockGame.id}`);
-    expect(summaryText).toHaveTextContent("Read more");
+    // Summary paragraph shows truncated text; "Read more" is a sibling button
+    expect(summaryText.textContent?.length).toBeLessThan(300);
 
     const readMoreButton = screen.getByText("Read more");
     fireEvent.click(readMoreButton);
 
-    expect(summaryText).toHaveTextContent("Show less");
+    expect(screen.getByText("Show less")).toBeInTheDocument();
   });
 
   it("renders the Your rating section", () => {

--- a/client/src/components/GameCard.tsx
+++ b/client/src/components/GameCard.tsx
@@ -283,10 +283,12 @@ const GameCard = ({
               <div
                 className="flex items-center gap-1"
                 role="img"
-                aria-label={`Release Date: ${game.releaseDate || "To be announced"}`}
+                aria-label={`Release Date: ${game.releaseDate ? new Date(game.releaseDate).getFullYear() : "To be announced"}`}
               >
                 <Calendar className="w-3 h-3" aria-hidden="true" />
-                <span data-testid={`text-release-${game.id}`}>{game.releaseDate || "TBA"}</span>
+                <span data-testid={`text-release-${game.id}`}>
+                  {game.releaseDate ? new Date(game.releaseDate).getFullYear() : "TBA"}
+                </span>
               </div>
             </TooltipTrigger>
             <TooltipContent>

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -337,6 +337,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
       return res.json();
     },
     enabled: open && !!game?.id && !isDiscoveryId(game.id),
+    refetchInterval: 5000,
   });
 
   const { data: hltbResult } = useQuery<{ data: HLTBEntry | null }>({
@@ -607,20 +608,20 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                         About
                       </h3>
                       <p
-                        className="text-sm text-muted-foreground leading-relaxed"
+                        className="text-sm text-muted-foreground leading-relaxed break-words"
                         data-testid={`text-summary-${game.id}`}
                       >
                         {displaySummary}
-                        {isSummaryLong && (
-                          <Button
-                            variant="link"
-                            className="p-0 h-auto ml-1 font-semibold"
-                            onClick={() => setIsSummaryExpanded(!isSummaryExpanded)}
-                          >
-                            {isSummaryExpanded ? "Show less" : "Read more"}
-                          </Button>
-                        )}
                       </p>
+                      {isSummaryLong && (
+                        <Button
+                          variant="link"
+                          className="p-0 h-auto mt-1 font-semibold"
+                          onClick={() => setIsSummaryExpanded(!isSummaryExpanded)}
+                        >
+                          {isSummaryExpanded ? "Show less" : "Read more"}
+                        </Button>
+                      )}
                     </div>
                   )}
 

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -56,6 +56,7 @@ import {
   ArrowDown,
   Activity,
   Ban,
+  Info,
 } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
@@ -479,6 +480,9 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
         return { ...old, items: old.items.filter((i) => i.title !== item.title) };
       });
       queryClient.invalidateQueries({ queryKey: ["/api/blacklist"] });
+      // Re-fetch the search so the server can recalculate searchResultsAvailable
+      // with the updated blacklist applied (blacklisted item is now excluded server-side).
+      queryClient.invalidateQueries({ queryKey: [searchQueryKey] });
       toast({ description: "Release blacklisted" });
     },
     onError: () => {
@@ -861,341 +865,391 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
               </Card>
             )}
 
-            {!isSearching && searchResults && searchResults.items.length > 0 && (
-              <div className="space-y-8">
-                {/* Render each category separately */}
-                {(["main", "update", "dlc", "extra"] as const).map((category) => {
-                  const downloadsInCategory = filteredCategorizedDownloads[category] || [];
-                  if (downloadsInCategory.length === 0) return null;
-
-                  return (
-                    <div key={category} className="relative">
-                      {/* Category Header */}
-                      <div className="flex items-center gap-2 mb-3 px-1">
-                        <h3 className="font-bold text-lg capitalize tracking-tight">
-                          {category === "main"
-                            ? "Main Game"
-                            : category === "update"
-                              ? "Updates & Patches"
-                              : category === "dlc"
-                                ? "DLC & Expansions"
-                                : "Extras"}
-                        </h3>
-                        <Badge variant="secondary" className="text-xs font-semibold">
-                          {downloadsInCategory.length}
-                        </Badge>
-                      </div>
-
-                      {/* Downloads in this category */}
-                      <div className="border rounded-md divide-y mb-4 bg-card">
-                        {/* Sticky Sort Header */}
-                        <div className="sticky top-0 z-10 bg-muted/95 backdrop-blur-md p-3 text-xs font-bold flex items-center px-4 border-b rounded-t-md group">
-                          <div className="flex-1 flex items-center">
-                            <span className="text-muted-foreground/70 uppercase tracking-widest">
-                              Release Information
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-6 md:gap-10">
-                            <SortHeader
-                              field="date"
-                              label="Date"
-                              className="min-w-[70px] justify-end"
-                            />
-                            <SortHeader
-                              field="size"
-                              label="Size"
-                              className="min-w-[70px] justify-end"
-                            />
-                            <SortHeader
-                              field="seeders"
-                              label="Health"
-                              className="min-w-[70px] justify-end"
-                            />
-                            <div className="w-[80px] text-right text-muted-foreground/70 uppercase tracking-widest">
-                              Actions
-                            </div>
-                          </div>
+            {!isSearching &&
+              searchResults &&
+              searchResults.items.length > 0 &&
+              (() => {
+                const totalFiltered = Object.values(filteredCategorizedDownloads).reduce(
+                  (sum, arr) => sum + arr.length,
+                  0
+                );
+                const totalCategorized = Object.values(categorizedDownloads).reduce(
+                  (sum, arr) => sum + arr.length,
+                  0
+                );
+                const platformFilterHidesAll =
+                  selectedPlatforms.length > 0 && totalFiltered === 0 && totalCategorized > 0;
+                return (
+                  <div className="space-y-8">
+                    {/* Platform filter banner: shown when the preferred platform leaves no results */}
+                    {platformFilterHidesAll && (
+                      <div className="flex items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-300">
+                        <Info className="mt-0.5 h-4 w-4 shrink-0" />
+                        <div className="flex-1">
+                          <span>
+                            No results match your preferred platform (
+                            <strong>{selectedPlatforms.join(", ")}</strong>).
+                          </span>{" "}
+                          <button
+                            type="button"
+                            className="underline hover:text-amber-100 transition-colors"
+                            onClick={() => setSelectedPlatforms([])}
+                          >
+                            Show all results
+                          </button>
                         </div>
+                      </div>
+                    )}
+                    {/* Render each category separately */}
+                    {(["main", "update", "dlc", "extra"] as const).map((category) => {
+                      const downloadsInCategory = filteredCategorizedDownloads[category] || [];
+                      if (downloadsInCategory.length === 0) return null;
 
-                        {downloadsInCategory.map((download: DownloadItem) => {
-                          const isUsenet = isUsenetItem(download);
-                          const metadata =
-                            itemsMetadata.get(download.title) ??
-                            parseReleaseMetadata(download.title);
+                      return (
+                        <div key={category} className="relative">
+                          {/* Category Header */}
+                          <div className="flex items-center gap-2 mb-3 px-1">
+                            <h3 className="font-bold text-lg capitalize tracking-tight">
+                              {category === "main"
+                                ? "Main Game"
+                                : category === "update"
+                                  ? "Updates & Patches"
+                                  : category === "dlc"
+                                    ? "DLC & Expansions"
+                                    : "Extras"}
+                            </h3>
+                            <Badge variant="secondary" className="text-xs font-semibold">
+                              {downloadsInCategory.length}
+                            </Badge>
+                          </div>
 
-                          // Health calculation
-                          let healthColor = "text-muted-foreground";
-
-                          if (isUsenet) {
-                            const grabs = download.grabs ?? 0;
-                            if (grabs > 100) healthColor = "text-green-500";
-                            else if (grabs > 20) healthColor = "text-amber-500";
-                            else healthColor = "text-red-500";
-                          } else {
-                            const seeders = download.seeders ?? 0;
-                            if (seeders >= 20) healthColor = "text-green-500";
-                            else if (seeders >= 5) healthColor = "text-amber-500";
-                            else healthColor = "text-red-500";
-                          }
-
-                          const pubDate = new Date(download.pubDate);
-                          const hoursOld = (Date.now() - pubDate.getTime()) / (1000 * 60 * 60);
-                          const isNew = hoursOld <= 24;
-                          const compatibleDownloaders = isUsenet
-                            ? usenetCompatibleDownloaders
-                            : torrentCompatibleDownloaders;
-
-                          return (
-                            <div
-                              key={download.guid || download.link}
-                              className="p-4 text-sm hover:bg-muted/30 transition-colors group/row"
-                            >
-                              <div className="flex items-center gap-4">
-                                {/* Left Side: Title and Metadata */}
-                                <div className="flex-1 min-w-0 space-y-1">
-                                  <div className="flex items-center gap-2">
-                                    <Tooltip>
-                                      <TooltipTrigger asChild>
-                                        <div
-                                          className={cn(
-                                            "h-5 w-5 flex items-center justify-center rounded-full flex-shrink-0",
-                                            isUsenet ? "text-amber-500" : "text-violet-500"
-                                          )}
-                                        >
-                                          {isUsenet ? (
-                                            <Newspaper className="h-4 w-4" />
-                                          ) : (
-                                            <Magnet className="h-4 w-4" />
-                                          )}
-                                        </div>
-                                      </TooltipTrigger>
-                                      <TooltipContent>
-                                        {isUsenet ? "Usenet (NZB)" : "Torrent"}
-                                      </TooltipContent>
-                                    </Tooltip>
-
-                                    <h4 className="font-bold text-base truncate leading-tight">
-                                      {download.title}
-                                    </h4>
-
-                                    {isNew && (
-                                      <Badge
-                                        variant="default"
-                                        className="h-4 px-1 text-[8px] uppercase bg-blue-600 hover:bg-blue-600"
-                                      >
-                                        NEW
-                                      </Badge>
-                                    )}
-                                  </div>
-
-                                  {/* Metadata Line */}
-                                  <div className="flex flex-wrap items-center gap-1.5">
-                                    {metadata.version && (
-                                      <Badge
-                                        variant="secondary"
-                                        className="h-5 px-1.5 text-xs font-mono bg-blue-500/10 text-blue-600 dark:text-blue-400 border-none"
-                                      >
-                                        {metadata.version}
-                                      </Badge>
-                                    )}
-                                    {metadata.languages?.map((lang) => (
-                                      <Badge
-                                        key={lang}
-                                        variant="secondary"
-                                        className="h-5 px-1.5 text-xs bg-green-500/10 text-green-600 dark:text-green-400 border-none"
-                                      >
-                                        {lang}
-                                      </Badge>
-                                    ))}
-                                    {metadata.drm && (
-                                      <Badge
-                                        variant="secondary"
-                                        className="h-5 px-1.5 text-xs bg-purple-500/10 text-purple-600 dark:text-purple-400 border-none"
-                                      >
-                                        {metadata.drm}
-                                      </Badge>
-                                    )}
-                                    {metadata.platform && (
-                                      <Badge
-                                        variant="secondary"
-                                        className="h-5 px-1.5 text-xs bg-orange-500/10 text-orange-600 dark:text-orange-400 border-none"
-                                      >
-                                        {metadata.platform}
-                                      </Badge>
-                                    )}
-                                    {metadata.isScene && (
-                                      <Badge
-                                        variant="outline"
-                                        className="h-5 px-1.5 text-xs border-muted-foreground/30 text-muted-foreground uppercase tracking-tighter"
-                                      >
-                                        Scene
-                                      </Badge>
-                                    )}
-                                    {!isUsenet && download.downloadVolumeFactor === 0 && (
-                                      <Badge
-                                        variant="secondary"
-                                        className="h-5 px-1.5 text-[10px] bg-emerald-500/15 text-emerald-500 dark:text-emerald-400 border-none uppercase tracking-tighter"
-                                      >
-                                        Freeleech
-                                      </Badge>
-                                    )}
-                                  </div>
-
-                                  {/* Release info line */}
-                                  <div className="flex items-center gap-2 text-[11px] text-muted-foreground/70">
-                                    {metadata.group && (
-                                      <span className="font-bold text-foreground/50">
-                                        {metadata.group}
-                                      </span>
-                                    )}
-                                    {metadata.group && <span>•</span>}
-                                    <span>{download.indexerName}</span>
-                                    {isUsenet && download.poster && (
-                                      <>
-                                        <span>•</span>
-                                        <span
-                                          className="truncate max-w-[160px]"
-                                          title={download.poster}
-                                        >
-                                          {download.poster}
-                                        </span>
-                                      </>
-                                    )}
-                                  </div>
-                                </div>
-
-                                {/* Right Side: Metrics and Actions */}
-                                <div className="flex items-center gap-6 md:gap-10 flex-shrink-0">
-                                  {/* Date Column */}
-                                  <div className="min-w-[70px] text-right">
-                                    <div className="text-xs font-medium">
-                                      {formatDate(download.pubDate)}
-                                    </div>
-                                    <div className="text-xs text-muted-foreground/50">
-                                      {formatAge(isUsenet ? download.age : hoursOld / 24)}
-                                    </div>
-                                  </div>
-
-                                  {/* Size Column */}
-                                  <div className="min-w-[70px] text-right font-mono text-xs font-bold">
-                                    {download.size ? formatBytes(download.size) : "-"}
-                                    {isUsenet && download.files != null && (
-                                      <div className="text-[10px] font-sans font-normal text-muted-foreground/60">
-                                        {download.files} files
-                                      </div>
-                                    )}
-                                  </div>
-
-                                  {/* Health Column */}
-                                  <div
-                                    className={cn(
-                                      "min-w-[70px] text-right flex flex-col items-end justify-center",
-                                      healthColor
-                                    )}
-                                  >
-                                    <div className="flex items-center gap-1 font-bold">
-                                      <Activity className="h-3 w-3" />
-                                      {isUsenet ? (download.grabs ?? 0) : (download.seeders ?? 0)}
-                                    </div>
-                                    <div className="text-xs uppercase font-bold opacity-70">
-                                      {isUsenet ? "Grabs" : "Seeds"}
-                                    </div>
-                                    {!isUsenet && download.leechers != null && (
-                                      <div className="text-[10px] text-muted-foreground/60">
-                                        {download.leechers}L
-                                      </div>
-                                    )}
-                                  </div>
-
-                                  {/* Actions Column */}
-                                  <div className="w-[80px] flex items-center justify-end gap-1">
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      onClick={() => handleDownload(download)}
-                                      disabled={
-                                        downloadingGuid === (download.guid || download.link)
-                                      }
-                                      className="h-9 w-9 hover:bg-primary hover:text-primary-foreground transition-all"
-                                      aria-label={`Download ${download.title.replace(/[._]/g, " ")}`}
-                                    >
-                                      {downloadingGuid === (download.guid || download.link) ? (
-                                        <Loader2 className="h-4 w-4 animate-spin" />
-                                      ) : (
-                                        <Download className="h-4 w-4" />
-                                      )}
-                                    </Button>
-
-                                    <DropdownMenu>
-                                      <DropdownMenuTrigger asChild>
-                                        <Button
-                                          variant="ghost"
-                                          size="icon"
-                                          className="h-9 w-9"
-                                          aria-label="More options"
-                                        >
-                                          <MoreVertical className="h-4 w-4" />
-                                        </Button>
-                                      </DropdownMenuTrigger>
-                                      <DropdownMenuContent align="end">
-                                        <DropdownMenuItem
-                                          onClick={() => {
-                                            navigator.clipboard.writeText(download.link);
-                                            toast({ description: "Link copied to clipboard" });
-                                          }}
-                                        >
-                                          <Copy className="h-4 w-4 mr-2" />
-                                          Copy {isUsenet ? "NZB" : "Torrent"} Link
-                                        </DropdownMenuItem>
-
-                                        {compatibleDownloaders.length > 1 && (
-                                          <DropdownMenuSub>
-                                            <DropdownMenuSubTrigger>
-                                              <Download className="h-4 w-4 mr-2" />
-                                              Send to downloader
-                                            </DropdownMenuSubTrigger>
-                                            <DropdownMenuPortal>
-                                              <DropdownMenuSubContent>
-                                                {compatibleDownloaders.map((d) => (
-                                                  <DropdownMenuItem
-                                                    key={d.id}
-                                                    onClick={() =>
-                                                      sendToDownloaderMutation.mutate({
-                                                        download,
-                                                        downloaderId: d.id,
-                                                        downloaderName: d.name,
-                                                      })
-                                                    }
-                                                  >
-                                                    {d.name}
-                                                  </DropdownMenuItem>
-                                                ))}
-                                              </DropdownMenuSubContent>
-                                            </DropdownMenuPortal>
-                                          </DropdownMenuSub>
-                                        )}
-                                        <DropdownMenuItem
-                                          onClick={() => blacklistMutation.mutate(download)}
-                                          disabled={blacklistMutation.isPending}
-                                          className="text-destructive focus:text-destructive"
-                                        >
-                                          <Ban className="h-4 w-4 mr-2" />
-                                          Blacklist release
-                                        </DropdownMenuItem>
-                                      </DropdownMenuContent>
-                                    </DropdownMenu>
-                                  </div>
+                          {/* Downloads in this category */}
+                          <div className="border rounded-md divide-y mb-4 bg-card">
+                            {/* Sticky Sort Header */}
+                            <div className="sticky top-0 z-10 bg-muted/95 backdrop-blur-md p-3 text-xs font-bold flex items-center px-4 border-b rounded-t-md group">
+                              <div className="flex-1 flex items-center">
+                                <span className="text-muted-foreground/70 uppercase tracking-widest">
+                                  Release Information
+                                </span>
+                              </div>
+                              <div className="flex items-center gap-6 md:gap-10">
+                                <SortHeader
+                                  field="date"
+                                  label="Date"
+                                  className="min-w-[70px] justify-end"
+                                />
+                                <SortHeader
+                                  field="size"
+                                  label="Size"
+                                  className="min-w-[70px] justify-end"
+                                />
+                                <SortHeader
+                                  field="seeders"
+                                  label="Health"
+                                  className="min-w-[70px] justify-end"
+                                />
+                                <div className="w-[80px] text-right text-muted-foreground/70 uppercase tracking-widest">
+                                  Actions
                                 </div>
                               </div>
                             </div>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
+
+                            {downloadsInCategory.map((download: DownloadItem) => {
+                              const isUsenet = isUsenetItem(download);
+                              const metadata =
+                                itemsMetadata.get(download.title) ??
+                                parseReleaseMetadata(download.title);
+
+                              // Health calculation
+                              let healthColor = "text-muted-foreground";
+
+                              if (isUsenet) {
+                                const grabs = download.grabs ?? 0;
+                                if (grabs > 100) healthColor = "text-green-500";
+                                else if (grabs > 20) healthColor = "text-amber-500";
+                                else healthColor = "text-red-500";
+                              } else {
+                                const seeders = download.seeders ?? 0;
+                                if (seeders >= 20) healthColor = "text-green-500";
+                                else if (seeders >= 5) healthColor = "text-amber-500";
+                                else healthColor = "text-red-500";
+                              }
+
+                              const pubDate = new Date(download.pubDate);
+                              const hoursOld = (Date.now() - pubDate.getTime()) / (1000 * 60 * 60);
+                              const isNew = hoursOld <= 24;
+
+                              return (
+                                <div
+                                  key={download.guid || download.link}
+                                  className="p-4 text-sm hover:bg-muted/30 transition-colors group/row"
+                                >
+                                  <div className="flex items-center gap-4">
+                                    {/* Left Side: Title and Metadata */}
+                                    <div className="flex-1 min-w-0 space-y-1">
+                                      <div className="flex items-center gap-2">
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <div
+                                              className={cn(
+                                                "h-5 w-5 flex items-center justify-center rounded-full flex-shrink-0",
+                                                isUsenet ? "text-amber-500" : "text-violet-500"
+                                              )}
+                                            >
+                                              {isUsenet ? (
+                                                <Newspaper className="h-4 w-4" />
+                                              ) : (
+                                                <Magnet className="h-4 w-4" />
+                                              )}
+                                            </div>
+                                          </TooltipTrigger>
+                                          <TooltipContent>
+                                            {isUsenet ? "Usenet (NZB)" : "Torrent"}
+                                          </TooltipContent>
+                                        </Tooltip>
+
+                                        <h4 className="font-bold text-base truncate leading-tight">
+                                          {download.title}
+                                        </h4>
+
+                                        {isNew && (
+                                          <Badge
+                                            variant="default"
+                                            className="h-4 px-1 text-[8px] uppercase bg-blue-600 hover:bg-blue-600"
+                                          >
+                                            NEW
+                                          </Badge>
+                                        )}
+                                      </div>
+
+                                      {/* Metadata Line */}
+                                      <div className="flex flex-wrap items-center gap-1.5">
+                                        {metadata.version && (
+                                          <Badge
+                                            variant="secondary"
+                                            className="h-5 px-1.5 text-xs font-mono bg-blue-500/10 text-blue-600 dark:text-blue-400 border-none"
+                                          >
+                                            {metadata.version}
+                                          </Badge>
+                                        )}
+                                        {metadata.languages?.map((lang) => (
+                                          <Badge
+                                            key={lang}
+                                            variant="secondary"
+                                            className="h-5 px-1.5 text-xs bg-green-500/10 text-green-600 dark:text-green-400 border-none"
+                                          >
+                                            {lang}
+                                          </Badge>
+                                        ))}
+                                        {metadata.drm && (
+                                          <Badge
+                                            variant="secondary"
+                                            className="h-5 px-1.5 text-xs bg-purple-500/10 text-purple-600 dark:text-purple-400 border-none"
+                                          >
+                                            {metadata.drm}
+                                          </Badge>
+                                        )}
+                                        {metadata.platform && (
+                                          <Badge
+                                            variant="secondary"
+                                            className="h-5 px-1.5 text-xs bg-orange-500/10 text-orange-600 dark:text-orange-400 border-none"
+                                          >
+                                            {metadata.platform}
+                                          </Badge>
+                                        )}
+                                        {metadata.isScene && (
+                                          <Badge
+                                            variant="outline"
+                                            className="h-5 px-1.5 text-xs border-muted-foreground/30 text-muted-foreground uppercase tracking-tighter"
+                                          >
+                                            Scene
+                                          </Badge>
+                                        )}
+                                        {!isUsenet && download.downloadVolumeFactor === 0 && (
+                                          <Badge
+                                            variant="secondary"
+                                            className="h-5 px-1.5 text-[10px] bg-emerald-500/15 text-emerald-500 dark:text-emerald-400 border-none uppercase tracking-tighter"
+                                          >
+                                            Freeleech
+                                          </Badge>
+                                        )}
+                                      </div>
+
+                                      {/* Release info line */}
+                                      <div className="flex items-center gap-2 text-[11px] text-muted-foreground/70">
+                                        {metadata.group && (
+                                          <span className="font-bold text-foreground/50">
+                                            {metadata.group}
+                                          </span>
+                                        )}
+                                        {metadata.group && <span>•</span>}
+                                        <span>{download.indexerName}</span>
+                                        {isUsenet && download.poster && (
+                                          <>
+                                            <span>•</span>
+                                            <span
+                                              className="truncate max-w-[160px]"
+                                              title={download.poster}
+                                            >
+                                              {download.poster}
+                                            </span>
+                                          </>
+                                        )}
+                                      </div>
+                                    </div>
+
+                                    {/* Right Side: Metrics and Actions */}
+                                    <div className="flex items-center gap-6 md:gap-10 flex-shrink-0">
+                                      {/* Date Column */}
+                                      <div className="min-w-[70px] text-right">
+                                        <div className="text-xs font-medium">
+                                          {formatDate(download.pubDate)}
+                                        </div>
+                                        <div className="text-xs text-muted-foreground/50">
+                                          {formatAge(isUsenet ? download.age : hoursOld / 24)}
+                                        </div>
+                                      </div>
+
+                                      {/* Size Column */}
+                                      <div className="min-w-[70px] text-right font-mono text-xs font-bold">
+                                        {download.size ? formatBytes(download.size) : "-"}
+                                        {isUsenet && download.files != null && (
+                                          <div className="text-[10px] font-sans font-normal text-muted-foreground/60">
+                                            {download.files} files
+                                          </div>
+                                        )}
+                                      </div>
+
+                                      {/* Health Column */}
+                                      <div
+                                        className={cn(
+                                          "min-w-[70px] text-right flex flex-col items-end justify-center",
+                                          healthColor
+                                        )}
+                                      >
+                                        <div className="flex items-center gap-1 font-bold">
+                                          <Activity className="h-3 w-3" />
+                                          {isUsenet
+                                            ? (download.grabs ?? 0)
+                                            : (download.seeders ?? 0)}
+                                        </div>
+                                        <div className="text-xs uppercase font-bold opacity-70">
+                                          {isUsenet ? "Grabs" : "Seeds"}
+                                        </div>
+                                        {!isUsenet && download.leechers != null && (
+                                          <div className="text-[10px] text-muted-foreground/60">
+                                            {download.leechers}L
+                                          </div>
+                                        )}
+                                      </div>
+
+                                      {/* Actions Column */}
+                                      <div className="w-[80px] flex items-center justify-end gap-1">
+                                        <Button
+                                          variant="ghost"
+                                          size="icon"
+                                          onClick={() => handleDownload(download)}
+                                          disabled={
+                                            downloadingGuid === (download.guid || download.link)
+                                          }
+                                          className="h-9 w-9 hover:bg-primary hover:text-primary-foreground transition-all"
+                                          aria-label={`Download ${download.title.replace(/[._]/g, " ")}`}
+                                        >
+                                          {downloadingGuid === (download.guid || download.link) ? (
+                                            <Loader2 className="h-4 w-4 animate-spin" />
+                                          ) : (
+                                            <Download className="h-4 w-4" />
+                                          )}
+                                        </Button>
+
+                                        <DropdownMenu>
+                                          <DropdownMenuTrigger asChild>
+                                            <Button
+                                              variant="ghost"
+                                              size="icon"
+                                              className="h-9 w-9"
+                                              aria-label="More options"
+                                            >
+                                              <MoreVertical className="h-4 w-4" />
+                                            </Button>
+                                          </DropdownMenuTrigger>
+                                          <DropdownMenuContent align="end">
+                                            <DropdownMenuItem
+                                              onClick={() => {
+                                                navigator.clipboard.writeText(download.link);
+                                                toast({ description: "Link copied to clipboard" });
+                                              }}
+                                            >
+                                              <Copy className="h-4 w-4 mr-2" />
+                                              Copy {isUsenet ? "NZB" : "Torrent"} Link
+                                            </DropdownMenuItem>
+
+                                            {(() => {
+                                              const compatibleDownloaders = downloaders.filter(
+                                                (d) =>
+                                                  isUsenet
+                                                    ? ["sabnzbd", "nzbget"].includes(d.type)
+                                                    : [
+                                                        "transmission",
+                                                        "rtorrent",
+                                                        "qbittorrent",
+                                                      ].includes(d.type)
+                                              );
+
+                                              if (compatibleDownloaders.length <= 1) {
+                                                return null;
+                                              }
+
+                                              return (
+                                                <DropdownMenuSub>
+                                                  <DropdownMenuSubTrigger>
+                                                    <Download className="h-4 w-4 mr-2" />
+                                                    Send to downloader
+                                                  </DropdownMenuSubTrigger>
+                                                  <DropdownMenuPortal>
+                                                    <DropdownMenuSubContent>
+                                                      {compatibleDownloaders.map((d) => (
+                                                        <DropdownMenuItem
+                                                          key={d.id}
+                                                          onClick={() =>
+                                                            sendToDownloaderMutation.mutate({
+                                                              download,
+                                                              downloaderId: d.id,
+                                                              downloaderName: d.name,
+                                                            })
+                                                          }
+                                                        >
+                                                          {d.name}
+                                                        </DropdownMenuItem>
+                                                      ))}
+                                                    </DropdownMenuSubContent>
+                                                  </DropdownMenuPortal>
+                                                </DropdownMenuSub>
+                                              );
+                                            })()}
+                                            <DropdownMenuItem
+                                              onClick={() => blacklistMutation.mutate(download)}
+                                              disabled={blacklistMutation.isPending}
+                                              className="text-destructive focus:text-destructive"
+                                            >
+                                              <Ban className="h-4 w-4 mr-2" />
+                                              Blacklist release
+                                            </DropdownMenuItem>
+                                          </DropdownMenuContent>
+                                        </DropdownMenu>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })()}
 
             {searchResults?.errors && searchResults.errors.length > 0 && (
               <Card className="border-destructive">

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -232,16 +232,6 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     enabled: open,
   });
 
-  const torrentCompatibleDownloaders = useMemo(
-    () => downloaders.filter((d) => ["transmission", "rtorrent", "qbittorrent"].includes(d.type)),
-    [downloaders]
-  );
-
-  const usenetCompatibleDownloaders = useMemo(
-    () => downloaders.filter((d) => ["sabnzbd", "nzbget"].includes(d.type)),
-    [downloaders]
-  );
-
   // Categorize downloads
   const categorizedDownloads = useMemo(() => {
     if (!searchResults?.items) return { main: [], update: [], dlc: [], extra: [] };
@@ -873,12 +863,32 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                   (sum, arr) => sum + arr.length,
                   0
                 );
-                const totalCategorized = Object.values(categorizedDownloads).reduce(
-                  (sum, arr) => sum + arr.length,
+                // Count items that pass all active filters *except* platform so the banner
+                // only appears when platform filtering is specifically the cause of an empty
+                // list, not when other filters (e.g. minSeeders) already hide everything.
+                const totalWithoutPlatformFilter = Object.entries(categorizedDownloads).reduce(
+                  (sum, [cat, downloads]) => {
+                    if (!visibleCategories.has(cat as DownloadCategory)) return sum;
+                    return (
+                      sum +
+                      downloads
+                        .filter((t) => (t.seeders ?? 0) >= minSeeders)
+                        .filter(
+                          (t) => selectedIndexer === "all" || t.indexerName === selectedIndexer
+                        )
+                        .filter(
+                          (t) =>
+                            selectedGroups.length === 0 ||
+                            (t.group && selectedGroups.includes(t.group))
+                        ).length
+                    );
+                  },
                   0
                 );
                 const platformFilterHidesAll =
-                  selectedPlatforms.length > 0 && totalFiltered === 0 && totalCategorized > 0;
+                  selectedPlatforms.length > 0 &&
+                  totalFiltered === 0 &&
+                  totalWithoutPlatformFilter > 0;
                 return (
                   <div className="space-y-8">
                     {/* Platform filter banner: shown when the preferred platform leaves no results */}

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 z-10 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/server/__tests__/path_traversal.test.ts
+++ b/server/__tests__/path_traversal.test.ts
@@ -75,6 +75,13 @@ vi.mock("../auth.js", () => ({
     };
     next();
   },
+  optionalAuthenticateToken: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction
+  ) => {
+    next();
+  },
 }));
 
 vi.mock("../steam-routes.js", () => ({

--- a/server/__tests__/rss-routes.test.ts
+++ b/server/__tests__/rss-routes.test.ts
@@ -29,6 +29,9 @@ vi.mock("../auth.js", () => ({
     req.user = { id: 1, username: "testuser" };
     next();
   },
+  optionalAuthenticateToken: (_req: any, _res: any, next: any) => {
+    next();
+  },
   hashPassword: vi.fn(),
   comparePassword: vi.fn(),
   generateToken: vi.fn(),

--- a/server/__tests__/rss-ssrf.test.ts
+++ b/server/__tests__/rss-ssrf.test.ts
@@ -31,6 +31,13 @@ vi.mock("../auth.js", () => ({
     req.user = { id: 1, username: "testuser" };
     next();
   },
+  optionalAuthenticateToken: (
+    _req: import("express").Request,
+    _res: import("express").Response,
+    next: import("express").NextFunction
+  ) => {
+    next();
+  },
   hashPassword: vi.fn(),
   comparePassword: vi.fn(),
   generateToken: vi.fn(),

--- a/server/__tests__/ssrf_routes.test.ts
+++ b/server/__tests__/ssrf_routes.test.ts
@@ -89,6 +89,13 @@ vi.mock("../auth.js", () => ({
     };
     next();
   },
+  optionalAuthenticateToken: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction
+  ) => {
+    next();
+  },
 }));
 
 vi.mock("../steam-routes.js", () => ({

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -81,6 +81,26 @@ export async function generateToken(user: User) {
   });
 }
 
+/**
+ * Optional authentication middleware. Sets req.user when a valid JWT is present
+ * but never blocks the request — unauthenticated callers simply get no req.user.
+ */
+export async function optionalAuthenticateToken(req: Request, _res: Response, next: NextFunction) {
+  const authHeader = req.headers["authorization"];
+  const token = authHeader && authHeader.split(" ")[1];
+  if (token) {
+    try {
+      const secret = await getJwtSecret();
+      const payload = jwt.verify(token, secret) as { id: string; username: string };
+      const user = await storage.getUser(payload.id);
+      if (user) req.user = user;
+    } catch {
+      // Invalid token — continue without user context
+    }
+  }
+  next();
+}
+
 export async function authenticateToken(req: Request, res: Response, next: NextFunction) {
   const authHeader = req.headers["authorization"];
   const token = authHeader && authHeader.split(" ")[1];

--- a/server/newznab.ts
+++ b/server/newznab.ts
@@ -140,14 +140,14 @@ class NewznabClient {
 
         for (const item of items) {
           // Extract Newznab attributes
-          const attrs = item["newznab:attr"] || [];
+          // fast-xml-parser returns a single element as an object, multiple as an array
+          const attrsRaw = item["newznab:attr"];
+          const attrsArray = Array.isArray(attrsRaw) ? attrsRaw : attrsRaw ? [attrsRaw] : [];
           const attrMap = new Map<string, string>();
 
-          if (Array.isArray(attrs)) {
-            for (const attr of attrs) {
-              if (attr["@_name"] && attr["@_value"]) {
-                attrMap.set(attr["@_name"], attr["@_value"]);
-              }
+          for (const attr of attrsArray) {
+            if (attr["@_name"] && attr["@_value"]) {
+              attrMap.set(attr["@_name"], attr["@_value"]);
             }
           }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -49,7 +49,13 @@ import { config as appConfig } from "./config.js";
 import { configLoader } from "./config-loader.js";
 import { prowlarrClient } from "./prowlarr.js";
 import { isSafeUrl, safeFetch } from "./ssrf.js";
-import { hashPassword, comparePassword, generateToken, authenticateToken } from "./auth.js";
+import {
+  hashPassword,
+  comparePassword,
+  generateToken,
+  authenticateToken,
+  optionalAuthenticateToken,
+} from "./auth.js";
 import { hltbClient } from "./hltb.js";
 import { nexusmodsClient } from "./nexusmods.js";
 import multer from "multer";
@@ -68,7 +74,13 @@ const upload = multer({
 });
 import { searchAllIndexers, filterBlacklistedReleases } from "./search.js";
 import { xrelClient, DEFAULT_XREL_BASE, ALLOWED_XREL_DOMAINS } from "./xrel.js";
-import { normalizeTitle, cleanReleaseName, releaseMatchesGame } from "../shared/title-utils.js";
+import {
+  normalizeTitle,
+  cleanReleaseName,
+  releaseMatchesGame,
+  parseReleaseMetadata,
+  matchesPlatformFilter,
+} from "../shared/title-utils.js";
 import { categorizeDownload } from "../shared/download-categorizer.js";
 import archiver from "archiver";
 import helmet from "helmet";
@@ -143,6 +155,19 @@ async function handleAggregatedIndexerSearch(req: Request, res: Response) {
         const blacklisted = await storage.getReleaseBlacklistSet(gameId);
         filteredItems = filterBlacklistedReleases(items, blacklisted);
         blacklistedCount = items.length - filteredItems.length;
+
+        // Apply preferred platform filter to determine if results are truly available
+        // for this user, then update the live flag so it stays accurate without waiting
+        // for the next cron run (fixes stale "has results" badge and newly-added games).
+        const userSettings = await storage.getUserSettings(req.user.id);
+        const preferredPlatform = userSettings?.preferredPlatform ?? null;
+        const platformFiltered = preferredPlatform
+          ? filteredItems.filter((item) => {
+              const { platform } = parseReleaseMetadata(item.title);
+              return matchesPlatformFilter(platform, preferredPlatform);
+            })
+          : filteredItems;
+        await storage.updateGameSearchResultsAvailable(game.id, platformFiltered.length > 0);
       }
     }
 
@@ -1498,6 +1523,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Aggregated search across all enabled indexers
   app.get(
     "/api/indexers/search",
+    optionalAuthenticateToken,
     sanitizeIndexerSearchQuery,
     validateRequest,
     handleAggregatedIndexerSearch
@@ -1752,6 +1778,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Search for games using configured indexers (alias for /api/indexers/search)
   app.get(
     "/api/search",
+    optionalAuthenticateToken,
     sanitizeIndexerSearchQuery,
     validateRequest,
     handleAggregatedIndexerSearch

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -152,22 +152,29 @@ async function handleAggregatedIndexerSearch(req: Request, res: Response) {
     if (gameId && req.user) {
       const game = await storage.getGame(gameId);
       if (game && game.userId === req.user.id) {
-        const blacklisted = await storage.getReleaseBlacklistSet(gameId);
+        const [blacklisted, userSettings] = await Promise.all([
+          storage.getReleaseBlacklistSet(gameId),
+          storage.getUserSettings(req.user.id),
+        ]);
         filteredItems = filterBlacklistedReleases(items, blacklisted);
         blacklistedCount = items.length - filteredItems.length;
 
-        // Apply preferred platform filter to determine if results are truly available
-        // for this user, then update the live flag so it stays accurate without waiting
-        // for the next cron run (fixes stale "has results" badge and newly-added games).
-        const userSettings = await storage.getUserSettings(req.user.id);
-        const preferredPlatform = userSettings?.preferredPlatform ?? null;
-        const platformFiltered = preferredPlatform
-          ? filteredItems.filter((item) => {
-              const { platform } = parseReleaseMetadata(item.title);
-              return matchesPlatformFilter(platform, preferredPlatform);
-            })
-          : filteredItems;
-        await storage.updateGameSearchResultsAvailable(game.id, platformFiltered.length > 0);
+        // Update the "has results" flag only for canonical game-title searches so that
+        // partial/custom user-typed queries in the download dialog don't flip the badge
+        // based on a transient, narrow result set. Runs async to avoid blocking the response.
+        const isCanonicalSearch = normalizeTitle(query.trim()) === normalizeTitle(game.title);
+        if (isCanonicalSearch) {
+          const preferredPlatform = userSettings?.preferredPlatform ?? null;
+          const platformFiltered = preferredPlatform
+            ? filteredItems.filter((item) => {
+                const { platform } = parseReleaseMetadata(item.title);
+                return matchesPlatformFilter(platform, preferredPlatform);
+              })
+            : filteredItems;
+          storage
+            .updateGameSearchResultsAvailable(game.id, platformFiltered.length > 0)
+            .catch((err) => routesLogger.warn({ err }, "Failed to update searchResultsAvailable"));
+        }
       }
     }
 


### PR DESCRIPTION
- [ ]  When a release is blacklisted for a game, the preferred platform is not taken into account anymore in the download search. E.g Crimson desert has 1 PC download, 2 mac. If I blacklist the PC release and 1 mac release, it will display the mac release. So when the preferred platform doesnt exist, maybe show a message and allow user to show anyway
- [ ]  Whe the combination of blacklist + preferred platform (even just preffered platform) makes it so no releases are actually available to fit the user setting, the lists are still displaying the game as “has results”: Still KO
- [ ]  When a download changes status (e.g. completed), it is not updated in the game details download tab
- [ ]  Not all games with results available have the “has results” icon —> e.g. Pioneers of Pagonia: ko
- [ ]  “files” attribute for nzbs doesn’t work: ko
- [ ]  When clicking on view more in game details, th text is not contained and overflows
- [ ]  X button doesn’t close game details