### PR TITLE
fix: harden download status checks and migrate steam logger

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Force LF for all text files to prevent CRLF issues on Linux containers
+* text=auto eol=lf
+
+# Shell scripts must always be LF
+*.sh text eol=lf
+
+# Windows-specific files can use CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ sqlite.db*
 pr_status.json
 .omc/
 .sonarlint/connectedMode.json
+data_test/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/sh
-npx lint-staged
+npx --no-install lint-staged

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,4 @@ LABEL org.opencontainers.image.description="A video game management application 
 LABEL org.opencontainers.image.authors="Doezer"
 LABEL org.opencontainers.image.source="https://github.com/Doezer/questarr"
 LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
-LABEL org.opencontainers.image.version="1.3.0"
+LABEL org.opencontainers.image.version="1.4.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ RUN npm ci
 # Build client and server
 FROM base AS builder
 
-WORKDIR /app
-
 COPY . .
 RUN npm run build
 
@@ -37,20 +35,15 @@ RUN npm prune --omit=dev
 # Copy necessary files from build stage
 COPY --from=builder /app/dist ./dist
 
-# Copy drizzle configuration and migrations for production
-COPY --from=builder /app/drizzle.config.ts ./
 COPY --from=builder /app/migrations ./migrations
 COPY --from=builder /app/shared ./shared
-COPY --from=builder /app/scripts ./scripts
-
-# Copy configuration files...
 COPY --from=builder /app/package.json ./
 
 # Create user, group, data directory, and set ownership
-RUN addgroup questarr
-RUN adduser -G questarr -s /bin/sh -D questarr 
-RUN mkdir -p /app/data
-RUN chown -R questarr:questarr /app
+RUN addgroup questarr && \
+    adduser -G questarr -s /bin/sh -D questarr && \
+    mkdir -p /app/data && \
+    chown -R questarr:questarr /app
 
 # Copy and set up entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,10 @@ COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/package.json ./
 
 # Create user, group, data directory, and set ownership
-RUN addgroup questarr && \
-    adduser -G questarr -s /bin/sh -D questarr && \
-    mkdir -p /app/data && \
-    chown -R questarr:questarr /app
+RUN addgroup questarr
+RUN adduser -G questarr -s /bin/sh -D questarr 
+RUN mkdir -p /app/data
+RUN chown -R questarr:questarr /app
 
 # Copy and set up entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,13 +14,7 @@ services:
       - ./data:/app/data
     restart: unless-stopped
     healthcheck:
-      test:
-        [
-          "CMD",
-          "node",
-          "-e",
-          "require('http').get('http://localhost:5000/api/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))",
-        ]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:5000/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/plan-synology-download-station.md
+++ b/docs/plan-synology-download-station.md
@@ -1,0 +1,169 @@
+# Plan: Add Synology Download Station Support (Issue #567)
+
+## Context
+
+A user requested Synology Download Station as a download client (like Sonarr/Radarr support it). Questarr already supports 5 clients (qBittorrent, Transmission, rTorrent, SABnzbd, NZBGet) via a clean factory pattern. No schema changes are needed — existing fields cover all Synology config. The Synology Web API uses session-based auth and has a DSM 6 vs DSM 7 split (different CGI paths/API names).
+
+---
+
+## Files to Modify
+
+| File                                   | Change                                                   |
+| -------------------------------------- | -------------------------------------------------------- |
+| `server/downloaders.ts`                | Add `SynologyDownloadStationClient` class + factory case |
+| `client/src/pages/downloaders.tsx`     | Add to type picker + default port                        |
+| `server/__tests__/downloaders.test.ts` | Add test suite for Synology client                       |
+
+No migrations needed.
+
+---
+
+## Implementation Plan
+
+### 1. `server/downloaders.ts` — New Client Class
+
+Add `SynologyDownloadStationClient implements DownloaderClient` near line 3250 (after NZBGet).
+
+**Auth strategy:**
+
+- On first request, call `GET /webapi/query.cgi?api=SYNO.API.Info&version=1&method=query&query=SYNO.API.Auth,SYNO.DownloadStation2.Task` to detect DSM version
+- Cache the session ID (`_sid`) in-memory; re-login on error code 106 (session timeout), retry once
+- Build base URL from `downloader.url`, `downloader.port`, `downloader.useSsl`
+
+**API dual-path:**
+
+- DSM 6: `POST /webapi/DownloadStation/task.cgi` with `SYNO.DownloadStation.Task` v2
+- DSM 7: `POST /webapi/DownloadStation/entry.cgi` with `SYNO.DownloadStation2.Task` v2 + `create_list=false`
+- Detection: presence of `SYNO.DownloadStation2.Task` in `SYNO.API.Info` response
+
+**Method implementations:**
+
+| Method                            | Synology API call                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `testConnection()`                | Login + logout                                                                                                |
+| `addDownload(request)`            | URL/magnet: `uri=` (DSM6) or `url=`+`type=url`+`create_list=false` (DSM7); torrent/NZB file: multipart upload |
+| `getDownloadStatus(id)`           | `method=getinfo&id=<id>&additional=detail,transfer`                                                           |
+| `getDownloadDetails(id)`          | `method=getinfo&id=<id>&additional=detail,transfer,file,tracker`                                              |
+| `getAllDownloads()`               | `method=list&additional=detail,transfer`                                                                      |
+| `pauseDownload(id)`               | `method=pause&id=<id>`                                                                                        |
+| `resumeDownload(id)`              | `method=resume&id=<id>`                                                                                       |
+| `removeDownload(id, deleteFiles)` | `method=delete&id=<id>&force_complete=false`                                                                  |
+| `getFreeSpace()`                  | `SYNO.FileStation.Info&method=get` → `useable_space` field                                                    |
+
+**Status mapping** (Synology → internal):
+
+```typescript
+const STATUS_MAP = {
+  waiting: "queued",
+  downloading: "downloading",
+  paused: "paused",
+  finishing: "downloading",
+  finished: "completed",
+  hash_checking: "checking",
+  seeding: "seeding",
+  extracting: "downloading",
+  error: "error",
+  filehosting_waiting: "queued",
+};
+```
+
+**Destination:** use `downloader.downloadPath` if set (Synology expects shared-folder-relative path, e.g. `video/downloads`, not `/volume1/video/downloads`).
+
+**SSRF:** wrap all fetch calls with `isSafeUrl()` (same pattern as other clients, e.g. line 308 of `downloaders.ts`).
+
+### 2. Factory (downloaders.ts ~line 3001)
+
+```typescript
+case "synology":
+  return new SynologyDownloadStationClient(downloader);
+```
+
+### 3. Frontend (client/src/pages/downloaders.tsx ~line 41)
+
+```typescript
+{ value: "synology", label: "Synology Download Station", protocol: "torrent" },
+```
+
+- Add default port `5000` for Synology in the port defaults map
+- No additional custom fields needed — existing fields (name, URL, port, SSL, username, password, download path, category, priority) are sufficient
+- Add help text noting DSM 7 uses HTTPS by default
+
+### 4. Tests (server/**tests**/downloaders.test.ts)
+
+Follow Transmission test pattern (lines 25–195). Mock global `fetch`. Cover:
+
+- `testConnection()` — success, auth failure (code 400), network error
+- `addDownload()` — magnet (DSM6 path), torrent file upload, DSM7 path detection
+- `getDownloadStatus()` — found, not found
+- `getAllDownloads()` — status mapping
+- `pauseDownload()` / `resumeDownload()` / `removeDownload()`
+- Session timeout (error 106) → re-login + retry once
+- `getFreeSpace()`
+
+---
+
+## Synology API Reference
+
+**Base URL:** `http(s)://<host>:<port>/webapi/` (default ports: 5000 HTTP, 5001 HTTPS)
+
+**Auth:**
+
+```
+GET /webapi/auth.cgi?api=SYNO.API.Auth&version=3&method=login
+  &account=<user>&passwd=<pass>&session=DownloadStation&format=sid
+```
+
+Returns `{ "success": true, "data": { "sid": "..." } }`. Pass `_sid=<sid>` on all subsequent calls.
+
+**Version detection:**
+
+```
+GET /webapi/query.cgi?api=SYNO.API.Info&version=1&method=query
+  &query=SYNO.API.Auth,SYNO.DownloadStation2.Task
+```
+
+**Task list:**
+
+```
+GET /webapi/DownloadStation/task.cgi?api=SYNO.DownloadStation.Task
+  &version=1&method=list&additional=detail,transfer&_sid=<sid>
+```
+
+**Add by URL (DSM 6):**
+
+```
+POST /webapi/DownloadStation/task.cgi
+api=SYNO.DownloadStation.Task&version=1&method=create&uri=<url_or_magnet>&_sid=<sid>
+```
+
+**Add by URL (DSM 7):**
+
+```
+POST /webapi/DownloadStation/entry.cgi
+api=SYNO.DownloadStation2.Task&version=2&method=create&type=url&url=<url>&create_list=false&_sid=<sid>
+```
+
+Note: `create_list=false` is **required** on DSM 7 — omitting causes error 101.
+
+**Pause / Resume / Delete:**
+
+```
+GET /webapi/DownloadStation/task.cgi?api=SYNO.DownloadStation.Task
+  &version=1&method=pause|resume|delete&id=<task_id>&_sid=<sid>
+```
+
+**Key error codes:**
+
+- 106 = session timeout → re-login and retry
+- 400 = wrong credentials
+- 401 = max tasks reached
+- 402/403 = destination denied/not found
+
+---
+
+## Verification
+
+1. `npm run check` — TypeScript compiles cleanly
+2. `npx vitest run server/__tests__/downloaders.test.ts` — new Synology tests pass
+3. `npm run lint` — no lint errors
+4. Manual: configure Synology DS in UI, click "Test Connection"

--- a/package.json
+++ b/package.json
@@ -172,11 +172,11 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
-      "eslint --fix",
-      "prettier --write"
+      "eslint --fix --cache --cache-strategy content --cache-location node_modules/.cache/eslint",
+      "prettier --cache --cache-strategy content --cache-location node_modules/.cache/prettier/.prettier-cache --write"
     ],
     "*.{json,css,md}": [
-      "prettier --write"
+      "prettier --cache --cache-strategy content --cache-location node_modules/.cache/prettier/.prettier-cache --write"
     ]
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "questarr",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A video game management application inspired by the -Arr apps. Track and organize your video game collection with automated discovery and download management.",
   "type": "module",
   "packageManager": "npm@11.7.0",

--- a/server/__tests__/cron_autosearch.test.ts
+++ b/server/__tests__/cron_autosearch.test.ts
@@ -804,4 +804,71 @@ describe("Cron - checkAutoSearch", () => {
 
     expect(mockUpdateGameSearchResultsAvailable).toHaveBeenCalledWith(game.id, false);
   });
+
+  describe("Download Rules", () => {
+    const ITEM_LOW_SEEDERS = {
+      title: "Test Game-SKIDROW",
+      link: "https://example.com/low",
+      pubDate: FIXED_PUB_DATE,
+      seeders: 5,
+      size: 10_000,
+    };
+    const ITEM_HIGH_SEEDERS = {
+      title: "Test Game-CODEX",
+      link: "https://example.com/high",
+      pubDate: FIXED_PUB_DATE,
+      seeders: 100,
+      size: 10_000,
+    };
+
+    it("should apply minSeeders from valid downloadRules to filter results", async () => {
+      const game = { ...baseGame, releaseStatus: "released" as const };
+      const settings = {
+        ...baseSettings,
+        downloadRules: JSON.stringify({
+          minSeeders: 50,
+          sortBy: "seeders",
+          visibleCategories: ["main"],
+        }),
+        autoDownloadEnabled: false,
+      };
+
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+      mockGetUserSettings.mockResolvedValue(settings);
+      mockSearchAllIndexers.mockResolvedValue({
+        items: [ITEM_LOW_SEEDERS, ITEM_HIGH_SEEDERS],
+        errors: [],
+        total: 2,
+      });
+
+      await checkAutoSearch();
+
+      // Only ITEM_HIGH_SEEDERS (100 seeders) passes the minSeeders:50 filter
+      expect(mockUpdateGameSearchResultsAvailable).toHaveBeenCalledWith(game.id, true);
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Available" })
+      );
+    });
+
+    it("should fall back to default rules when downloadRules JSON is malformed", async () => {
+      const game = { ...baseGame, releaseStatus: "released" as const };
+      const settings = {
+        ...baseSettings,
+        downloadRules: "{not valid json}",
+        autoDownloadEnabled: false,
+      };
+
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+      mockGetUserSettings.mockResolvedValue(settings);
+      mockSearchAllIndexers.mockResolvedValue({
+        items: [ITEM_LOW_SEEDERS],
+        errors: [],
+        total: 1,
+      });
+
+      // Should not throw; defaults have minSeeders=0, so the item passes
+      await expect(checkAutoSearch()).resolves.not.toThrow();
+      expect(mockUpdateGameSearchResultsAvailable).toHaveBeenCalledWith(game.id, true);
+    });
+  });
 });

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -48,11 +48,15 @@ function getAutoSearchRules(downloadRules: string | null): AutoSearchRules {
   let visibleCategoriesSet = new Set(["main", "update", "dlc", "extra"]);
 
   if (downloadRules) {
-    const parsed = JSON.parse(downloadRules);
-    const rules = downloadRulesSchema.parse(parsed);
-    minSeeders = rules.minSeeders;
-    sortBy = rules.sortBy;
-    visibleCategoriesSet = new Set(rules.visibleCategories);
+    try {
+      const parsed = JSON.parse(downloadRules);
+      const rules = downloadRulesSchema.parse(parsed);
+      minSeeders = rules.minSeeders;
+      sortBy = rules.sortBy;
+      visibleCategoriesSet = new Set(rules.visibleCategories);
+    } catch {
+      // malformed rules — use defaults
+    }
   }
 
   return { minSeeders, sortBy, visibleCategoriesSet };
@@ -306,6 +310,11 @@ export async function checkGameUpdates() {
           releaseDate: currentReleaseDateStr,
           originalReleaseDate: currentReleaseDateStr,
         });
+        // We need to update local object if we were to continue using it,
+        // but the original code did 'continue'.
+        // However, 'continue' skips the rest of the loop logic (status check).
+        // If we just initialized, do we want to skip status check?
+        // Original code: yes.
         continue;
       }
     }
@@ -514,6 +523,7 @@ export async function checkDownloadStatus() {
               title: "Download Completed",
               message,
               link: "/library",
+              userId: game?.userId ?? undefined,
             });
             notifyUser("notification", notification);
           } else {
@@ -650,6 +660,7 @@ export async function checkDownloadStatus() {
             title: "Download Status Changed",
             message: `Download for "${gameTitle}" was not found in the downloader and has been marked as completed. If this was removed due to an error, you may need to re-download it.`,
             link: "/library",
+            userId: game?.userId ?? undefined,
           });
           notifyUser("notification", notification);
 

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -48,15 +48,11 @@ function getAutoSearchRules(downloadRules: string | null): AutoSearchRules {
   let visibleCategoriesSet = new Set(["main", "update", "dlc", "extra"]);
 
   if (downloadRules) {
-    try {
-      const parsed = JSON.parse(downloadRules);
-      const rules = downloadRulesSchema.parse(parsed);
-      minSeeders = rules.minSeeders;
-      sortBy = rules.sortBy;
-      visibleCategoriesSet = new Set(rules.visibleCategories);
-    } catch {
-      // malformed rules — use defaults
-    }
+    const parsed = JSON.parse(downloadRules);
+    const rules = downloadRulesSchema.parse(parsed);
+    minSeeders = rules.minSeeders;
+    sortBy = rules.sortBy;
+    visibleCategoriesSet = new Set(rules.visibleCategories);
   }
 
   return { minSeeders, sortBy, visibleCategoriesSet };
@@ -310,11 +306,6 @@ export async function checkGameUpdates() {
           releaseDate: currentReleaseDateStr,
           originalReleaseDate: currentReleaseDateStr,
         });
-        // We need to update local object if we were to continue using it,
-        // but the original code did 'continue'.
-        // However, 'continue' skips the rest of the loop logic (status check).
-        // If we just initialized, do we want to skip status check?
-        // Original code: yes.
         continue;
       }
     }
@@ -415,11 +406,11 @@ export async function checkDownloadStatus() {
 
   // Prune stale entries from downloadMissCount (e.g. downloads removed from DB while still downloading)
   const activeDownloadIds = new Set(downloadingDownloads.map((d) => d.id));
-  for (const key of Array.from(downloadMissCount.keys())) {
+  downloadMissCount.forEach((_, key) => {
     if (!activeDownloadIds.has(key)) {
       downloadMissCount.delete(key);
     }
-  }
+  });
 
   // Group by downloader
   const downloadsByDownloader = new Map<string, typeof downloadingDownloads>();

--- a/server/downloaders.ts
+++ b/server/downloaders.ts
@@ -1630,12 +1630,14 @@ export class RTorrentClient implements DownloaderClient {
                   url,
                   username: this.downloader.username,
                   method,
+                  authHeader,
                   errorText: retryErrorText,
                 },
                 "rTorrent Digest Authentication failed"
               );
+              const isHttp = url.startsWith("http://");
               throw new Error(
-                `Digest Authentication failed: ${retryResponse.status} ${retryResponse.statusText}`
+                `Digest Authentication failed (wrong credentials${isHttp ? ", or server may have switched to HTTPS" : ""})`
               );
             }
           } catch (error) {


### PR DESCRIPTION
- Wrap downloadRules JSON parsing in try/catch to handle malformed config
- Prune stale downloadMissCount entries for downloads removed from DB
- Move getDownloader call inside try/catch to handle per-downloader errors
- Clean up downloadMissCount on downloader error to avoid stale miss tracking
- Add userId to download completed/status-changed notifications
- Replace console.error with structured logger in steam-routes