### PR TITLE
🎨 Palette: Improve button ARIA semantics

### DIFF
--- a/client/src/components/AppSidebar.tsx
+++ b/client/src/components/AppSidebar.tsx
@@ -187,12 +187,12 @@ export default function AppSidebar({ activeItem = "/", onNavigate }: Readonly<Ap
                           : undefined
                       }
                     >
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2" aria-hidden={item.badge ? "true" : undefined}>
                         <item.icon className="w-4 h-4" />
                         <span>{item.title}</span>
                       </div>
                       {item.badge && (
-                        <Badge variant="secondary" className="ml-auto text-xs">
+                        <Badge variant="secondary" className="ml-auto text-xs" aria-hidden="true">
                           {item.badge}
                         </Badge>
                       )}

--- a/client/src/components/PreferredReleaseGroupsSettings.tsx
+++ b/client/src/components/PreferredReleaseGroupsSettings.tsx
@@ -126,8 +126,9 @@ export default function PreferredReleaseGroupsSettings({
                 size="icon"
                 onClick={handleAddGroup}
                 disabled={!inputValue.trim()}
+                aria-label="Add preferred release group"
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
### 💡 What

Added an `aria-label` to the "Add preferred release group" button and improved ARIA semantics in the App Sidebar by applying `aria-hidden="true"` to inner icon and text elements when the parent button already defines a comprehensive, consolidated `aria-label`.

### 🎯 Why

Icon-only buttons must provide an `aria-label` so screen reader users understand their function. Additionally, when a parent element provides a complete, accessible name via `aria-label` (such as combining the navigation text and notification badge count), the child elements should be hidden from assistive technologies. If they are not hidden, screen readers will redundantly read the parent label and then the text of the child elements again.

### 📸 Before/After

**Before:**

- Screen readers encounter an unlabelled `<button>` in the release groups settings.
- Screen readers reading the sidebar hear: "Downloads, 2 active downloads, button. Downloads. 2."

**After:**

- Screen readers announce "Add preferred release group, button" in the settings.
- Screen readers reading the sidebar hear only: "Downloads, 2 active downloads, button."

### ♿ Accessibility

- Fixed missing accessible name for icon-only button.
- Prevented redundant reading of text and badges by assistive technologies in the navigation sidebar.

---

*PR created automatically by Jules for task [4187433868248849735](https://jules.google.com/task/4187433868248849735) started by @Doezer*