### PR TITLE
Backport PR #622 and #623 to release/1.4.0

### DIFF
--- a/client/__tests__/CompactGameCard.test.tsx
+++ b/client/__tests__/CompactGameCard.test.tsx
@@ -85,23 +85,24 @@ describe("CompactGameCard", () => {
     renderWithProviders(<CompactGameCard game={mockGame} />);
 
     expect(screen.getByText("Test Game")).toBeInTheDocument();
-    expect(screen.getByText("8.5/10")).toBeInTheDocument();
-    expect(screen.getByText("2023-01-01")).toBeInTheDocument();
+    expect(screen.getByText("8.5")).toBeInTheDocument();
+    expect(screen.getByText("2023")).toBeInTheDocument();
     expect(screen.getByText("Action")).toBeInTheDocument();
     expect(screen.getByText("Adventure")).toBeInTheDocument();
   });
 
-  it("renders 'No genres' when genres is empty or undefined", () => {
+  it("renders no genre pills when genres is empty", () => {
     const gameWithoutGenres = { ...mockGame, genres: [] };
     renderWithProviders(<CompactGameCard game={gameWithoutGenres} />);
-    expect(screen.getByText("No genres")).toBeInTheDocument();
+    expect(screen.queryByText("Action")).not.toBeInTheDocument();
+    expect(screen.queryByText("Adventure")).not.toBeInTheDocument();
   });
 
   it("calls onStatusChange when status button is clicked", () => {
     const onStatusChange = vi.fn();
     renderWithProviders(<CompactGameCard game={mockGame} onStatusChange={onStatusChange} />);
 
-    const button = screen.getByText("Mark Owned");
+    const button = screen.getByLabelText("Mark Test Game as Owned");
     fireEvent.click(button);
 
     expect(onStatusChange).toHaveBeenCalledWith("1", "owned");
@@ -152,7 +153,7 @@ describe("CompactGameCard", () => {
   it("shows Early Access badge when earlyAccess is true", () => {
     const game = { ...mockGame, earlyAccess: true } as unknown as Game;
     renderWithProviders(<CompactGameCard game={game} />);
-    expect(screen.getByText("Early Access")).toBeInTheDocument();
+    expect(screen.getByText("EA")).toBeInTheDocument();
   });
 
   it("does not show Early Access badge when earlyAccess is false", () => {

--- a/client/__tests__/ViewControlsToolbar.test.tsx
+++ b/client/__tests__/ViewControlsToolbar.test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import ViewControlsToolbar from "../src/components/ViewControlsToolbar";
+import { TooltipProvider } from "../src/components/ui/tooltip";
 import "@testing-library/jest-dom";
 
 // Mock lucide-react icons
@@ -12,27 +13,14 @@ vi.mock("lucide-react", async (importOriginal) => {
     ...actual,
     LayoutGrid: () => <div data-testid="icon-layout-grid" />,
     List: () => <div data-testid="icon-list" />,
-    Settings2: () => <div data-testid="icon-settings2" />,
+    Rows2: () => <div data-testid="icon-rows2" />,
+    Rows3: () => <div data-testid="icon-rows3" />,
   };
 });
 
-// Mock Radix UI DropdownMenu — renders content inline so items are always accessible
-vi.mock("@/components/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: React.PropsWithChildren) => <>{children}</>,
-  DropdownMenuTrigger: ({ children }: React.PropsWithChildren<{ asChild?: boolean }>) => (
-    <>{children}</>
-  ),
-  DropdownMenuContent: ({ children }: React.PropsWithChildren) => (
-    <div data-testid="dropdown-content">{children}</div>
-  ),
-  DropdownMenuItem: ({ children, onClick }: React.PropsWithChildren<{ onClick?: () => void }>) => (
-    <button role="menuitem" onClick={onClick}>
-      {children}
-    </button>
-  ),
-  DropdownMenuLabel: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-  DropdownMenuSeparator: () => null,
-}));
+function renderWithTooltip(ui: React.ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
 
 describe("ViewControlsToolbar", () => {
   const defaultProps = {
@@ -43,64 +31,55 @@ describe("ViewControlsToolbar", () => {
   };
 
   it("renders grid and list toggle buttons", () => {
-    render(<ViewControlsToolbar {...defaultProps} />);
+    renderWithTooltip(<ViewControlsToolbar {...defaultProps} />);
     expect(screen.getByLabelText("Grid View")).toBeInTheDocument();
     expect(screen.getByLabelText("List View")).toBeInTheDocument();
   });
 
-  it("does not show density dropdown in grid mode", () => {
-    render(<ViewControlsToolbar {...defaultProps} viewMode="grid" />);
-    expect(screen.queryByTestId("dropdown-content")).not.toBeInTheDocument();
+  it("does not show density button in grid mode", () => {
+    renderWithTooltip(<ViewControlsToolbar {...defaultProps} viewMode="grid" />);
+    expect(screen.queryByText("Comfortable")).not.toBeInTheDocument();
+    expect(screen.queryByText("Compact")).not.toBeInTheDocument();
   });
 
-  it("shows density options in list mode", () => {
-    render(<ViewControlsToolbar {...defaultProps} viewMode="list" />);
-    expect(screen.getByTestId("dropdown-content")).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: "Comfortable" })).toBeInTheDocument();
+  it("shows density toggle button in list mode", () => {
+    renderWithTooltip(<ViewControlsToolbar {...defaultProps} viewMode="list" />);
+    expect(screen.getByText("Comfortable")).toBeInTheDocument();
   });
 
   it("calls onViewModeChange when list toggle clicked", () => {
     const onViewModeChange = vi.fn();
-    render(<ViewControlsToolbar {...defaultProps} onViewModeChange={onViewModeChange} />);
+    renderWithTooltip(
+      <ViewControlsToolbar {...defaultProps} onViewModeChange={onViewModeChange} />
+    );
     fireEvent.click(screen.getByLabelText("List View"));
     expect(onViewModeChange).toHaveBeenCalledWith("list");
   });
 
   it("shows current density label in list mode trigger button", () => {
-    render(<ViewControlsToolbar {...defaultProps} viewMode="list" listDensity="compact" />);
-    // The trigger button span shows the current density
-    expect(screen.getAllByText("Compact").length).toBeGreaterThanOrEqual(1);
+    renderWithTooltip(
+      <ViewControlsToolbar {...defaultProps} viewMode="list" listDensity="compact" />
+    );
+    expect(screen.getByText("Compact")).toBeInTheDocument();
   });
 
-  it("calls onListDensityChange with compact when Compact item clicked", () => {
+  it("calls onListDensityChange with compact when button clicked in comfortable mode", () => {
     const onListDensityChange = vi.fn();
-    render(
+    renderWithTooltip(
       <ViewControlsToolbar
         {...defaultProps}
         viewMode="list"
+        listDensity="comfortable"
         onListDensityChange={onListDensityChange}
       />
     );
-    fireEvent.click(screen.getByRole("menuitem", { name: "Compact" }));
+    fireEvent.click(screen.getByText("Comfortable"));
     expect(onListDensityChange).toHaveBeenCalledWith("compact");
   });
 
-  it("calls onListDensityChange with ultra-compact when Ultra-compact item clicked", () => {
+  it("calls onListDensityChange with comfortable when button clicked in compact mode", () => {
     const onListDensityChange = vi.fn();
-    render(
-      <ViewControlsToolbar
-        {...defaultProps}
-        viewMode="list"
-        onListDensityChange={onListDensityChange}
-      />
-    );
-    fireEvent.click(screen.getByRole("menuitem", { name: "Ultra-compact" }));
-    expect(onListDensityChange).toHaveBeenCalledWith("ultra-compact");
-  });
-
-  it("calls onListDensityChange with comfortable when Comfortable item clicked", () => {
-    const onListDensityChange = vi.fn();
-    render(
+    renderWithTooltip(
       <ViewControlsToolbar
         {...defaultProps}
         viewMode="list"
@@ -108,7 +87,7 @@ describe("ViewControlsToolbar", () => {
         onListDensityChange={onListDensityChange}
       />
     );
-    fireEvent.click(screen.getByRole("menuitem", { name: "Comfortable" }));
+    fireEvent.click(screen.getByText("Compact"));
     expect(onListDensityChange).toHaveBeenCalledWith("comfortable");
   });
 });

--- a/client/src/components/AppSidebar.tsx
+++ b/client/src/components/AppSidebar.tsx
@@ -176,11 +176,11 @@ export default function AppSidebar({ activeItem = "/", onNavigate }: Readonly<Ap
                       }
                     >
                       <div className="flex items-center gap-2">
-                        <item.icon className="w-4 h-4" />
+                        <item.icon className="w-4 h-4" aria-hidden="true" />
                         <span>{item.title}</span>
                       </div>
                       {item.badge && (
-                        <Badge variant="secondary" className="ml-auto text-xs">
+                        <Badge variant="secondary" className="ml-auto text-xs" aria-hidden="true">
                           {item.badge}
                         </Badge>
                       )}
@@ -207,7 +207,7 @@ export default function AppSidebar({ activeItem = "/", onNavigate }: Readonly<Ap
                       onClick={() => handleNavigation(item.url)}
                       className="flex items-center gap-2 w-full"
                     >
-                      <item.icon className="w-4 h-4" />
+                      <item.icon className="w-4 h-4" aria-hidden="true" />
                       <span>{item.title}</span>
                     </button>
                   </SidebarMenuButton>

--- a/client/src/components/PreferredReleaseGroupsSettings.tsx
+++ b/client/src/components/PreferredReleaseGroupsSettings.tsx
@@ -126,8 +126,9 @@ export default function PreferredReleaseGroupsSettings({
                 size="icon"
                 onClick={handleAddGroup}
                 disabled={!inputValue.trim()}
+                aria-label="Add preferred release group"
               >
-                <Plus className="h-4 w-4" />
+                <Plus className="h-4 w-4" aria-hidden="true" />
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">

--- a/server/__tests__/security.test.ts
+++ b/server/__tests__/security.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import request from "supertest";
 import express from "express";
+import { createApp as createServerApp } from "../app.js";
 
 // Use vi.hoisted to create the mock object before hoisting occurs
 const { mockConfig } = vi.hoisted(() => {
@@ -75,8 +76,6 @@ vi.mock("../steam-routes.js", () => ({
 import { registerRoutes } from "../routes.js";
 
 describe("Security Headers", () => {
-  let app: express.Express;
-
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset config to dev default
@@ -88,7 +87,7 @@ describe("Security Headers", () => {
   });
 
   const createApp = async () => {
-    app = express();
+    const app = createServerApp();
     await registerRoutes(app);
     return app;
   };
@@ -133,6 +132,12 @@ describe("Security Headers", () => {
     const app = await createApp();
     const response = await request(app).get("/api/auth/status");
     expect(response.headers["x-content-type-options"]).toBe("nosniff");
+  });
+
+  it("should hide X-Powered-By header", async () => {
+    const app = await createApp();
+    const response = await request(app).get("/api/auth/status");
+    expect(response.headers["x-powered-by"]).toBeUndefined();
   });
 });
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,0 +1,86 @@
+import express from "express";
+import cors from "cors";
+import { generalApiLimiter } from "./middleware.js";
+import { config } from "./config.js";
+import { expressLogger } from "./logger.js";
+import { truncateLogData } from "./log-response.js";
+
+export function createApp() {
+  const app = express();
+  app.disable("x-powered-by");
+
+  if (config.server.isProduction) {
+    app.set("trust proxy", 1);
+  }
+
+  app.use(
+    cors({
+      origin: config.server.allowedOrigins,
+      credentials: true,
+    })
+  );
+  app.use(express.json({ limit: "5mb" }));
+  app.use(express.urlencoded({ extended: false }));
+
+  app.use("/api", generalApiLimiter);
+
+  app.use((_req, res, next) => {
+    res.setHeader("Origin-Agent-Cluster", "?1");
+    next();
+  });
+
+  app.use((req, res, next) => {
+    const start = Date.now();
+    const path = req.path;
+    let capturedJsonResponse: Record<string, unknown> | undefined;
+
+    const originalResJson = res.json;
+    res.json = function (bodyJson, ...args) {
+      capturedJsonResponse = bodyJson;
+      return originalResJson.apply(res, [bodyJson, ...args]);
+    };
+
+    res.on("finish", () => {
+      const duration = Date.now() - start;
+      if (path.startsWith("/api")) {
+        const isNoisyEndpoint =
+          ((path === "/api/downloads" ||
+            path === "/api/games" ||
+            path === "/api/notifications" ||
+            path === "/api/search" ||
+            path === "/api/rss/items") &&
+            req.method === "GET") ||
+          path.startsWith("/api/igdb/genre/") ||
+          path === "/api/igdb/popular" ||
+          path === "/api/igdb/upcoming" ||
+          path.match(/^\/api\/indexers\/[^/]+\/categories$/);
+
+        expressLogger.info(
+          {
+            method: req.method,
+            path,
+            statusCode: res.statusCode,
+            duration,
+            response: isNoisyEndpoint ? undefined : truncateLogData(capturedJsonResponse),
+          },
+          `${req.method} ${path} ${res.statusCode} in ${duration}ms`
+        );
+
+        if (isNoisyEndpoint) {
+          expressLogger.debug(
+            {
+              method: req.method,
+              path,
+              response: capturedJsonResponse,
+            },
+            `${req.method} ${path} response body`
+          );
+        }
+      }
+    });
+
+    next();
+  });
+
+  return app;
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -32,7 +32,7 @@ export function createApp() {
   app.use((req, res, next) => {
     const start = Date.now();
     const path = req.path;
-    let capturedJsonResponse: Record<string, unknown> | undefined;
+    let capturedJsonResponse: unknown;
 
     const originalResJson = res.json;
     res.json = function (bodyJson, ...args) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,15 +1,13 @@
 // Force restart trigger
 import "dotenv/config";
-import express from "express";
 import https from "https";
 import fs from "fs";
-import cors from "cors";
 
+import { createApp } from "./app.js";
 import { registerRoutes } from "./routes.js";
 import { setupVite, serveStatic, log } from "./vite.js";
-import { generalApiLimiter, errorHandler } from "./middleware.js";
+import { errorHandler } from "./middleware.js";
 import { config } from "./config.js";
-import { expressLogger } from "./logger.js";
 import { startCronJobs } from "./cron.js";
 import { setupSocketIO } from "./socket.js";
 import { ensureDatabase } from "./migrate.js";
@@ -17,85 +15,8 @@ import { rssService } from "./rss.js";
 import { nexusmodsClient } from "./nexusmods.js";
 import { appriseClient } from "./apprise.js";
 import { storage } from "./storage.js";
-import { truncateLogData } from "./log-response.js";
 
-const app = express();
-if (config.server.isProduction) {
-  app.set("trust proxy", 1);
-}
-app.use(
-  cors({
-    origin: config.server.allowedOrigins,
-    credentials: true,
-  })
-);
-app.use(express.json({ limit: "5mb" }));
-app.use(express.urlencoded({ extended: false }));
-
-// Apply general rate limiting to all API routes
-app.use("/api", generalApiLimiter);
-
-// 🛡️ Set Origin-Agent-Cluster header to preventing mismatch errors
-app.use((_req, res, next) => {
-  res.setHeader("Origin-Agent-Cluster", "?1");
-  next();
-});
-
-app.use((req, res, next) => {
-  const start = Date.now();
-  const path = req.path;
-  let capturedJsonResponse: Record<string, unknown> | undefined = undefined;
-
-  const originalResJson = res.json;
-  res.json = function (bodyJson, ...args) {
-    capturedJsonResponse = bodyJson;
-    return originalResJson.apply(res, [bodyJson, ...args]);
-  };
-
-  res.on("finish", () => {
-    const duration = Date.now() - start;
-    if (path.startsWith("/api")) {
-      const isNoisyEndpoint =
-        ((path === "/api/downloads" ||
-          path === "/api/games" ||
-          path === "/api/notifications" ||
-          path === "/api/search" ||
-          path === "/api/rss/items") &&
-          req.method === "GET") ||
-        path.startsWith("/api/igdb/genre/") ||
-        path === "/api/igdb/popular" ||
-        path === "/api/igdb/upcoming" ||
-        path.match(/^\/api\/indexers\/[^/]+\/categories$/);
-
-      // Always log metadata at info level
-      expressLogger.info(
-        {
-          method: req.method,
-          path,
-          statusCode: res.statusCode,
-          duration,
-          // Only include response body for non-noisy endpoints at info level, but truncated
-          response: isNoisyEndpoint ? undefined : truncateLogData(capturedJsonResponse),
-        },
-        `${req.method} ${path} ${res.statusCode} in ${duration}ms`
-      );
-
-      // Log the full response body at debug level for noisy endpoints
-      if (isNoisyEndpoint) {
-        expressLogger.debug(
-          {
-            method: req.method,
-            path,
-            response: capturedJsonResponse,
-          },
-          `${req.method} ${path} response body`
-        );
-      }
-    }
-  });
-
-  next();
-});
+const app = createApp();
 
 (async () => {
   try {


### PR DESCRIPTION
## Summary\n- backport the useful parts of #622 and #623 onto

elease/1.4.0\n- disable Express X-Powered-By through a shared app factory used by production startup and the security test\n- improve accessibility for the preferred release group add button and hide decorative sidebar icons and badges from assistive tech\n\n## Notes from review\n- intentionally omitted the unrelated package-lock.json version bump from #622\n- addressed the #622 review by testing the shared app setup instead of manually disabling the header in a single test\n- addressed the #623 review by hiding decorative icons consistently in the sidebar, while keeping visible text available as fallback semantics\n\n## Utility review\n- the x-powered-by hardening is low-risk and worth backporting because it reduces framework fingerprinting with essentially no behavior change\n- the accessibility fixes are small, user-facing improvements with low release risk and clear benefit for screen-reader users\n\n## Validation\n-
px vitest run server/__tests__/security.test.ts\n-
pm run check\n-
pm run lint *(existing unrelated warning remains in client/src/pages/settings.tsx)*\n\n## Source PRs\n- #622\n- #623