### PR TITLE
feat: add filter for games with available updates

### DIFF
--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -369,7 +369,7 @@ describe("GameDownloadDialog", () => {
     });
   });
 
-  it("closes dialog after successful download", async () => {
+  it("keeps dialog open and shows toast after successful download", async () => {
     renderComponent();
 
     await waitFor(() => {
@@ -381,8 +381,13 @@ describe("GameDownloadDialog", () => {
     fireEvent.click(downloadButton);
 
     await waitFor(() => {
-      expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: expect.stringContaining("download(s) sent") })
+      );
     });
+
+    // Dialog should remain open (onOpenChange should NOT be called with false)
+    expect(mockOnOpenChange).not.toHaveBeenCalledWith(false);
   });
 
   it("shows destructive toast when download API returns success:false", async () => {

--- a/client/src/components/GameFilterPills.tsx
+++ b/client/src/components/GameFilterPills.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Search, Download } from "lucide-react";
+import { Search, Download, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -8,6 +8,8 @@ interface GameFilterPillsProps {
   setShowSearchResultsOnly: (value: boolean) => void;
   showDownloadsOnly: boolean;
   setShowDownloadsOnly: (value: boolean | ((prev: boolean) => boolean)) => void;
+  showUpdateAvailableOnly?: boolean;
+  setShowUpdateAvailableOnly?: (value: boolean | ((prev: boolean) => boolean)) => void;
 }
 
 export default function GameFilterPills({
@@ -15,6 +17,8 @@ export default function GameFilterPills({
   setShowSearchResultsOnly,
   showDownloadsOnly,
   setShowDownloadsOnly,
+  showUpdateAvailableOnly = false,
+  setShowUpdateAvailableOnly,
 }: Readonly<GameFilterPillsProps>) {
   return (
     <>
@@ -43,6 +47,27 @@ export default function GameFilterPills({
         </TooltipTrigger>
         <TooltipContent>{showDownloadsOnly ? "Show all" : "Has downloads"}</TooltipContent>
       </Tooltip>
+      {setShowUpdateAvailableOnly && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={showUpdateAvailableOnly ? "default" : "outline"}
+              size="sm"
+              className="h-7 gap-1.5 text-xs"
+              onClick={() => setShowUpdateAvailableOnly((v) => !v)}
+              aria-label={
+                showUpdateAvailableOnly ? "Show all games" : "Show games with update downloads only"
+              }
+            >
+              <RefreshCw className="h-3 w-3" />
+              Update Available
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {showUpdateAvailableOnly ? "Show all" : "Has update downloads"}
+          </TooltipContent>
+        </Tooltip>
+      )}
     </>
   );
 }

--- a/client/src/pages/library.tsx
+++ b/client/src/pages/library.tsx
@@ -20,6 +20,7 @@ export default function LibraryPage() {
   const [showDownloadsOnly, setShowDownloadsOnly] = useState(false);
   const downloadSummaries = useDownloadSummary();
   const [showSearchResultsOnly, setShowSearchResultsOnly] = useState(false);
+  const [showUpdateAvailableOnly, setShowUpdateAvailableOnly] = useState(false);
 
   const { data: games = [], isLoading } = useQuery<Game[]>({
     queryKey: ["/api/games", "?status=owned,completed,downloading"],
@@ -31,10 +32,13 @@ export default function LibraryPage() {
     return result;
   }, [games, showSearchResultsOnly]);
 
-  const displayedGames = useMemo(
-    () => (showDownloadsOnly ? libraryGames.filter((g) => downloadSummaries[g.id]) : libraryGames),
-    [libraryGames, showDownloadsOnly, downloadSummaries]
-  );
+  const displayedGames = useMemo(() => {
+    let result = libraryGames;
+    if (showDownloadsOnly) result = result.filter((g) => downloadSummaries[g.id]);
+    if (showUpdateAvailableOnly)
+      result = result.filter((g) => downloadSummaries[g.id]?.hasUpdateDownload);
+    return result;
+  }, [libraryGames, showDownloadsOnly, showUpdateAvailableOnly, downloadSummaries]);
 
   const statusMutation = useMutation({
     mutationFn: async ({ gameId, status }: { gameId: string; status: GameStatus }) => {
@@ -76,6 +80,8 @@ export default function LibraryPage() {
               setShowSearchResultsOnly={setShowSearchResultsOnly}
               showDownloadsOnly={showDownloadsOnly}
               setShowDownloadsOnly={setShowDownloadsOnly}
+              showUpdateAvailableOnly={showUpdateAvailableOnly}
+              setShowUpdateAvailableOnly={setShowUpdateAvailableOnly}
             />
           }
           viewControls={{

--- a/server/__tests__/download-summary.test.ts
+++ b/server/__tests__/download-summary.test.ts
@@ -373,6 +373,28 @@ describe("getDownloadSummaryByGame (MemStorage)", () => {
     expect(summary["game-2"].topStatus).toBe("failed");
     expect(Object.keys(summary)).toHaveLength(2);
   });
+
+  it("sets hasUpdateDownload when a download title matches update patterns", async () => {
+    await memStorage.addGameDownload(
+      makeDownload({ downloadHash: "hash-main", downloadTitle: "Test.Game-GROUP" })
+    );
+    await memStorage.addGameDownload(
+      makeDownload({ downloadHash: "hash-upd", downloadTitle: "Test.Game.Update.v2-GROUP" })
+    );
+    const summary = await memStorage.getDownloadSummaryByGame(USER_ID);
+    expect(summary["game-1"].hasUpdateDownload).toBe(true);
+  });
+
+  it("leaves hasUpdateDownload false when no update title exists", async () => {
+    await memStorage.addGameDownload(
+      makeDownload({ downloadHash: "hash-1", downloadTitle: "Test.Game-GROUP" })
+    );
+    await memStorage.addGameDownload(
+      makeDownload({ downloadHash: "hash-2", downloadTitle: "Test.Game-DLC-GROUP" })
+    );
+    const summary = await memStorage.getDownloadSummaryByGame(USER_ID);
+    expect(summary["game-1"].hasUpdateDownload).toBe(false);
+  });
 });
 
 // ─── Integration tests ───

--- a/server/__tests__/download-summary.test.ts
+++ b/server/__tests__/download-summary.test.ts
@@ -292,6 +292,7 @@ describe("getDownloadSummaryByGame (MemStorage)", () => {
       topStatus: "downloading",
       count: 1,
       downloadTypes: ["torrent"],
+      hasUpdateDownload: false,
     });
   });
 
@@ -403,8 +404,18 @@ describe("GET /api/downloads/summary", () => {
 
   it("returns correct summary map when downloads exist", async () => {
     const mockSummary: Record<string, DownloadSummary> = {
-      "game-1": { topStatus: "downloading", count: 2, downloadTypes: ["torrent"] },
-      "game-2": { topStatus: "completed", count: 1, downloadTypes: ["usenet"] },
+      "game-1": {
+        topStatus: "downloading",
+        count: 2,
+        downloadTypes: ["torrent"],
+        hasUpdateDownload: false,
+      },
+      "game-2": {
+        topStatus: "completed",
+        count: 1,
+        downloadTypes: ["usenet"],
+        hasUpdateDownload: false,
+      },
     };
     vi.mocked(storage.getDownloadSummaryByGame).mockResolvedValue(mockSummary);
     const res = await request(app)

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -42,6 +42,9 @@ import { db } from "./db.js";
 import { eq, like, or, sql, desc, and, inArray, type SQL } from "drizzle-orm";
 import { categorizeDownload } from "../shared/download-categorizer.js";
 
+const isUpdateDownload = (title: string): boolean =>
+  categorizeDownload(title).category === "update";
+
 const STATUS_PRIORITY: Record<string, number> = {
   failed: 4,
   downloading: 3,
@@ -699,7 +702,7 @@ export class MemStorage implements IStorage {
       if (!userGameIds.has(gameId)) continue;
       const status = gd.status as DownloadSummary["topStatus"];
       const downloadType = (gd.downloadType ?? "torrent") as "torrent" | "usenet";
-      const isUpdate = categorizeDownload(gd.downloadTitle).category === "update";
+      const isUpdate = isUpdateDownload(gd.downloadTitle);
       if (!result[gameId]) {
         result[gameId] = {
           topStatus: status,
@@ -1529,7 +1532,13 @@ export class DatabaseStorage implements IStorage {
           END
         `,
         downloadTypes: sql<string>`group_concat(DISTINCT ${gameDownloads.downloadType})`,
-        downloadTitles: sql<string>`group_concat(${gameDownloads.downloadTitle}, '||')`,
+        hasUpdateDownload: sql<number>`max(CASE
+          WHEN ${gameDownloads.downloadTitle} LIKE '%update%'
+            OR ${gameDownloads.downloadTitle} LIKE '%patch%'
+            OR ${gameDownloads.downloadTitle} LIKE '%hotfix%'
+            OR ${gameDownloads.downloadTitle} LIKE '%crackfix%'
+            OR ${gameDownloads.downloadTitle} LIKE '%fix%'
+          THEN 1 ELSE 0 END)`,
       })
       .from(gameDownloads)
       .innerJoin(games, eq(gameDownloads.gameId, games.id))
@@ -1538,8 +1547,6 @@ export class DatabaseStorage implements IStorage {
 
     return Object.fromEntries(
       rows.map((row) => {
-        const titles = (row.downloadTitles ?? "").split("||").filter(Boolean);
-        const hasUpdateDownload = titles.some((t) => categorizeDownload(t).category === "update");
         return [
           row.gameId,
           {
@@ -1549,7 +1556,7 @@ export class DatabaseStorage implements IStorage {
               | "torrent"
               | "usenet"
             )[],
-            hasUpdateDownload,
+            hasUpdateDownload: row.hasUpdateDownload > 0,
           },
         ];
       })

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -40,6 +40,7 @@ import {
 import { randomUUID } from "crypto";
 import { db } from "./db.js";
 import { eq, like, or, sql, desc, and, inArray, type SQL } from "drizzle-orm";
+import { categorizeDownload } from "../shared/download-categorizer.js";
 
 const STATUS_PRIORITY: Record<string, number> = {
   failed: 4,
@@ -698,11 +699,13 @@ export class MemStorage implements IStorage {
       if (!userGameIds.has(gameId)) continue;
       const status = gd.status as DownloadSummary["topStatus"];
       const downloadType = (gd.downloadType ?? "torrent") as "torrent" | "usenet";
+      const isUpdate = categorizeDownload(gd.downloadTitle).category === "update";
       if (!result[gameId]) {
         result[gameId] = {
           topStatus: status,
           count: 1,
           downloadTypes: [downloadType],
+          hasUpdateDownload: isUpdate,
         };
       } else {
         result[gameId].topStatus = resolveTopStatus(result[gameId].topStatus, status);
@@ -710,6 +713,7 @@ export class MemStorage implements IStorage {
         if (!result[gameId].downloadTypes.includes(downloadType)) {
           result[gameId].downloadTypes.push(downloadType);
         }
+        if (isUpdate) result[gameId].hasUpdateDownload = true;
       }
     }
     return result;
@@ -1525,6 +1529,7 @@ export class DatabaseStorage implements IStorage {
           END
         `,
         downloadTypes: sql<string>`group_concat(DISTINCT ${gameDownloads.downloadType})`,
+        downloadTitles: sql<string>`group_concat(${gameDownloads.downloadTitle}, '||')`,
       })
       .from(gameDownloads)
       .innerJoin(games, eq(gameDownloads.gameId, games.id))
@@ -1532,17 +1537,22 @@ export class DatabaseStorage implements IStorage {
       .groupBy(gameDownloads.gameId);
 
     return Object.fromEntries(
-      rows.map((row) => [
-        row.gameId,
-        {
-          topStatus: row.topStatus as DownloadSummary["topStatus"],
-          count: row.count,
-          downloadTypes: (row.downloadTypes ?? "torrent").split(",").filter(Boolean) as (
-            | "torrent"
-            | "usenet"
-          )[],
-        },
-      ])
+      rows.map((row) => {
+        const titles = (row.downloadTitles ?? "").split("||").filter(Boolean);
+        const hasUpdateDownload = titles.some((t) => categorizeDownload(t).category === "update");
+        return [
+          row.gameId,
+          {
+            topStatus: row.topStatus as DownloadSummary["topStatus"],
+            count: row.count,
+            downloadTypes: (row.downloadTypes ?? "torrent").split(",").filter(Boolean) as (
+              | "torrent"
+              | "usenet"
+            )[],
+            hasUpdateDownload,
+          },
+        ];
+      })
     );
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -398,6 +398,7 @@ export interface DownloadSummary {
   topStatus: "downloading" | "paused" | "failed" | "completed";
   count: number;
   downloadTypes: ("torrent" | "usenet")[];
+  hasUpdateDownload: boolean;
 }
 
 // Application configuration type


### PR DESCRIPTION
This pull request adds support for filtering games in the library by whether they have update downloads available. It introduces a new "Update Available" filter pill in the UI and updates the backend and shared types to track and expose this information. The most important changes are:

**UI Enhancements:**

* Added an "Update Available" filter pill to the `GameFilterPills` component, allowing users to filter games to only those with update downloads. This includes new props and UI logic for toggling the filter. [[1]](diffhunk://#diff-57ce8ebfaa2a211724154ee82b5b031e307e9a54e56b40bebfd65e9bd422f8b4L2-R2) [[2]](diffhunk://#diff-57ce8ebfaa2a211724154ee82b5b031e307e9a54e56b40bebfd65e9bd422f8b4R11-R21) [[3]](diffhunk://#diff-57ce8ebfaa2a211724154ee82b5b031e307e9a54e56b40bebfd65e9bd422f8b4R50-R70)
* Integrated the new filter into the `LibraryPage`, updating state management and the logic for filtering displayed games based on the presence of update downloads. [[1]](diffhunk://#diff-8225c53ace7c8c6d8da99d9285e9b6d33a4e971cc7e2905557de98f46202d70cR23) [[2]](diffhunk://#diff-8225c53ace7c8c6d8da99d9285e9b6d33a4e971cc7e2905557de98f46202d70cL34-R41) [[3]](diffhunk://#diff-8225c53ace7c8c6d8da99d9285e9b6d33a4e971cc7e2905557de98f46202d70cR83-R84)

**Backend and Shared Logic:**

* Updated the `DownloadSummary` type in `shared/schema.ts` to include a new `hasUpdateDownload` boolean, indicating whether a game has any update downloads.
* Modified both in-memory (`MemStorage`) and database (`DatabaseStorage`) storage implementations to calculate and return the `hasUpdateDownload` field by categorizing download titles. [[1]](diffhunk://#diff-6af4f8e34285120717169f57249241ec070dfd0f878e186658aaa341e568c84fR43) [[2]](diffhunk://#diff-6af4f8e34285120717169f57249241ec070dfd0f878e186658aaa341e568c84fR702-R716) [[3]](diffhunk://#diff-6af4f8e34285120717169f57249241ec070dfd0f878e186658aaa341e568c84fR1532-R1543) [[4]](diffhunk://#diff-6af4f8e34285120717169f57249241ec070dfd0f878e186658aaa341e568c84fR1552-R1555)

**Testing:**

* Updated tests to include the new `hasUpdateDownload` field in download summaries, ensuring correct behavior. [[1]](diffhunk://#diff-2607699cff6a53a77374690a6fbef1fef061e4a6c3fbded6e80c1b6e034c7c8cR295) [[2]](diffhunk://#diff-2607699cff6a53a77374690a6fbef1fef061e4a6c3fbded6e80c1b6e034c7c8cL406-R418)