### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerabilities by using safeFetch

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -15,3 +15,8 @@
 **Vulnerability:** The RSS feed creation and update endpoints (`POST /api/rss/feeds` and `PUT /api/rss/feeds/:id`) lacked `isSafeUrl` validation, allowing attackers to force the server to fetch arbitrary URLs, including cloud metadata services (`169.254.169.254`).
 **Learning:** Even if `isSafeUrl` exists, it must be applied to _all_ inputs that trigger server-side requests. RSS feeds are a common vector for SSRF because they inherently involve fetching remote content.
 **Prevention:** Apply `isSafeUrl` validation to all URL inputs in API routes. Implement defense-in-depth by also validating the URL at the point of use (in `rssService.refreshFeed`).
+
+## 2025-05-24 - [SSRF via Global Fetch]
+**Vulnerability:** Core integration logic in `server/igdb.ts`, `server/routes.ts`, and `server/downloaders.ts` used the global `fetch` function directly, bypassing the application's SSRF protection and DNS rebinding mitigations.
+**Learning:** Even when validation middleware or `isSafeUrl` checks exist, directly calling `fetch` leaves the system vulnerable to Time-of-Check to Time-of-Use (TOCTOU) attacks, specifically DNS rebinding, where an attacker changes the DNS record after validation but before the actual fetch.
+**Prevention:** Always use the `safeFetch` wrapper from `server/ssrf.ts` for all outbound HTTP requests, as it performs IP validation at the time of resolution and pins the request to the verified IP.

--- a/server/downloaders.ts
+++ b/server/downloaders.ts
@@ -816,7 +816,7 @@ export class TransmissionClient implements DownloaderClient {
       headers["Authorization"] = `Basic ${auth}`;
     }
 
-    const response = await fetch(url, {
+    const response = await safeFetch(url, {
       method: "POST",
       headers,
       body: JSON.stringify(body),
@@ -833,7 +833,7 @@ export class TransmissionClient implements DownloaderClient {
         downloadersLogger.debug({ method, url }, "Retrying Transmission request with session ID");
 
         // Retry with session ID
-        const retryResponse = await fetch(url, {
+        const retryResponse = await safeFetch(url, {
           method: "POST",
           headers,
           body: JSON.stringify(body),
@@ -1584,7 +1584,7 @@ export class RTorrentClient implements DownloaderClient {
       headers["Authorization"] = `Basic ${auth}`;
     }
 
-    const response = await fetch(url, {
+    const response = await safeFetch(url, {
       method: "POST",
       headers,
       body: xmlBody,
@@ -1617,7 +1617,7 @@ export class RTorrentClient implements DownloaderClient {
 
             downloadersLogger.debug({ url }, "Retrying rTorrent request with Digest Auth");
 
-            const retryResponse = await fetch(url, {
+            const retryResponse = await safeFetch(url, {
               method: "POST",
               headers,
               body: xmlBody,
@@ -2829,7 +2829,7 @@ export class QBittorrentClient implements DownloaderClient {
     formData.append("password", this.downloader.password);
 
     try {
-      const response = await fetch(url, {
+      const response = await safeFetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
@@ -2979,7 +2979,7 @@ export class QBittorrentClient implements DownloaderClient {
       "Making qBittorrent request"
     );
 
-    let response = await fetch(url, {
+    let response = await safeFetch(url, {
       method,
       headers,
       body: requestBody,
@@ -2998,7 +2998,7 @@ export class QBittorrentClient implements DownloaderClient {
         retryHeaders["Cookie"] = this.cookie;
       }
 
-      response = await fetch(url, {
+      response = await safeFetch(url, {
         method,
         headers: retryHeaders,
         body: requestBody,
@@ -3331,7 +3331,7 @@ export class SABnzbdClient implements DownloaderClient {
 
   private async fetchWithFallback(url: string, options: RequestInit = {}): Promise<Response> {
     try {
-      return await fetch(url, options);
+      return await safeFetch(url, options);
     } catch (error) {
       const isSslError =
         error instanceof Error &&
@@ -3988,7 +3988,7 @@ export class NZBGetClient implements DownloaderClient {
 
     downloadersLogger.debug({ url, method, params: logParams }, "Making NZBGet XML-RPC request");
 
-    const response = await fetch(url, {
+    const response = await safeFetch(url, {
       method: "POST",
       headers,
       body: xmlBody,

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -5,6 +5,7 @@ import { storage } from "./storage.js";
 import { db } from "./db.js";
 import { userSettings } from "../shared/schema.js";
 import { logger } from "./logger.js";
+import { safeFetch } from "./ssrf.js";
 
 // Configuration constants for search limits
 const MAX_SEARCH_ATTEMPTS = 5;
@@ -195,7 +196,7 @@ class IGDBClient {
       throw new Error("IGDB credentials not configured");
     }
 
-    const response = await fetch(
+    const response = await safeFetch(
       `https://id.twitch.tv/oauth2/token?client_id=${clientId}&client_secret=${clientSecret}&grant_type=client_credentials`,
       {
         method: "POST",
@@ -226,7 +227,7 @@ class IGDBClient {
 
     let attempt = 0;
     while (true) {
-      const response = await fetch(`https://api.igdb.com/v4/${endpoint}`, {
+      const response = await safeFetch(`https://api.igdb.com/v4/${endpoint}`, {
         method: "POST",
         headers: {
           Accept: "application/json",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3256,7 +3256,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (message) formData.append("content", message);
       formData.append("file", new Blob([imageBuffer], { type: "image/png" }), "questarr-stats.png");
 
-      const discordRes = await fetch(webhookUrl, { method: "POST", body: formData });
+      const discordRes = await safeFetch(webhookUrl, { method: "POST", body: formData });
       if (!discordRes.ok) {
         const errorText = await discordRes.text().catch(() => "Unknown Discord error");
         routesLogger.error(


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Several backend components (`server/igdb.ts`, `server/routes.ts`, and `server/downloaders.ts`) were making outbound HTTP requests using the global `fetch` API. This bypassed the application's built-in SSRF and DNS rebinding protections, potentially allowing attackers to pivot requests into internal networks.
🎯 **Impact:** An attacker could potentially perform Server-Side Request Forgery (SSRF) and access sensitive internal services, local host ports, or cloud metadata endpoints.
🔧 **Fix:** Replaced all global `fetch` calls with the `safeFetch` utility from `server/ssrf.ts`. `safeFetch` securely resolves hostnames, checks the resulting IPs against an allowlist/denylist to prevent access to private networks, and pins the connection to the validated IP to prevent Time-of-Check to Time-of-Use (TOCTOU) DNS rebinding attacks.
✅ **Verification:** Verified by running the project's test suite, which includes comprehensive tests for SSRF protection (`ssrf.test.ts`, `downloaders_ssrf.test.ts`) and ensuring all integrations still function as expected.

---

*PR created automatically by Jules for task [16751343961242960896](https://jules.google.com/task/16751343961242960896) started by @Doezer*