### PR TITLE
Enhance mobile layout and navigation

### DIFF
--- a/client/__tests__/AddGameModal.test.tsx
+++ b/client/__tests__/AddGameModal.test.tsx
@@ -206,6 +206,15 @@ describe("AddGameModal", () => {
     expect(screen.getByRole("button", { name: "Go to Settings" })).toBeInTheDocument();
   });
 
+  it("shows the mobile starter prompt before a query is entered", async () => {
+    mockIsMobile = true;
+    renderModal();
+
+    fireEvent.click(screen.getByTestId("open-btn"));
+
+    expect(await screen.findByText("Type at least 3 characters to search.")).toBeInTheDocument();
+  });
+
   it("renders the mobile empty prompt and added badge for games already in collection", async () => {
     mockIsMobile = true;
     const result = makeSearchResult("Collection Game", "2024-12-31");

--- a/client/__tests__/AddGameModal.test.tsx
+++ b/client/__tests__/AddGameModal.test.tsx
@@ -73,7 +73,7 @@ function setupFetch({
   configured?: boolean;
   postHandler?: () => Promise<unknown>;
 } = {}) {
-  global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+  globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
     const u = String(url);
     if (u.includes("/api/config") && !u.includes("/api/igdb")) {
       return { ok: true, json: async () => ({ igdb: { configured } }) };
@@ -188,7 +188,7 @@ describe("AddGameModal", () => {
     fireEvent.click(screen.getByRole("switch"));
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         expect.stringContaining("includeUndated=true"),
         expect.any(Object)
       );
@@ -248,5 +248,17 @@ describe("AddGameModal", () => {
     });
 
     resolvePost?.();
+  });
+
+  it("shows a no-results message on mobile when a search returns nothing", async () => {
+    mockIsMobile = true;
+    setupFetch({ searchResults: [] });
+    renderModal({ initialQuery: "Missing Game" });
+
+    fireEvent.click(screen.getByTestId("open-btn"));
+
+    expect(
+      await screen.findByText("No games found. Try a different search term.")
+    ).toBeInTheDocument();
   });
 });

--- a/client/__tests__/AddGameModal.test.tsx
+++ b/client/__tests__/AddGameModal.test.tsx
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AddGameModal from "../src/components/AddGameModal";
@@ -10,13 +11,20 @@ vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: vi.fn() }),
 }));
 
+let mockIsMobile = false;
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => mockIsMobile,
+}));
+
 vi.mock("lucide-react", () => ({
   Search: () => <div />,
   Plus: () => <div />,
   Star: () => <div />,
   AlertCircle: () => <div />,
   Calendar: () => <div data-testid="icon-calendar" />,
-  Loader2: () => <div />,
+  Loader2: () => <div data-testid="icon-loader" />,
+  Check: () => <div data-testid="icon-check" />,
   X: () => <div />,
 }));
 
@@ -26,7 +34,19 @@ vi.mock("wouter", () => ({
 
 const createTestQueryClient = () =>
   new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    defaultOptions: {
+      queries: {
+        retry: false,
+        queryFn: async ({ queryKey }) => {
+          const response = await fetch(queryKey.join(""));
+          if (!response.ok) {
+            throw new Error("Network response was not ok");
+          }
+          return response.json();
+        },
+      },
+      mutations: { retry: false },
+    },
   });
 
 const makeSearchResult = (title = "Test Game", releaseDate = "2023-06-15") => ({
@@ -42,17 +62,34 @@ const makeSearchResult = (title = "Test Game", releaseDate = "2023-06-15") => ({
   source: "api",
 });
 
-function setupFetch(searchResults: object[] = []) {
-  global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+function setupFetch({
+  searchResults = [],
+  userGames = [],
+  configured = true,
+  postHandler,
+}: {
+  searchResults?: object[];
+  userGames?: object[];
+  configured?: boolean;
+  postHandler?: () => Promise<unknown>;
+} = {}) {
+  global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
     const u = String(url);
     if (u.includes("/api/config") && !u.includes("/api/igdb")) {
-      return { ok: true, json: async () => ({ igdb: { configured: true } }) };
+      return { ok: true, json: async () => ({ igdb: { configured } }) };
     }
     if (u.includes("/api/igdb/search")) {
       return { ok: true, json: async () => searchResults };
     }
-    if (u.includes("/api/games")) {
-      return { ok: true, json: async () => [] };
+    if (u === "/api/games" && init?.method === "POST" && postHandler) {
+      await postHandler();
+      return { ok: true, json: async () => ({}) };
+    }
+    if (u === "/api/games" && init?.method === "POST") {
+      return { ok: true, json: async () => ({}) };
+    }
+    if (u.endsWith("/api/games")) {
+      return { ok: true, json: async () => userGames };
     }
     return { ok: true, json: async () => [] };
   }) as never;
@@ -71,6 +108,7 @@ const renderModal = (props: { initialQuery?: string } = {}) => {
 describe("AddGameModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsMobile = false;
     clearAddGamePendingQuery();
     setupFetch();
   });
@@ -111,7 +149,7 @@ describe("AddGameModal", () => {
   });
 
   it("shows Calendar icon for search results with a release date", async () => {
-    setupFetch([makeSearchResult("Elden Ring", "2022-02-25")]);
+    setupFetch({ searchResults: [makeSearchResult("Elden Ring", "2022-02-25")] });
     renderModal({ initialQuery: "Elden Ring" });
     fireEvent.click(screen.getByTestId("open-btn"));
 
@@ -125,7 +163,7 @@ describe("AddGameModal", () => {
   });
 
   it("shows release year only for year-end release dates (Dec 31)", async () => {
-    setupFetch([makeSearchResult("TBD Game", "2024-12-31")]);
+    setupFetch({ searchResults: [makeSearchResult("TBD Game", "2024-12-31")] });
     renderModal({ initialQuery: "TBD Game" });
     fireEvent.click(screen.getByTestId("open-btn"));
 
@@ -139,7 +177,7 @@ describe("AddGameModal", () => {
   });
 
   it("requests undated IGDB results when the toggle is enabled", async () => {
-    setupFetch([makeSearchResult("Elden Ring", "2022-02-25")]);
+    setupFetch({ searchResults: [makeSearchResult("Elden Ring", "2022-02-25")] });
     renderModal({ initialQuery: "Elden Ring" });
     fireEvent.click(screen.getByTestId("open-btn"));
 
@@ -155,5 +193,60 @@ describe("AddGameModal", () => {
         expect.any(Object)
       );
     });
+  });
+
+  it("shows the mobile configuration prompt when IGDB is not configured", async () => {
+    mockIsMobile = true;
+    setupFetch({ configured: false });
+    renderModal();
+
+    fireEvent.click(screen.getByTestId("open-btn"));
+
+    expect(await screen.findByText("IGDB Configuration Required")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go to Settings" })).toBeInTheDocument();
+  });
+
+  it("renders the mobile empty prompt and added badge for games already in collection", async () => {
+    mockIsMobile = true;
+    const result = makeSearchResult("Collection Game", "2024-12-31");
+    setupFetch({
+      searchResults: [result],
+      userGames: [{ ...result }],
+    });
+    renderModal({ initialQuery: "Collection Game" });
+    fireEvent.click(screen.getByTestId("open-btn"));
+    fireEvent.change(screen.getByTestId("input-game-search"), {
+      target: { value: "Collection Game" },
+    });
+
+    expect(await screen.findByTestId("search-result-igdb-1")).toBeInTheDocument();
+    expect(screen.getByText("Added")).toBeInTheDocument();
+    expect(screen.getByText("2024")).toBeInTheDocument();
+  });
+
+  it("shows the mobile add spinner while a game is being added", async () => {
+    mockIsMobile = true;
+
+    let resolvePost: (() => void) | undefined;
+    setupFetch({
+      searchResults: [makeSearchResult("Pending Game", "2025-04-01")],
+      postHandler: () =>
+        new Promise<void>((resolve) => {
+          resolvePost = resolve;
+        }),
+    });
+
+    renderModal({ initialQuery: "Pending Game" });
+    fireEvent.click(screen.getByTestId("open-btn"));
+
+    const addButton = await screen.findByTestId("button-add-igdb-1");
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("icon-loader")).toBeInTheDocument();
+      expect(addButton).toBeDisabled();
+    });
+
+    resolvePost?.();
   });
 });

--- a/client/__tests__/CalendarPage.test.tsx
+++ b/client/__tests__/CalendarPage.test.tsx
@@ -97,7 +97,7 @@ describe("CalendarPage", () => {
   it("shows the IGDB setup prompt when configuration is missing", async () => {
     const { apiRequest } = await import("@/lib/queryClient");
     vi.mocked(apiRequest).mockResolvedValueOnce(
-      createJsonResponse({ igdb: { configured: false } }) as Awaited<ReturnType<typeof apiRequest>>
+      createJsonResponse({ igdb: { configured: false } })
     );
 
     renderPage();

--- a/client/__tests__/CalendarPage.test.tsx
+++ b/client/__tests__/CalendarPage.test.tsx
@@ -2,11 +2,12 @@
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TooltipProvider } from "../src/components/ui/tooltip";
 import CalendarPage from "../src/pages/calendar";
+import { createTestQueryClient, getRequestUrl } from "./test-utils";
 
 vi.mock("@/components/GameDownloadDialog", () => ({
   default: ({ open, game }: { open: boolean; game: { title: string } | null }) =>
@@ -49,22 +50,6 @@ vi.mock("@/components/ui/select", () => ({
   ),
 }));
 
-const createTestQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        queryFn: async ({ queryKey }) => {
-          const response = await fetch(queryKey.join(""));
-          if (!response.ok) {
-            throw new Error("Network response was not ok");
-          }
-          return response.json();
-        },
-      },
-    },
-  });
-
 const baseGame = {
   id: "game-1",
   title: "Space Quest",
@@ -86,29 +71,34 @@ function renderPage() {
   );
 }
 
+function createJsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    json: async () => data,
+  } as Response;
+}
+
+function mockGamesFetch(games: unknown[]) {
+  globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
+    if (getRequestUrl(url).includes("/api/games")) {
+      return createJsonResponse(games);
+    }
+
+    return createJsonResponse({});
+  });
+}
+
 describe("CalendarPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
-      if (String(url).includes("/api/games")) {
-        return {
-          ok: true,
-          json: async () => [],
-        } as Response;
-      }
-
-      return {
-        ok: true,
-        json: async () => ({}),
-      } as Response;
-    });
+    mockGamesFetch([]);
   });
 
   it("shows the IGDB setup prompt when configuration is missing", async () => {
     const { apiRequest } = await import("@/lib/queryClient");
-    vi.mocked(apiRequest).mockResolvedValueOnce({
-      json: async () => ({ igdb: { configured: false } }),
-    } as Awaited<ReturnType<typeof apiRequest>>);
+    vi.mocked(apiRequest).mockResolvedValueOnce(
+      createJsonResponse({ igdb: { configured: false } }) as Awaited<ReturnType<typeof apiRequest>>
+    );
 
     renderPage();
 
@@ -125,23 +115,11 @@ describe("CalendarPage", () => {
   });
 
   it("filters displayed games and renders the undated year section", async () => {
-    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
-      if (String(url).includes("/api/games")) {
-        return {
-          ok: true,
-          json: async () => [
-            baseGame,
-            { ...baseGame, id: "game-2", title: "Mystery Year", releaseDate: "2026-12-31" },
-            { ...baseGame, id: "game-3", title: "Owned Game", status: "owned" },
-          ],
-        } as Response;
-      }
-
-      return {
-        ok: true,
-        json: async () => ({}),
-      } as Response;
-    });
+    mockGamesFetch([
+      baseGame,
+      { ...baseGame, id: "game-2", title: "Mystery Year", releaseDate: "2026-12-31" },
+      { ...baseGame, id: "game-3", title: "Owned Game", status: "owned" },
+    ]);
 
     renderPage();
 
@@ -161,21 +139,7 @@ describe("CalendarPage", () => {
   });
 
   it("switches to week view and opens the download dialog from a visible game", async () => {
-    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
-      if (String(url).includes("/api/games")) {
-        return {
-          ok: true,
-          json: async () => [
-            { ...baseGame, id: "game-4", title: "Week Hero", releaseDate: "2026-05-29" },
-          ],
-        } as Response;
-      }
-
-      return {
-        ok: true,
-        json: async () => ({}),
-      } as Response;
-    });
+    mockGamesFetch([{ ...baseGame, id: "game-4", title: "Week Hero", releaseDate: "2026-05-29" }]);
 
     renderPage();
 
@@ -192,21 +156,7 @@ describe("CalendarPage", () => {
   });
 
   it("shows month view mobile day details when a day with releases is tapped", async () => {
-    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
-      if (String(url).includes("/api/games")) {
-        return {
-          ok: true,
-          json: async () => [
-            { ...baseGame, id: "game-5", title: "Month Hero", releaseDate: "2026-05-29" },
-          ],
-        } as Response;
-      }
-
-      return {
-        ok: true,
-        json: async () => ({}),
-      } as Response;
-    });
+    mockGamesFetch([{ ...baseGame, id: "game-5", title: "Month Hero", releaseDate: "2026-05-29" }]);
 
     renderPage();
 
@@ -218,23 +168,26 @@ describe("CalendarPage", () => {
       expect(screen.queryByText("Loading calendar...")).not.toBeInTheDocument();
     });
 
-    const dayCell = Array.from(document.querySelectorAll("div.cursor-pointer")).find((node) =>
+    const dayButton = Array.from(document.querySelectorAll("button.cursor-pointer")).find((node) =>
       node.textContent?.includes("29")
-    ) as HTMLDivElement | undefined;
+    ) as HTMLButtonElement | undefined;
 
-    expect(dayCell).toBeDefined();
-    fireEvent.click(dayCell);
+    expect(dayButton).toBeDefined();
+    const dayCell = dayButton?.parentElement as HTMLDivElement | null;
+
+    expect(dayCell).not.toBeNull();
+    fireEvent.click(dayButton!);
 
     await waitFor(() => {
-      expect(dayCell.className).toContain("border-primary/60");
-      expect(dayCell.className).toContain("bg-primary/5");
+      expect(dayCell?.className).toContain("border-primary/60");
+      expect(dayCell?.className).toContain("bg-primary/5");
     });
 
-    fireEvent.click(dayCell);
+    fireEvent.click(dayButton!);
 
     await waitFor(() => {
-      expect(dayCell.className).not.toContain("border-primary/60");
-      expect(dayCell.className).not.toContain("bg-primary/5");
+      expect(dayCell?.className).not.toContain("border-primary/60");
+      expect(dayCell?.className).not.toContain("bg-primary/5");
     });
   });
 });

--- a/client/__tests__/CalendarPage.test.tsx
+++ b/client/__tests__/CalendarPage.test.tsx
@@ -89,7 +89,7 @@ function renderPage() {
 describe("CalendarPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
       if (String(url).includes("/api/games")) {
         return {
           ok: true,
@@ -125,7 +125,7 @@ describe("CalendarPage", () => {
   });
 
   it("filters displayed games and renders the undated year section", async () => {
-    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
       if (String(url).includes("/api/games")) {
         return {
           ok: true,
@@ -161,7 +161,7 @@ describe("CalendarPage", () => {
   });
 
   it("switches to week view and opens the download dialog from a visible game", async () => {
-    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
       if (String(url).includes("/api/games")) {
         return {
           ok: true,
@@ -192,7 +192,7 @@ describe("CalendarPage", () => {
   });
 
   it("shows month view mobile day details when a day with releases is tapped", async () => {
-    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
       if (String(url).includes("/api/games")) {
         return {
           ok: true,

--- a/client/__tests__/CalendarPage.test.tsx
+++ b/client/__tests__/CalendarPage.test.tsx
@@ -1,0 +1,240 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TooltipProvider } from "../src/components/ui/tooltip";
+import CalendarPage from "../src/pages/calendar";
+
+vi.mock("@/components/GameDownloadDialog", () => ({
+  default: ({ open, game }: { open: boolean; game: { title: string } | null }) =>
+    open && game ? <div data-testid="calendar-download-dialog">Download {game.title}</div> : null,
+}));
+
+vi.mock("@/lib/queryClient", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    apiRequest: vi.fn(async () => ({
+      json: async () => ({ igdb: { configured: true } }),
+    })),
+  };
+});
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <select
+      aria-label="Calendar view"
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        queryFn: async ({ queryKey }) => {
+          const response = await fetch(queryKey.join(""));
+          if (!response.ok) {
+            throw new Error("Network response was not ok");
+          }
+          return response.json();
+        },
+      },
+    },
+  });
+
+const baseGame = {
+  id: "game-1",
+  title: "Space Quest",
+  releaseDate: "2026-06-02",
+  status: "wanted",
+  releaseStatus: "released",
+  coverUrl: null,
+  genres: ["Adventure"],
+  summary: "A space adventure",
+};
+
+function renderPage() {
+  return render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <TooltipProvider>
+        <CalendarPage />
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("CalendarPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes("/api/games")) {
+        return {
+          ok: true,
+          json: async () => [],
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
+  });
+
+  it("shows the IGDB setup prompt when configuration is missing", async () => {
+    const { apiRequest } = await import("@/lib/queryClient");
+    vi.mocked(apiRequest).mockResolvedValueOnce({
+      json: async () => ({ igdb: { configured: false } }),
+    } as Awaited<ReturnType<typeof apiRequest>>);
+
+    renderPage();
+
+    expect(await screen.findByText("IGDB Configuration Required")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go to Settings" })).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no wanted games", async () => {
+    renderPage();
+
+    expect(
+      await screen.findByText("No games in your wishlist. Add games to track their release dates.")
+    ).toBeInTheDocument();
+  });
+
+  it("filters displayed games and renders the undated year section", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes("/api/games")) {
+        return {
+          ok: true,
+          json: async () => [
+            baseGame,
+            { ...baseGame, id: "game-2", title: "Mystery Year", releaseDate: "2026-12-31" },
+            { ...baseGame, id: "game-3", title: "Owned Game", status: "owned" },
+          ],
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText((content) => content.includes("No Release Date"))
+    ).toBeInTheDocument();
+    expect(screen.getByText("Mystery Year")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Filter games..." }), {
+      target: { value: "space" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Space Quest")).toBeInTheDocument();
+      expect(screen.queryByText("Mystery Year")).not.toBeInTheDocument();
+    });
+  });
+
+  it("switches to week view and opens the download dialog from a visible game", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes("/api/games")) {
+        return {
+          ok: true,
+          json: async () => [
+            { ...baseGame, id: "game-4", title: "Week Hero", releaseDate: "2026-05-29" },
+          ],
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
+
+    renderPage();
+
+    fireEvent.change(await screen.findByRole("combobox", { name: "Calendar view" }), {
+      target: { value: "week" },
+    });
+
+    const [gameButton] = await screen.findAllByRole("button", { name: /Week Hero/i });
+    fireEvent.click(gameButton);
+
+    expect(await screen.findByTestId("calendar-download-dialog")).toHaveTextContent(
+      "Download Week Hero"
+    );
+  });
+
+  it("shows month view mobile day details when a day with releases is tapped", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes("/api/games")) {
+        return {
+          ok: true,
+          json: async () => [
+            { ...baseGame, id: "game-5", title: "Month Hero", releaseDate: "2026-05-29" },
+          ],
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
+
+    renderPage();
+
+    fireEvent.change(await screen.findByRole("combobox", { name: "Calendar view" }), {
+      target: { value: "month" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Loading calendar...")).not.toBeInTheDocument();
+    });
+
+    const dayCell = Array.from(document.querySelectorAll("div.cursor-pointer")).find((node) =>
+      node.textContent?.includes("29")
+    ) as HTMLDivElement | undefined;
+
+    expect(dayCell).toBeDefined();
+    fireEvent.click(dayCell);
+
+    await waitFor(() => {
+      expect(dayCell.className).toContain("border-primary/60");
+      expect(dayCell.className).toContain("bg-primary/5");
+    });
+
+    fireEvent.click(dayCell);
+
+    await waitFor(() => {
+      expect(dayCell.className).not.toContain("border-primary/60");
+      expect(dayCell.className).not.toContain("bg-primary/5");
+    });
+  });
+});

--- a/client/__tests__/DownloadsPage.test.tsx
+++ b/client/__tests__/DownloadsPage.test.tsx
@@ -1,0 +1,80 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Downloads from "../src/pages/downloads";
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("../src/components/DownloadDetailsModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/ClaimDownloadModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/ClaimBatchModal", () => ({
+  default: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="claim-batch-modal">Claim batch modal</div> : null,
+}));
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        queryFn: async ({ queryKey }) => {
+          const response = await fetch(queryKey.join(""));
+          if (!response.ok) {
+            throw new Error("Network response was not ok");
+          }
+          return response.json();
+        },
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+describe("Downloads page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes("/api/downloads")) {
+        return {
+          ok: true,
+          json: async () => ({ downloads: [], errors: [] }),
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
+  });
+
+  it("keeps the scan unlinked action available and opens the batch modal", async () => {
+    render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <Downloads />
+      </QueryClientProvider>
+    );
+
+    const scanButton = await screen.findByRole("button", { name: "Scan unlinked downloads" });
+    expect(scanButton).toHaveTextContent("Scan");
+
+    fireEvent.click(scanButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("claim-batch-modal")).toBeInTheDocument();
+    });
+  });
+});

--- a/client/__tests__/DownloadsPage.test.tsx
+++ b/client/__tests__/DownloadsPage.test.tsx
@@ -7,21 +7,60 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import Downloads from "../src/pages/downloads";
 
+const toastSpy = vi.fn();
+
 vi.mock("@/hooks/use-toast", () => ({
-  useToast: () => ({ toast: vi.fn() }),
+  useToast: () => ({ toast: toastSpy }),
 }));
 
 vi.mock("../src/components/DownloadDetailsModal", () => ({
-  default: () => null,
+  default: ({
+    open,
+    downloadId,
+    downloadName,
+  }: {
+    open: boolean;
+    downloadId: string;
+    downloadName: string;
+  }) =>
+    open ? (
+      <div data-testid="download-details-modal">
+        {downloadId}:{downloadName}
+      </div>
+    ) : null,
 }));
 
 vi.mock("@/components/ClaimDownloadModal", () => ({
-  default: () => null,
+  default: ({ open, download }: { open: boolean; download: { id: string; name: string } }) =>
+    open ? (
+      <div data-testid="claim-download-modal">
+        {download.id}:{download.name}
+      </div>
+    ) : null,
 }));
 
 vi.mock("@/components/ClaimBatchModal", () => ({
   default: ({ open }: { open: boolean }) =>
     open ? <div data-testid="claim-batch-modal">Claim batch modal</div> : null,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onClick,
+    ...props
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    [key: string]: unknown;
+  }) => (
+    <button type="button" onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
 }));
 
 const createTestQueryClient = () =>
@@ -46,6 +85,7 @@ const createTestQueryClient = () =>
 describe("Downloads page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    toastSpy.mockReset();
     global.fetch = vi.fn(async (url: RequestInfo | URL) => {
       if (String(url).includes("/api/downloads")) {
         return {
@@ -61,12 +101,15 @@ describe("Downloads page", () => {
     });
   });
 
-  it("keeps the scan unlinked action available and opens the batch modal", async () => {
+  const renderPage = () =>
     render(
       <QueryClientProvider client={createTestQueryClient()}>
         <Downloads />
       </QueryClientProvider>
     );
+
+  it("keeps the scan unlinked action available and opens the batch modal", async () => {
+    renderPage();
 
     const scanButton = await screen.findByRole("button", { name: "Scan unlinked downloads" });
     expect(scanButton).toHaveTextContent("Scan");
@@ -76,5 +119,325 @@ describe("Downloads page", () => {
     await waitFor(() => {
       expect(screen.getByTestId("claim-batch-modal")).toBeInTheDocument();
     });
+  });
+
+  it("filters downloads by search and Questarr-only toggle while showing the category banner", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes("/api/downloads")) {
+        return {
+          ok: true,
+          json: async () => ({
+            downloads: [
+              {
+                id: "dl-1",
+                name: "Questarr Release",
+                status: "downloading",
+                progress: 55,
+                downloaderId: "downloader-1",
+                downloaderName: "qBittorrent",
+                trackedByQuestarr: true,
+                downloaderCategory: "questarr",
+                downloadType: "torrent",
+                size: 1024,
+                downloaded: 512,
+              },
+              {
+                id: "dl-2",
+                name: "Manual NZB",
+                status: "completed",
+                progress: 100,
+                downloaderId: "downloader-2",
+                downloaderName: "SABnzbd",
+                trackedByQuestarr: false,
+                downloadType: "usenet",
+              },
+            ],
+            errors: [],
+          }),
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
+
+    renderPage();
+
+    expect(await screen.findByTestId("category-filter-banner")).toHaveTextContent(
+      'qBittorrent: "questarr"'
+    );
+    expect(screen.getByTestId("card-download-dl-1")).toBeInTheDocument();
+    expect(screen.getByTestId("card-download-dl-2")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Filter downloads" }), {
+      target: { value: "manual" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("card-download-dl-1")).not.toBeInTheDocument();
+      expect(screen.getByTestId("card-download-dl-2")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+    fireEvent.click(screen.getByTestId("filter-source-questarr"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("card-download-dl-1")).toBeInTheDocument();
+      expect(screen.queryByTestId("card-download-dl-2")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows a filtered empty state message when no downloads match the active search", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes("/api/downloads")) {
+        return {
+          ok: true,
+          json: async () => ({
+            downloads: [
+              {
+                id: "dl-3",
+                name: "Only Torrent",
+                status: "downloading",
+                progress: 25,
+                downloaderId: "downloader-1",
+                downloaderName: "qBittorrent",
+                trackedByQuestarr: true,
+                downloadType: "torrent",
+              },
+            ],
+            errors: [],
+          }),
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
+
+    renderPage();
+
+    await screen.findByTestId("card-download-dl-3");
+    fireEvent.change(screen.getByRole("textbox", { name: "Filter downloads" }), {
+      target: { value: "missing" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("text-no-downloads-title")).toHaveTextContent(
+        "No Active Downloads"
+      );
+      expect(screen.getByTestId("text-no-downloads-description")).toHaveTextContent(
+        "No downloads match the current filters"
+      );
+    });
+  });
+
+  it("shows the loading skeleton before downloads resolve", async () => {
+    let resolveResponse: ((value: Response) => void) | undefined;
+    global.fetch = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveResponse = resolve;
+        })
+    ) as never;
+
+    renderPage();
+
+    expect(await screen.findByTestId("loading-downloads")).toBeInTheDocument();
+
+    resolveResponse?.({
+      ok: true,
+      json: async () => ({ downloads: [], errors: [] }),
+    } as Response);
+
+    expect(await screen.findByTestId("card-no-downloads")).toBeInTheDocument();
+  });
+
+  it("renders torrent and usenet-specific metric badges and download errors", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (String(url).includes("/api/downloads")) {
+        return {
+          ok: true,
+          json: async () => ({
+            downloads: [
+              {
+                id: "dl-torrent",
+                name: "Torrent Game",
+                status: "downloading",
+                progress: 45,
+                downloaderId: "downloader-1",
+                downloaderName: "qBittorrent",
+                trackedByQuestarr: true,
+                downloadType: "torrent",
+                size: 2 * 1024 * 1024,
+                downloaded: 1024 * 1024,
+                downloadSpeed: 2048,
+                uploadSpeed: 512,
+                eta: 3600,
+                seeders: 12,
+                leechers: 3,
+                ratio: 1.25,
+              },
+              {
+                id: "dl-usenet",
+                name: "Usenet Game",
+                status: "error",
+                progress: 90,
+                downloaderId: "downloader-2",
+                downloaderName: "SABnzbd",
+                trackedByQuestarr: false,
+                downloadType: "usenet",
+                repairStatus: "repairing",
+                unpackStatus: "running",
+                age: 5,
+                grabs: 8,
+                error: "Post-processing failed",
+              },
+            ],
+            errors: [],
+          }),
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    });
+
+    renderPage();
+
+    expect(await screen.findByTestId("badge-download-speed-dl-torrent")).toBeInTheDocument();
+    expect(screen.getByTestId("badge-upload-speed-dl-torrent")).toBeInTheDocument();
+    expect(screen.getByTestId("badge-eta-dl-torrent")).toBeInTheDocument();
+    expect(screen.getByTestId("badge-peers-dl-torrent")).toBeInTheDocument();
+    expect(screen.getByTestId("badge-ratio-dl-torrent")).toBeInTheDocument();
+
+    expect(screen.getByTestId("badge-repair-dl-usenet")).toBeInTheDocument();
+    expect(screen.getByTestId("badge-unpack-dl-usenet")).toBeInTheDocument();
+    expect(screen.getByTestId("badge-age-dl-usenet")).toBeInTheDocument();
+    expect(screen.getByTestId("badge-grabs-dl-usenet")).toBeInTheDocument();
+    expect(screen.getByTestId("text-error-dl-usenet")).toHaveTextContent("Post-processing failed");
+  });
+
+  it("opens details and claim modals, performs download actions, and reports downloader errors", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const target = String(url);
+
+      if (target === "/api/downloads") {
+        return {
+          ok: true,
+          json: async () => ({
+            downloads: [
+              {
+                id: "dl-active",
+                name: "Active Download",
+                status: "downloading",
+                progress: 40,
+                downloaderId: "downloader-1",
+                downloaderName: "qBittorrent",
+                trackedByQuestarr: true,
+                downloadType: "torrent",
+              },
+              {
+                id: "dl-paused",
+                name: "Paused Download",
+                status: "paused",
+                progress: 60,
+                downloaderId: "downloader-1",
+                downloaderName: "qBittorrent",
+                trackedByQuestarr: true,
+                downloadType: "torrent",
+              },
+            ],
+            errors: [
+              {
+                downloaderId: "downloader-err",
+                downloaderName: "Broken Client",
+                error: "Indexer auth failed",
+              },
+            ],
+          }),
+        } as Response;
+      }
+
+      if (target.includes("/pause") && init?.method === "POST") {
+        return { ok: true, json: async () => ({ success: true }) } as Response;
+      }
+
+      if (target.includes("/resume") && init?.method === "POST") {
+        return { ok: true, json: async () => ({ success: true }) } as Response;
+      }
+
+      if (target.includes("/api/downloaders/") && init?.method === "DELETE") {
+        return { ok: true, json: async () => ({ success: true }) } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({}),
+      } as Response;
+    }) as never;
+
+    renderPage();
+
+    expect(await screen.findByTestId("button-pause-dl-active")).toBeInTheDocument();
+    expect(screen.getByTestId("button-resume-dl-paused")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("button-pause-dl-active"));
+    fireEvent.click(screen.getByTestId("button-resume-dl-paused"));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/downloaders/downloader-1/downloads/dl-active/pause",
+        expect.objectContaining({ method: "POST" })
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/downloaders/downloader-1/downloads/dl-paused/resume",
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("button-menu-dl-active"));
+    fireEvent.click(await screen.findByTestId("button-details-dl-active"));
+    expect(await screen.findByTestId("download-details-modal")).toHaveTextContent(
+      "dl-active:Active Download"
+    );
+
+    fireEvent.click(screen.getByTestId("button-menu-dl-active"));
+    fireEvent.click(await screen.findByTestId("button-link-dl-active"));
+    expect(await screen.findByTestId("claim-download-modal")).toHaveTextContent(
+      "dl-active:Active Download"
+    );
+
+    fireEvent.click(screen.getByTestId("button-menu-dl-active"));
+    fireEvent.click(await screen.findByTestId("button-remove-dl-active"));
+    fireEvent.click(screen.getByTestId("button-menu-dl-active"));
+    fireEvent.click(await screen.findByTestId("button-remove-files-dl-active"));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/downloaders/downloader-1/downloads/dl-active?deleteFiles=false",
+        expect.objectContaining({ method: "DELETE" })
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/downloaders/downloader-1/downloads/dl-active?deleteFiles=true",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+
+    expect(toastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Downloader Error: Broken Client",
+        description: "Indexer auth failed",
+        variant: "destructive",
+      })
+    );
+    expect(toastSpy).toHaveBeenCalledWith(expect.objectContaining({ title: "Download paused" }));
+    expect(toastSpy).toHaveBeenCalledWith(expect.objectContaining({ title: "Download resumed" }));
+    expect(toastSpy).toHaveBeenCalledWith(expect.objectContaining({ title: "Download removed" }));
   });
 });

--- a/client/__tests__/DownloadsPage.test.tsx
+++ b/client/__tests__/DownloadsPage.test.tsx
@@ -2,10 +2,11 @@
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import Downloads from "../src/pages/downloads";
+import { createTestQueryClient, getRequestUrl } from "./test-utils";
 
 const toastSpy = vi.fn();
 
@@ -63,42 +64,28 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   ),
 }));
 
-const createTestQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        queryFn: async ({ queryKey }) => {
-          const response = await fetch(queryKey.join(""));
-          if (!response.ok) {
-            throw new Error("Network response was not ok");
-          }
-          return response.json();
-        },
-      },
-      mutations: {
-        retry: false,
-      },
-    },
+function createJsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    json: async () => data,
+  } as Response;
+}
+
+function mockDownloadsFetch(responseData: unknown) {
+  globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
+    if (getRequestUrl(url).includes("/api/downloads")) {
+      return createJsonResponse(responseData);
+    }
+
+    return createJsonResponse({});
   });
+}
 
 describe("Downloads page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     toastSpy.mockReset();
-    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
-      if (String(url).includes("/api/downloads")) {
-        return {
-          ok: true,
-          json: async () => ({ downloads: [], errors: [] }),
-        } as Response;
-      }
-
-      return {
-        ok: true,
-        json: async () => ({}),
-      } as Response;
-    });
+    mockDownloadsFetch({ downloads: [], errors: [] });
   });
 
   const renderPage = () =>
@@ -122,45 +109,33 @@ describe("Downloads page", () => {
   });
 
   it("filters downloads by search and Questarr-only toggle while showing the category banner", async () => {
-    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
-      if (String(url).includes("/api/downloads")) {
-        return {
-          ok: true,
-          json: async () => ({
-            downloads: [
-              {
-                id: "dl-1",
-                name: "Questarr Release",
-                status: "downloading",
-                progress: 55,
-                downloaderId: "downloader-1",
-                downloaderName: "qBittorrent",
-                trackedByQuestarr: true,
-                downloaderCategory: "questarr",
-                downloadType: "torrent",
-                size: 1024,
-                downloaded: 512,
-              },
-              {
-                id: "dl-2",
-                name: "Manual NZB",
-                status: "completed",
-                progress: 100,
-                downloaderId: "downloader-2",
-                downloaderName: "SABnzbd",
-                trackedByQuestarr: false,
-                downloadType: "usenet",
-              },
-            ],
-            errors: [],
-          }),
-        } as Response;
-      }
-
-      return {
-        ok: true,
-        json: async () => ({}),
-      } as Response;
+    mockDownloadsFetch({
+      downloads: [
+        {
+          id: "dl-1",
+          name: "Questarr Release",
+          status: "downloading",
+          progress: 55,
+          downloaderId: "downloader-1",
+          downloaderName: "qBittorrent",
+          trackedByQuestarr: true,
+          downloaderCategory: "questarr",
+          downloadType: "torrent",
+          size: 1024,
+          downloaded: 512,
+        },
+        {
+          id: "dl-2",
+          name: "Manual NZB",
+          status: "completed",
+          progress: 100,
+          downloaderId: "downloader-2",
+          downloaderName: "SABnzbd",
+          trackedByQuestarr: false,
+          downloadType: "usenet",
+        },
+      ],
+      errors: [],
     });
 
     renderPage();
@@ -190,32 +165,20 @@ describe("Downloads page", () => {
   });
 
   it("shows a filtered empty state message when no downloads match the active search", async () => {
-    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
-      if (String(url).includes("/api/downloads")) {
-        return {
-          ok: true,
-          json: async () => ({
-            downloads: [
-              {
-                id: "dl-3",
-                name: "Only Torrent",
-                status: "downloading",
-                progress: 25,
-                downloaderId: "downloader-1",
-                downloaderName: "qBittorrent",
-                trackedByQuestarr: true,
-                downloadType: "torrent",
-              },
-            ],
-            errors: [],
-          }),
-        } as Response;
-      }
-
-      return {
-        ok: true,
-        json: async () => ({}),
-      } as Response;
+    mockDownloadsFetch({
+      downloads: [
+        {
+          id: "dl-3",
+          name: "Only Torrent",
+          status: "downloading",
+          progress: 25,
+          downloaderId: "downloader-1",
+          downloaderName: "qBittorrent",
+          trackedByQuestarr: true,
+          downloadType: "torrent",
+        },
+      ],
+      errors: [],
     });
 
     renderPage();
@@ -242,7 +205,7 @@ describe("Downloads page", () => {
         new Promise<Response>((resolve) => {
           resolveResponse = resolve;
         })
-    ) as never;
+    ) as typeof fetch;
 
     renderPage();
 
@@ -257,55 +220,43 @@ describe("Downloads page", () => {
   });
 
   it("renders torrent and usenet-specific metric badges and download errors", async () => {
-    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
-      if (String(url).includes("/api/downloads")) {
-        return {
-          ok: true,
-          json: async () => ({
-            downloads: [
-              {
-                id: "dl-torrent",
-                name: "Torrent Game",
-                status: "downloading",
-                progress: 45,
-                downloaderId: "downloader-1",
-                downloaderName: "qBittorrent",
-                trackedByQuestarr: true,
-                downloadType: "torrent",
-                size: 2 * 1024 * 1024,
-                downloaded: 1024 * 1024,
-                downloadSpeed: 2048,
-                uploadSpeed: 512,
-                eta: 3600,
-                seeders: 12,
-                leechers: 3,
-                ratio: 1.25,
-              },
-              {
-                id: "dl-usenet",
-                name: "Usenet Game",
-                status: "error",
-                progress: 90,
-                downloaderId: "downloader-2",
-                downloaderName: "SABnzbd",
-                trackedByQuestarr: false,
-                downloadType: "usenet",
-                repairStatus: "repairing",
-                unpackStatus: "running",
-                age: 5,
-                grabs: 8,
-                error: "Post-processing failed",
-              },
-            ],
-            errors: [],
-          }),
-        } as Response;
-      }
-
-      return {
-        ok: true,
-        json: async () => ({}),
-      } as Response;
+    mockDownloadsFetch({
+      downloads: [
+        {
+          id: "dl-torrent",
+          name: "Torrent Game",
+          status: "downloading",
+          progress: 45,
+          downloaderId: "downloader-1",
+          downloaderName: "qBittorrent",
+          trackedByQuestarr: true,
+          downloadType: "torrent",
+          size: 2 * 1024 * 1024,
+          downloaded: 1024 * 1024,
+          downloadSpeed: 2048,
+          uploadSpeed: 512,
+          eta: 3600,
+          seeders: 12,
+          leechers: 3,
+          ratio: 1.25,
+        },
+        {
+          id: "dl-usenet",
+          name: "Usenet Game",
+          status: "error",
+          progress: 90,
+          downloaderId: "downloader-2",
+          downloaderName: "SABnzbd",
+          trackedByQuestarr: false,
+          downloadType: "usenet",
+          repairStatus: "repairing",
+          unpackStatus: "running",
+          age: 5,
+          grabs: 8,
+          error: "Post-processing failed",
+        },
+      ],
+      errors: [],
     });
 
     renderPage();
@@ -325,7 +276,7 @@ describe("Downloads page", () => {
 
   it("opens details and claim modals, performs download actions, and reports downloader errors", async () => {
     globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
-      const target = String(url);
+      const target = getRequestUrl(url);
 
       if (target === "/api/downloads") {
         return {
@@ -380,7 +331,7 @@ describe("Downloads page", () => {
         ok: true,
         json: async () => ({}),
       } as Response;
-    }) as never;
+    }) as typeof fetch;
 
     renderPage();
 

--- a/client/__tests__/DownloadsPage.test.tsx
+++ b/client/__tests__/DownloadsPage.test.tsx
@@ -86,7 +86,7 @@ describe("Downloads page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     toastSpy.mockReset();
-    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
       if (String(url).includes("/api/downloads")) {
         return {
           ok: true,
@@ -122,7 +122,7 @@ describe("Downloads page", () => {
   });
 
   it("filters downloads by search and Questarr-only toggle while showing the category banner", async () => {
-    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
       if (String(url).includes("/api/downloads")) {
         return {
           ok: true,
@@ -190,7 +190,7 @@ describe("Downloads page", () => {
   });
 
   it("shows a filtered empty state message when no downloads match the active search", async () => {
-    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
       if (String(url).includes("/api/downloads")) {
         return {
           ok: true,
@@ -237,7 +237,7 @@ describe("Downloads page", () => {
 
   it("shows the loading skeleton before downloads resolve", async () => {
     let resolveResponse: ((value: Response) => void) | undefined;
-    global.fetch = vi.fn(
+    globalThis.fetch = vi.fn(
       () =>
         new Promise<Response>((resolve) => {
           resolveResponse = resolve;
@@ -257,7 +257,7 @@ describe("Downloads page", () => {
   });
 
   it("renders torrent and usenet-specific metric badges and download errors", async () => {
-    global.fetch = vi.fn(async (url: RequestInfo | URL) => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
       if (String(url).includes("/api/downloads")) {
         return {
           ok: true,
@@ -324,7 +324,7 @@ describe("Downloads page", () => {
   });
 
   it("opens details and claim modals, performs download actions, and reports downloader errors", async () => {
-    global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
       const target = String(url);
 
       if (target === "/api/downloads") {
@@ -391,11 +391,11 @@ describe("Downloads page", () => {
     fireEvent.click(screen.getByTestId("button-resume-dl-paused"));
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         "/api/downloaders/downloader-1/downloads/dl-active/pause",
         expect.objectContaining({ method: "POST" })
       );
-      expect(global.fetch).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         "/api/downloaders/downloader-1/downloads/dl-paused/resume",
         expect.objectContaining({ method: "POST" })
       );
@@ -419,11 +419,11 @@ describe("Downloads page", () => {
     fireEvent.click(await screen.findByTestId("button-remove-files-dl-active"));
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         "/api/downloaders/downloader-1/downloads/dl-active?deleteFiles=false",
         expect.objectContaining({ method: "DELETE" })
       );
-      expect(global.fetch).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         "/api/downloaders/downloader-1/downloads/dl-active?deleteFiles=true",
         expect.objectContaining({ method: "DELETE" })
       );

--- a/client/__tests__/GameCard.remaining.test.tsx
+++ b/client/__tests__/GameCard.remaining.test.tsx
@@ -203,7 +203,7 @@ describe("GameCard remaining coverage", () => {
     expect(content).toBeTruthy();
     onViewDetails.mockClear();
     fireEvent.click(content!);
-    expect(onViewDetails).not.toHaveBeenCalled();
+    expect(onViewDetails).toHaveBeenCalledWith("igdb-1");
 
     render(
       <GameCard game={baseGame} onToggleHidden={onToggleHidden} onViewDetails={onViewDetails} />

--- a/client/__tests__/GameCard.test.tsx
+++ b/client/__tests__/GameCard.test.tsx
@@ -28,6 +28,7 @@ vi.mock("lucide-react", () => ({
   SlidersHorizontal: () => <div data-testid="icon-sliders-horizontal" />,
   RefreshCw: () => <div data-testid="icon-refresh-cw" />,
   HardDrive: () => <div data-testid="icon-hard-drive" />,
+  CheckCircle2: () => <div data-testid="icon-check-circle2" />,
   Check: () => <div data-testid="icon-check" />,
   Database: () => <div data-testid="icon-database" />,
   Search: () => <div data-testid="icon-search" />,

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import React from "react";
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act, within } from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import GameDetailsModal from "../src/components/GameDetailsModal";
@@ -270,8 +270,9 @@ describe("GameDetailsModal", () => {
   it("renders the Your rating section", () => {
     renderComponent();
     // Links tab is forceMount-ed; always in DOM
-    expect(screen.getByTestId("section-user-rating")).toBeInTheDocument();
-    expect(screen.getByText("Your rating")).toBeInTheDocument();
+    const ratingSection = screen.getByTestId("section-user-rating");
+    expect(ratingSection).toBeInTheDocument();
+    expect(within(ratingSection).getAllByText("Your rating").length).toBeGreaterThan(0);
   });
 
   it('shows "Not rated" when userRating is null', () => {

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -314,6 +314,44 @@ describe("GameDetailsModal", () => {
     expect(screen.queryByText("Rating")).not.toBeInTheDocument();
   });
 
+  it("renders source labels for steam, api, and manual games", () => {
+    const { rerender } = render(
+      <QueryClientProvider client={createQueryClient()}>
+        <GameDetailsModal
+          game={{ ...mockGame, source: "steam" }}
+          open={true}
+          onOpenChange={() => {}}
+        />
+        <Toaster />
+      </QueryClientProvider>
+    );
+    expect(screen.getAllByText("Steam Wishlist").length).toBeGreaterThan(0);
+
+    rerender(
+      <QueryClientProvider client={createQueryClient()}>
+        <GameDetailsModal
+          game={{ ...mockGame, source: "api" }}
+          open={true}
+          onOpenChange={() => {}}
+        />
+        <Toaster />
+      </QueryClientProvider>
+    );
+    expect(screen.getAllByText("Via API").length).toBeGreaterThan(0);
+
+    rerender(
+      <QueryClientProvider client={createQueryClient()}>
+        <GameDetailsModal
+          game={{ ...mockGame, source: "manual" }}
+          open={true}
+          onOpenChange={() => {}}
+        />
+        <Toaster />
+      </QueryClientProvider>
+    );
+    expect(screen.getAllByText("Added Manually").length).toBeGreaterThan(0);
+  });
+
   describe("NexusMods integration", () => {
     it("shows fallback search link when Nexus Mods is not configured", async () => {
       // default beforeEach mock: configured: false, domain: null → fallback link shown

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -21,7 +21,9 @@ vi.mock("@/hooks/use-toast", () => ({
 }));
 
 vi.mock("../src/components/StatusBadge", () => ({
+  __esModule: true,
   default: ({ status }: { status: string }) => <div data-testid="status-badge">{status}</div>,
+  getStatusLabel: (status: string) => status,
 }));
 
 vi.mock("../src/components/GameDownloadDialog", () => ({

--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -959,4 +959,31 @@ describe("GameDownloadDialog", () => {
       );
     });
   });
+
+  it("renders parsed metadata badges for mobile torrent results", async () => {
+    mockIsMobile = true;
+    globalThis.fetch = createFetchMock({
+      search: makeSearchResult([
+        makeTorrentItem({
+          guid: "metadata-1",
+          title: "Shadow.of.the.Tomb.Raider.v1.2.MULTI5.DRM-Free.PC-SKIDROW",
+          link: "http://test.com/metadata",
+          seeders: 42,
+          downloadVolumeFactor: 0,
+        }),
+      ]),
+    });
+
+    renderComponent();
+
+    expect(
+      await screen.findByText("Shadow.of.the.Tomb.Raider.v1.2.MULTI5.DRM-Free.PC-SKIDROW")
+    ).toBeInTheDocument();
+    expect(screen.getByText("v1.2")).toBeInTheDocument();
+    expect(screen.getByText("Multi")).toBeInTheDocument();
+    expect(screen.getByText("DRM-Free")).toBeInTheDocument();
+    expect(screen.getByText("PC")).toBeInTheDocument();
+    expect(screen.getByText("Scene")).toBeInTheDocument();
+    expect(screen.getByText("Freeleech")).toBeInTheDocument();
+  });
 });

--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -929,7 +929,12 @@ describe("GameDownloadDialog", () => {
     });
 
     const downloadButtons = screen.getAllByTestId("icon-download");
-    fireEvent.click(downloadButtons[0].closest("button")!);
+    const firstDownloadButton = downloadButtons[0]?.closest("button");
+    expect(firstDownloadButton).not.toBeNull();
+    if (!firstDownloadButton) {
+      throw new Error("Expected a download button");
+    }
+    fireEvent.click(firstDownloadButton);
 
     await waitFor(() => {
       expect(screen.getByText("Download with Updates?")).toBeInTheDocument();

--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -51,6 +51,10 @@ vi.mock("@/hooks/use-toast", () => ({
   }),
 }));
 
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => false,
+}));
+
 // Mock Lucide icons
 vi.mock("lucide-react", () => ({
   Download: (props: Record<string, unknown>) => <div data-testid="icon-download" {...props} />,

--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -26,6 +26,7 @@ vi.mock("@/lib/queryClient", () => ({
 
 // Mocking external dependencies
 const mockToast = vi.fn();
+let mockIsMobile = false;
 
 vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -52,7 +53,7 @@ vi.mock("@/hooks/use-toast", () => ({
 }));
 
 vi.mock("@/hooks/use-mobile", () => ({
-  useIsMobile: () => false,
+  useIsMobile: () => mockIsMobile,
 }));
 
 // Mock Lucide icons
@@ -89,6 +90,7 @@ vi.mock("lucide-react", () => ({
   ChevronsUpDown: () => <div data-testid="icon-chevrons-up-down" />,
   MoreVertical: () => <div data-testid="icon-more-vertical" />,
   Copy: () => <div />,
+  Info: () => <div data-testid="icon-info" />,
   Ban: () => <div data-testid="icon-ban" />,
 }));
 
@@ -273,6 +275,12 @@ const createFetchMock = (overrides: FetchOverrides = {}) =>
 describe("GameDownloadDialog", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    mockIsMobile = false;
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn(),
+      },
+    });
     global.fetch = createFetchMock();
   });
 
@@ -827,5 +835,138 @@ describe("GameDownloadDialog", () => {
       },
       { timeout: 3000 }
     );
+  });
+
+  it("shows the preferred-platform warning and clears it with the inline action", async () => {
+    global.fetch = createFetchMock({
+      settings: { preferredPlatform: "PS5" },
+      search: platformSearchResults,
+    });
+
+    renderComponent();
+
+    expect(
+      (
+        await screen.findAllByText(
+          (_, element) =>
+            element?.textContent?.includes("No results match your preferred platform") ?? false
+        )
+      ).length
+    ).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show all results" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/No results match your preferred platform/i)).toBeNull();
+      expect(screen.getAllByText("Test Game PC v1.0-SKIDROW").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Test Game Mac Edition-CODEX").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("supports copying links and sending a release to a specific downloader", async () => {
+    global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const target = String(url);
+      if (target.includes("/api/search")) {
+        return { ok: true, json: async () => mockTorrents } as Response;
+      }
+      if (target.includes("/api/indexers/enabled")) {
+        return { ok: true, json: async () => mockEnabledIndexers } as Response;
+      }
+      if (target.includes("/api/downloaders/enabled")) {
+        return {
+          ok: true,
+          json: async () => [
+            { id: "1", name: "qBittorrent", enabled: true, type: "qbittorrent" },
+            { id: "2", name: "Transmission", enabled: true, type: "transmission" },
+            { id: "3", name: "SABnzbd", enabled: true, type: "sabnzbd" },
+          ],
+        } as Response;
+      }
+      if (target.includes("/api/settings")) {
+        return { ok: true, json: async () => ({}) } as Response;
+      }
+      if (target.includes("/api/downloaders/2/downloads") && init?.method === "POST") {
+        return { ok: true, json: async () => ({ success: true }) } as Response;
+      }
+      if (target.includes("/api/downloaders/")) {
+        return { ok: true, json: async () => ({ success: true }) } as Response;
+      }
+      return { ok: true, json: async () => ({ success: true }) } as Response;
+    }) as never;
+
+    renderComponent();
+
+    expect(await screen.findAllByText("Copy Torrent Link")).not.toHaveLength(0);
+    expect(await screen.findAllByText("Transmission")).not.toHaveLength(0);
+
+    fireEvent.click(screen.getAllByText("Copy Torrent Link")[0]);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("http://test.com/torrent1");
+
+    fireEvent.click(screen.getAllByText("Transmission")[0]);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/downloaders/2/downloads",
+        expect.objectContaining({ method: "POST" })
+      );
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Download sent to Transmission" })
+      );
+    });
+  });
+
+  it("lets mobile users select bundle updates and download only the main game", async () => {
+    mockIsMobile = true;
+    global.fetch = createFetchMock({
+      search: makeSearchResult([
+        makeTorrentItem({
+          guid: "mobile-main",
+          title: "Test Game ElAmigos",
+          link: "http://test.com/mobile-main",
+          pubDate: new Date().toISOString(),
+          downloadVolumeFactor: 0,
+        }),
+        makeTorrentItem({
+          guid: "mobile-update",
+          title: "Test Game Update v1.1",
+          link: "http://test.com/mobile-update",
+          seeders: 8,
+        }),
+      ]),
+    });
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Test Game ElAmigos").length).toBeGreaterThan(0);
+      expect(screen.getByText("Freeleech")).toBeInTheDocument();
+      expect(screen.getByText("NEW")).toBeInTheDocument();
+    });
+
+    const downloadButtons = screen.getAllByTestId("icon-download");
+    fireEvent.click(downloadButtons[0].closest("button")!);
+
+    await waitFor(() => {
+      expect(screen.getByText("Download with Updates?")).toBeInTheDocument();
+      expect(screen.getByText("1 of 1 updates selected")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Deselect All"));
+    expect(screen.getByText("0 of 1 updates selected")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Select All"));
+    expect(screen.getByText("1 of 1 updates selected")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Only the main game"));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/downloads",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining("mobile-main"),
+        })
+      );
+    });
   });
 });

--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -4,16 +4,17 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach } from "vitest";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import GameDownloadDialog from "../src/components/GameDownloadDialog";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { createTestQueryClient, getRequestUrl } from "./test-utils";
 
-// Route apiRequest through global.fetch so test mocks capture mutation calls
+// Route apiRequest through globalThis.fetch so test mocks capture mutation calls
 vi.mock("@/lib/queryClient", () => ({
   apiRequest: async (method: string, url: string, data?: unknown) => {
     const headers: Record<string, string> = data ? { "Content-Type": "application/json" } : {};
-    const res = await global.fetch(url, {
+    const res = await globalThis.fetch(url, {
       method,
       headers,
       body: data ? JSON.stringify(data) : undefined,
@@ -195,23 +196,7 @@ const mockDownloaders = [
 ];
 
 // Mock fetch
-global.fetch = vi.fn();
-
-const createTestQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        queryFn: async ({ queryKey }) => {
-          const response = await fetch(queryKey.join(""));
-          if (!response.ok) {
-            throw new Error("Network response was not ok");
-          }
-          return response.json();
-        },
-      },
-    },
-  });
+globalThis.fetch = vi.fn();
 
 let queryClient: QueryClient;
 const mockOnOpenChange = vi.fn();
@@ -238,7 +223,7 @@ type FetchOverrides = {
 /** Creates a fetch mock with sensible defaults, overridable per-endpoint. */
 const createFetchMock = (overrides: FetchOverrides = {}) =>
   vi.fn(async (url: RequestInfo | URL) => {
-    const urlString = url.toString();
+    const urlString = getRequestUrl(url);
     if (urlString.includes("/api/search")) {
       return { ok: true, json: async () => overrides.search ?? mockTorrents };
     }
@@ -270,7 +255,7 @@ const createFetchMock = (overrides: FetchOverrides = {}) =>
       };
     }
     return { ok: false, json: async () => ({}) };
-  }) as never;
+  }) as typeof fetch;
 
 describe("GameDownloadDialog", () => {
   beforeEach(() => {
@@ -281,7 +266,7 @@ describe("GameDownloadDialog", () => {
         writeText: vi.fn(),
       },
     });
-    global.fetch = createFetchMock();
+    globalThis.fetch = createFetchMock();
   });
 
   it("renders search results correctly", async () => {
@@ -369,7 +354,7 @@ describe("GameDownloadDialog", () => {
     fireEvent.click(screen.getAllByText("Blacklist release")[0]);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         expect.stringContaining("/blacklist"),
         expect.objectContaining({
           method: "POST",
@@ -403,7 +388,7 @@ describe("GameDownloadDialog", () => {
   });
 
   it("shows destructive toast when download API returns success:false", async () => {
-    global.fetch = createFetchMock({
+    globalThis.fetch = createFetchMock({
       downloads: { success: false, message: "Downloader offline" },
     });
 
@@ -423,7 +408,7 @@ describe("GameDownloadDialog", () => {
   });
 
   it("displays indexer errors returned by the search API", async () => {
-    global.fetch = createFetchMock({
+    globalThis.fetch = createFetchMock({
       search: { items: [], total: 0, offset: 0, errors: ["Indexer A: connection timeout"] },
     });
 
@@ -454,7 +439,7 @@ describe("GameDownloadDialog", () => {
       leechers: 1,
     });
 
-    global.fetch = createFetchMock({
+    globalThis.fetch = createFetchMock({
       search: makeSearchResult([mainItem, updateItem]),
     });
 
@@ -494,7 +479,7 @@ describe("GameDownloadDialog", () => {
   const groupSearchResults = makeSearchResult([skidrowItem, codexItem]);
 
   it("filters displayed results to preferred groups when filterByPreferredGroups is enabled", async () => {
-    global.fetch = createFetchMock({
+    globalThis.fetch = createFetchMock({
       search: groupSearchResults,
       settings: { filterByPreferredGroups: true, preferredReleaseGroups: '["SKIDROW"]' },
     });
@@ -512,7 +497,7 @@ describe("GameDownloadDialog", () => {
   });
 
   it("shows all results when filterByPreferredGroups is false even if groups are configured", async () => {
-    global.fetch = createFetchMock({
+    globalThis.fetch = createFetchMock({
       search: groupSearchResults,
       settings: { filterByPreferredGroups: false, preferredReleaseGroups: '["SKIDROW"]' },
     });
@@ -548,7 +533,7 @@ describe("GameDownloadDialog", () => {
   const platformSearchResults = makeSearchResult([pcItem, macItem]);
 
   it("shows platform filter section when results contain platform metadata", async () => {
-    global.fetch = createFetchMock({ search: platformSearchResults });
+    globalThis.fetch = createFetchMock({ search: platformSearchResults });
 
     renderComponent();
 
@@ -568,7 +553,7 @@ describe("GameDownloadDialog", () => {
   });
 
   it("filters results by selected platform", async () => {
-    global.fetch = createFetchMock({ search: platformSearchResults });
+    globalThis.fetch = createFetchMock({ search: platformSearchResults });
 
     renderComponent();
 
@@ -605,7 +590,7 @@ describe("GameDownloadDialog", () => {
 
   it("clears stale platform selections when search results no longer include that platform", async () => {
     // Start with PC + Mac results
-    global.fetch = createFetchMock({ search: platformSearchResults });
+    globalThis.fetch = createFetchMock({ search: platformSearchResults });
 
     renderComponent();
 
@@ -637,7 +622,7 @@ describe("GameDownloadDialog", () => {
 
     // Now simulate search returning only PC results (no Mac platform)
     const pcOnlyResults = makeSearchResult([pcItem]);
-    global.fetch = createFetchMock({ search: pcOnlyResults });
+    globalThis.fetch = createFetchMock({ search: pcOnlyResults });
 
     // Change search query to trigger re-fetch
     const searchInput = screen.getByDisplayValue("Test Game");
@@ -653,7 +638,7 @@ describe("GameDownloadDialog", () => {
   });
 
   it("displays Freeleech badge for torrents with downloadVolumeFactor of 0", async () => {
-    global.fetch = createFetchMock({
+    globalThis.fetch = createFetchMock({
       search: makeSearchResult([
         makeTorrentItem({
           guid: "fl-1",
@@ -678,7 +663,7 @@ describe("GameDownloadDialog", () => {
   });
 
   it("does not display Freeleech badge when downloadVolumeFactor is absent", async () => {
-    global.fetch = createFetchMock({
+    globalThis.fetch = createFetchMock({
       search: makeSearchResult([
         makeTorrentItem({
           guid: "no-fl-1",
@@ -701,7 +686,7 @@ describe("GameDownloadDialog", () => {
   });
 
   it("displays leechers count for torrent results", async () => {
-    global.fetch = createFetchMock({
+    globalThis.fetch = createFetchMock({
       search: makeSearchResult([
         makeTorrentItem({
           guid: "leecher-1",
@@ -724,7 +709,7 @@ describe("GameDownloadDialog", () => {
   });
 
   it.skip("displays file count for usenet results", async () => {
-    global.fetch = createFetchMock({
+    globalThis.fetch = createFetchMock({
       search: makeSearchResult([
         makeUsenetItem({
           guid: "nzb-files-1",
@@ -754,7 +739,7 @@ describe("GameDownloadDialog", () => {
       platform: string | null,
       items: ReturnType<typeof makeTorrentItem>[]
     ) {
-      global.fetch = createFetchMock({
+      globalThis.fetch = createFetchMock({
         settings: { preferredPlatform: platform },
         search: makeSearchResult(items),
       });
@@ -813,7 +798,7 @@ describe("GameDownloadDialog", () => {
   });
 
   it("displays poster name for usenet results", async () => {
-    global.fetch = createFetchMock({
+    globalThis.fetch = createFetchMock({
       search: makeSearchResult([
         makeUsenetItem({
           guid: "nzb-poster-1",
@@ -838,7 +823,7 @@ describe("GameDownloadDialog", () => {
   });
 
   it("shows the preferred-platform warning and clears it with the inline action", async () => {
-    global.fetch = createFetchMock({
+    globalThis.fetch = createFetchMock({
       settings: { preferredPlatform: "PS5" },
       search: platformSearchResults,
     });
@@ -864,8 +849,8 @@ describe("GameDownloadDialog", () => {
   });
 
   it("supports copying links and sending a release to a specific downloader", async () => {
-    global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
-      const target = String(url);
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const target = getRequestUrl(url);
       if (target.includes("/api/search")) {
         return { ok: true, json: async () => mockTorrents } as Response;
       }
@@ -892,7 +877,7 @@ describe("GameDownloadDialog", () => {
         return { ok: true, json: async () => ({ success: true }) } as Response;
       }
       return { ok: true, json: async () => ({ success: true }) } as Response;
-    }) as never;
+    }) as typeof fetch;
 
     renderComponent();
 
@@ -905,7 +890,7 @@ describe("GameDownloadDialog", () => {
     fireEvent.click(screen.getAllByText("Transmission")[0]);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         "/api/downloaders/2/downloads",
         expect.objectContaining({ method: "POST" })
       );
@@ -917,7 +902,7 @@ describe("GameDownloadDialog", () => {
 
   it("lets mobile users select bundle updates and download only the main game", async () => {
     mockIsMobile = true;
-    global.fetch = createFetchMock({
+    globalThis.fetch = createFetchMock({
       search: makeSearchResult([
         makeTorrentItem({
           guid: "mobile-main",
@@ -960,7 +945,7 @@ describe("GameDownloadDialog", () => {
     fireEvent.click(screen.getByText("Only the main game"));
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         "/api/downloads",
         expect.objectContaining({
           method: "POST",

--- a/client/__tests__/GameFilterPills.test.tsx
+++ b/client/__tests__/GameFilterPills.test.tsx
@@ -1,0 +1,60 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import GameFilterPills from "../src/components/GameFilterPills";
+import { TooltipProvider } from "../src/components/ui/tooltip";
+
+vi.mock("lucide-react", () => {
+  const Icon = () => <svg data-testid="icon" />;
+  return { Search: Icon, Download: Icon, RefreshCw: Icon };
+});
+
+function renderWithTooltip(ui: React.ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+describe("GameFilterPills", () => {
+  it("toggles search results and downloads filters", () => {
+    const setShowSearchResultsOnly = vi.fn();
+    const setShowDownloadsOnly = vi.fn();
+
+    renderWithTooltip(
+      <GameFilterPills
+        showSearchResultsOnly={false}
+        setShowSearchResultsOnly={setShowSearchResultsOnly}
+        showDownloadsOnly={false}
+        setShowDownloadsOnly={setShowDownloadsOnly}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show games with search results only" }));
+    fireEvent.click(screen.getByRole("button", { name: "Show games with downloads only" }));
+
+    expect(setShowSearchResultsOnly).toHaveBeenCalledWith(true);
+    expect(setShowDownloadsOnly).toHaveBeenCalledTimes(1);
+    expect(setShowDownloadsOnly.mock.calls[0][0](false)).toBe(true);
+  });
+
+  it("renders and toggles the update-available pill when enabled", () => {
+    const setShowUpdateAvailableOnly = vi.fn();
+
+    renderWithTooltip(
+      <GameFilterPills
+        showSearchResultsOnly={false}
+        setShowSearchResultsOnly={vi.fn()}
+        showDownloadsOnly
+        setShowDownloadsOnly={vi.fn()}
+        showUpdateAvailableOnly={false}
+        setShowUpdateAvailableOnly={setShowUpdateAvailableOnly}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show games with update downloads only" }));
+
+    expect(setShowUpdateAvailableOnly).toHaveBeenCalledTimes(1);
+    expect(setShowUpdateAvailableOnly.mock.calls[0][0](false)).toBe(true);
+  });
+});

--- a/client/__tests__/Library.mobile.test.tsx
+++ b/client/__tests__/Library.mobile.test.tsx
@@ -2,10 +2,11 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
 
 import Library from "../src/components/Library";
+import { createTestQueryClient } from "./test-utils";
 
 vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: vi.fn() }),
@@ -29,7 +30,10 @@ vi.mock("@/hooks/use-view-controls", () => ({
 }));
 
 vi.mock("@/hooks/use-local-storage-state", () => ({
-  useLocalStorageState: (_key: string, initial: number | boolean) => React.useState(initial),
+  useLocalStorageState: <T,>(_key: string, initial: T) => {
+    const [value, setValue] = React.useState(initial);
+    return [value, setValue] as const;
+  },
 }));
 
 vi.mock("@/components/GameFilterPills", () => ({
@@ -43,26 +47,12 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
 
-const createTestQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        queryFn: async ({ queryKey }) => {
-          const response = await fetch(queryKey.join(""));
-          if (!response.ok) throw new Error("Network response was not ok");
-          return response.json();
-        },
-      },
-    },
-  });
-
 describe("Library mobile toolbar", () => {
   it("renders mobile filter pills and the filter tooltip label", async () => {
-    global.fetch = vi.fn(async () => ({
+    globalThis.fetch = vi.fn(async () => ({
       ok: true,
       json: async () => [],
-    })) as never;
+    })) as typeof fetch;
 
     render(
       <QueryClientProvider client={createTestQueryClient()}>

--- a/client/__tests__/Library.mobile.test.tsx
+++ b/client/__tests__/Library.mobile.test.tsx
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import Library from "../src/components/Library";
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-hidden-mutation", () => ({
+  useHiddenMutation: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-download-summary", () => ({
+  useDownloadSummary: () => ({}),
+}));
+
+vi.mock("@/hooks/use-view-controls", () => ({
+  useViewControls: () => ({
+    viewMode: "grid",
+    setViewMode: vi.fn(),
+    listDensity: "comfortable",
+    setListDensity: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use-local-storage-state", () => ({
+  useLocalStorageState: (_key: string, initial: number | boolean) => React.useState(initial),
+}));
+
+vi.mock("@/components/GameFilterPills", () => ({
+  default: () => <div data-testid="library-filter-pills" />,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        queryFn: async ({ queryKey }) => {
+          const response = await fetch(queryKey.join(""));
+          if (!response.ok) throw new Error("Network response was not ok");
+          return response.json();
+        },
+      },
+    },
+  });
+
+describe("Library mobile toolbar", () => {
+  it("renders mobile filter pills and the filter tooltip label", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => [],
+    })) as never;
+
+    render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <Library />
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findAllByTestId("library-filter-pills")).toHaveLength(2);
+    expect(screen.getAllByText("Filters").length).toBeGreaterThan(0);
+  });
+});

--- a/client/__tests__/MobileBottomNav.test.tsx
+++ b/client/__tests__/MobileBottomNav.test.tsx
@@ -1,0 +1,69 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import MobileBottomNav from "../src/components/MobileBottomNav";
+
+vi.mock("lucide-react", () => {
+  const Icon = () => <svg data-testid="icon" />;
+  return {
+    MoreHorizontal: Icon,
+    Calendar: Icon,
+    Compass: Icon,
+    Database: Icon,
+    Download: Icon,
+    HardDrive: Icon,
+    Home: Icon,
+    Newspaper: Icon,
+    PieChart: Icon,
+    Rss: Icon,
+    ScrollText: Icon,
+    Search: Icon,
+    Settings: Icon,
+    Star: Icon,
+  };
+});
+
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ open, children }: { open: boolean; children: React.ReactNode }) => (
+    <div data-open={open}>{children}</div>
+  ),
+  SheetContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe("MobileBottomNav", () => {
+  it("marks the active pinned page", () => {
+    render(<MobileBottomNav activeItem="/downloads" onNavigate={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Downloads" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(screen.getByRole("button", { name: "More navigation options" })).not.toHaveAttribute(
+      "aria-current"
+    );
+  });
+
+  it("marks More as active for non-pinned pages and navigates from the sheet", () => {
+    const onNavigate = vi.fn();
+    render(<MobileBottomNav activeItem="/settings" onNavigate={onNavigate} />);
+
+    const moreButton = screen.getByRole("button", { name: "More navigation options" });
+    expect(moreButton).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(moreButton);
+    expect(moreButton).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: "Settings" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Logs" }));
+    expect(onNavigate).toHaveBeenCalledWith("/logs");
+    expect(moreButton).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/client/__tests__/MobileBottomNav.test.tsx
+++ b/client/__tests__/MobileBottomNav.test.tsx
@@ -66,4 +66,16 @@ describe("MobileBottomNav", () => {
     expect(onNavigate).toHaveBeenCalledWith("/logs");
     expect(moreButton).toHaveAttribute("aria-expanded", "false");
   });
+
+  it("does not treat login as a More page and shows section headings in the sheet", () => {
+    render(<MobileBottomNav activeItem="/login" onNavigate={vi.fn()} />);
+
+    const moreButton = screen.getByRole("button", { name: "More navigation options" });
+    expect(moreButton).not.toHaveAttribute("aria-current");
+
+    fireEvent.click(moreButton);
+
+    expect(screen.getByText("Pages")).toBeInTheDocument();
+    expect(screen.getByText("Management")).toBeInTheDocument();
+  });
 });

--- a/client/__tests__/MobileBottomNav.test.tsx
+++ b/client/__tests__/MobileBottomNav.test.tsx
@@ -36,6 +36,15 @@ vi.mock("@/components/ui/sheet", () => ({
 }));
 
 describe("MobileBottomNav", () => {
+  it("navigates directly from pinned items", () => {
+    const onNavigate = vi.fn();
+    render(<MobileBottomNav activeItem="/discover" onNavigate={onNavigate} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Downloads" }));
+
+    expect(onNavigate).toHaveBeenCalledWith("/downloads");
+  });
+
   it("marks the active pinned page", () => {
     render(<MobileBottomNav activeItem="/downloads" onNavigate={vi.fn()} />);
 
@@ -77,5 +86,13 @@ describe("MobileBottomNav", () => {
 
     expect(screen.getByText("Pages")).toBeInTheDocument();
     expect(screen.getByText("Management")).toBeInTheDocument();
+  });
+
+  it("does not treat setup as a More page", () => {
+    render(<MobileBottomNav activeItem="/setup" onNavigate={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "More navigation options" })).not.toHaveAttribute(
+      "aria-current"
+    );
   });
 });

--- a/client/__tests__/PageHeader.test.tsx
+++ b/client/__tests__/PageHeader.test.tsx
@@ -1,0 +1,34 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it } from "vitest";
+
+import PageHeader from "../src/components/PageHeader";
+
+describe("PageHeader", () => {
+  it("renders title, description, actions, and custom className", () => {
+    render(
+      <PageHeader
+        title="Downloads"
+        description="Manage active downloads"
+        className="custom-header"
+        actions={<button>Refresh</button>}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "Downloads" })).toBeInTheDocument();
+    expect(screen.getByText("Manage active downloads")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Manage active downloads").closest(".custom-header")
+    ).toBeInTheDocument();
+  });
+
+  it("omits optional description and actions when not provided", () => {
+    render(<PageHeader title="Calendar" />);
+
+    expect(screen.getByRole("heading", { name: "Calendar" })).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/client/__tests__/PagesHiddenWiring.test.tsx
+++ b/client/__tests__/PagesHiddenWiring.test.tsx
@@ -199,7 +199,7 @@ describe("Library filter buttons", () => {
       expect(lastGames).toHaveLength(2);
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Show games with downloads only" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Show games with downloads only" })[0]);
 
     await waitFor(() => {
       const calls = gameGridSpy.mock.calls;
@@ -217,7 +217,9 @@ describe("Library filter buttons", () => {
       expect(calls[calls.length - 1]?.[0]?.games).toHaveLength(2);
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Show games with search results only" }));
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Show games with search results only" })[0]
+    );
 
     await waitFor(() => {
       const calls = gameGridSpy.mock.calls;

--- a/client/__tests__/StatusBadge.test.tsx
+++ b/client/__tests__/StatusBadge.test.tsx
@@ -1,0 +1,23 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import StatusBadge, { getStatusLabel } from "../src/components/StatusBadge";
+
+describe("StatusBadge", () => {
+  it("returns known labels and falls back to the raw status", () => {
+    expect(getStatusLabel("downloading")).toBe("Downloading");
+    expect(getStatusLabel("queued")).toBe("queued");
+  });
+
+  it("renders the completed badge label", () => {
+    render(<StatusBadge status="completed" />);
+    expect(screen.getByTestId("badge-status-completed")).toHaveTextContent("Completed");
+  });
+
+  it("renders unknown statuses without an icon fallback error", () => {
+    render(<StatusBadge status="queued" />);
+    expect(screen.getByTestId("badge-status-queued")).toHaveTextContent("queued");
+  });
+});

--- a/client/__tests__/WishlistPage.mobile.test.tsx
+++ b/client/__tests__/WishlistPage.mobile.test.tsx
@@ -1,0 +1,132 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import WishlistPage from "../src/pages/wishlist";
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-hidden-mutation", () => ({
+  useHiddenMutation: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => true,
+}));
+
+vi.mock("@/hooks/use-view-controls", () => ({
+  useViewControls: () => ({
+    viewMode: "grid",
+    setViewMode: vi.fn(),
+    listDensity: "comfortable",
+    setListDensity: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use-local-storage-state", () => ({
+  useLocalStorageState: (_key: string, initial: boolean) => React.useState(initial),
+}));
+
+vi.mock("@/hooks/use-download-summary", () => ({
+  useDownloadSummary: () => ({}),
+}));
+
+vi.mock("@/components/PageToolbar", () => ({
+  default: ({
+    filterPills,
+    actions,
+  }: {
+    filterPills?: React.ReactNode;
+    actions?: React.ReactNode;
+  }) => (
+    <div>
+      {filterPills}
+      {actions}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/GameFilterPills", () => ({
+  default: () => <div data-testid="wishlist-filter-pills" />,
+}));
+
+vi.mock("@/components/EmptyState", () => ({
+  default: ({ title, description }: { title: string; description: string }) => (
+    <div>
+      <h2>{title}</h2>
+      <p>{description}</p>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/GameGrid", () => ({
+  default: ({ games }: { games: Array<{ title: string }> }) => (
+    <div data-testid="wishlist-grid">{games.map((g) => g.title).join(", ")}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <div data-value={value}>{children}</div>
+  ),
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({
+    value,
+    children,
+    ...props
+  }: {
+    value: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <button type="button" {...props} data-value={value}>
+      {children}
+    </button>
+  ),
+  TabsContent: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <div data-testid={`wishlist-tab-${value}`}>{children}</div>
+  ),
+}));
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        queryFn: async ({ queryKey }) => {
+          const response = await fetch(queryKey.join(""));
+          if (!response.ok) throw new Error("Network response was not ok");
+          return response.json();
+        },
+      },
+    },
+  });
+
+describe("WishlistPage mobile sections", () => {
+  it("renders mobile tabs for released, upcoming, and TBA games", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        { id: "released", title: "Released Game", status: "wanted", releaseDate: "2024-01-01" },
+        { id: "upcoming", title: "Upcoming Game", status: "wanted", releaseDate: "2099-01-01" },
+        { id: "tba", title: "TBA Game", status: "wanted", releaseDate: null },
+      ],
+    })) as never;
+
+    render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <WishlistPage />
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("Released")).toBeInTheDocument();
+    expect(screen.getByText("Upcoming")).toBeInTheDocument();
+    expect(screen.getByText("TBA")).toBeInTheDocument();
+    expect(screen.getAllByTestId("wishlist-grid")[0]).toHaveTextContent("Released Game");
+  });
+});

--- a/client/__tests__/WishlistPage.mobile.test.tsx
+++ b/client/__tests__/WishlistPage.mobile.test.tsx
@@ -1,9 +1,9 @@
 /** @vitest-environment jsdom */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import WishlistPage from "../src/pages/wishlist";
 import { createTestQueryClient } from "./test-utils";
@@ -37,18 +37,29 @@ vi.mock("@/hooks/use-local-storage-state", () => ({
 }));
 
 vi.mock("@/hooks/use-download-summary", () => ({
-  useDownloadSummary: () => ({}),
+  useDownloadSummary: () => mockDownloadSummaries,
 }));
 
 vi.mock("@/components/PageToolbar", () => ({
   default: ({
+    search,
+    onSearchChange,
+    searchPlaceholder,
     filterPills,
     actions,
   }: {
+    search?: string;
+    onSearchChange?: (value: string) => void;
+    searchPlaceholder?: string;
     filterPills?: React.ReactNode;
     actions?: React.ReactNode;
   }) => (
     <div>
+      <input
+        aria-label={searchPlaceholder ?? "Search"}
+        value={search ?? ""}
+        onChange={(event) => onSearchChange?.(event.target.value)}
+      />
       {filterPills}
       {actions}
     </div>
@@ -56,7 +67,26 @@ vi.mock("@/components/PageToolbar", () => ({
 }));
 
 vi.mock("@/components/GameFilterPills", () => ({
-  default: () => <div data-testid="wishlist-filter-pills" />,
+  default: ({
+    showSearchResultsOnly,
+    setShowSearchResultsOnly,
+    showDownloadsOnly,
+    setShowDownloadsOnly,
+  }: {
+    showSearchResultsOnly: boolean;
+    setShowSearchResultsOnly: (value: boolean) => void;
+    showDownloadsOnly: boolean;
+    setShowDownloadsOnly: (value: boolean) => void;
+  }) => (
+    <div data-testid="wishlist-filter-pills">
+      <button type="button" onClick={() => setShowSearchResultsOnly(!showSearchResultsOnly)}>
+        Search results only
+      </button>
+      <button type="button" onClick={() => setShowDownloadsOnly(!showDownloadsOnly)}>
+        Downloads only
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("@/components/EmptyState", () => ({
@@ -97,6 +127,12 @@ vi.mock("@/components/ui/tabs", () => ({
   ),
 }));
 
+let mockDownloadSummaries: Record<string, unknown>;
+
+beforeEach(() => {
+  mockDownloadSummaries = {};
+});
+
 describe("WishlistPage mobile sections", () => {
   it("renders mobile tabs for released, upcoming, and TBA games", async () => {
     globalThis.fetch = vi.fn(async () => ({
@@ -118,5 +154,85 @@ describe("WishlistPage mobile sections", () => {
     expect(screen.getByText("Upcoming")).toBeInTheDocument();
     expect(screen.getByText("TBA")).toBeInTheDocument();
     expect(screen.getAllByTestId("wishlist-grid")[0]).toHaveTextContent("Released Game");
+  });
+
+  it("falls back to stacked sections when only one mobile section remains", async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        { id: "released", title: "Released Game", status: "wanted", releaseDate: "2024-01-01" },
+        { id: "upcoming", title: "Upcoming Game", status: "wanted", releaseDate: "2099-01-01" },
+      ],
+    })) as typeof fetch;
+
+    render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <WishlistPage />
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("Released")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Unreleased" }));
+
+    expect(await screen.findByText("Wishlist")).toBeInTheDocument();
+    expect(screen.getByText("Released Game")).toBeInTheDocument();
+    expect(screen.queryByTestId("wishlist-tab-upcoming")).not.toBeInTheDocument();
+  });
+
+  it("shows the combined-filter empty state when both mobile filters remove all games", async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        {
+          id: "released",
+          title: "Released Game",
+          status: "wanted",
+          releaseDate: "2024-01-01",
+          searchResultsAvailable: false,
+        },
+      ],
+    })) as typeof fetch;
+
+    render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <WishlistPage />
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("Released Game")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Search results only" }));
+    fireEvent.click(screen.getByRole("button", { name: "Downloads only" }));
+
+    expect(await screen.findByText("No games match your filters")).toBeInTheDocument();
+    expect(
+      screen.getByText("Try disabling one or more filters to see more games.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Multiple filters active")).toBeInTheDocument();
+  });
+
+  it("shows the search empty state on mobile", async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        { id: "released", title: "Released Game", status: "wanted", releaseDate: "2024-01-01" },
+      ],
+    })) as typeof fetch;
+
+    render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <WishlistPage />
+      </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("Released Game")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Filter wishlist..." }), {
+      target: { value: "Metroid" },
+    });
+
+    expect(await screen.findByText("No games match your search")).toBeInTheDocument();
+    expect(screen.getByText('No wishlist games found for "Metroid".')).toBeInTheDocument();
   });
 });

--- a/client/__tests__/WishlistPage.mobile.test.tsx
+++ b/client/__tests__/WishlistPage.mobile.test.tsx
@@ -1,11 +1,12 @@
 /** @vitest-environment jsdom */
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
 
 import WishlistPage from "../src/pages/wishlist";
+import { createTestQueryClient } from "./test-utils";
 
 vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: vi.fn() }),
@@ -29,7 +30,10 @@ vi.mock("@/hooks/use-view-controls", () => ({
 }));
 
 vi.mock("@/hooks/use-local-storage-state", () => ({
-  useLocalStorageState: (_key: string, initial: boolean) => React.useState(initial),
+  useLocalStorageState: <T,>(_key: string, initial: T) => {
+    const [value, setValue] = React.useState(initial);
+    return [value, setValue] as const;
+  },
 }));
 
 vi.mock("@/hooks/use-download-summary", () => ({
@@ -93,30 +97,16 @@ vi.mock("@/components/ui/tabs", () => ({
   ),
 }));
 
-const createTestQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        queryFn: async ({ queryKey }) => {
-          const response = await fetch(queryKey.join(""));
-          if (!response.ok) throw new Error("Network response was not ok");
-          return response.json();
-        },
-      },
-    },
-  });
-
 describe("WishlistPage mobile sections", () => {
   it("renders mobile tabs for released, upcoming, and TBA games", async () => {
-    global.fetch = vi.fn(async () => ({
+    globalThis.fetch = vi.fn(async () => ({
       ok: true,
       json: async () => [
         { id: "released", title: "Released Game", status: "wanted", releaseDate: "2024-01-01" },
         { id: "upcoming", title: "Upcoming Game", status: "wanted", releaseDate: "2099-01-01" },
         { id: "tba", title: "TBA Game", status: "wanted", releaseDate: null },
       ],
-    })) as never;
+    })) as typeof fetch;
 
     render(
       <QueryClientProvider client={createTestQueryClient()}>

--- a/client/__tests__/calendar-utils.test.ts
+++ b/client/__tests__/calendar-utils.test.ts
@@ -17,6 +17,6 @@ describe("calendar date helpers", () => {
   it("pads month grids with adjacent-month dates", () => {
     const days = getDaysInMonth(2026, 1);
     expect(formatDate(days[0])).toBe("2026-01-26");
-    expect(formatDate(days[days.length - 1])).toBe("2026-03-01");
+    expect(formatDate(days.at(-1)!)).toBe("2026-03-01");
   });
 });

--- a/client/__tests__/calendar-utils.test.ts
+++ b/client/__tests__/calendar-utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDate, getDaysInMonth, getWeekDays } from "../src/pages/calendar";
+
+describe("calendar date helpers", () => {
+  it("formats dates as yyyy-mm-dd", () => {
+    expect(formatDate(new Date("2026-05-28T12:00:00.000Z"))).toBe("2026-05-28");
+  });
+
+  it("returns a monday-first week even when starting from sunday", () => {
+    const week = getWeekDays(new Date("2026-06-07T12:00:00.000Z"));
+    expect(week).toHaveLength(7);
+    expect(formatDate(week[0])).toBe("2026-06-01");
+    expect(formatDate(week[6])).toBe("2026-06-07");
+  });
+
+  it("pads month grids with adjacent-month dates", () => {
+    const days = getDaysInMonth(2026, 1);
+    expect(formatDate(days[0])).toBe("2026-01-26");
+    expect(formatDate(days[days.length - 1])).toBe("2026-03-01");
+  });
+});

--- a/client/__tests__/test-utils.tsx
+++ b/client/__tests__/test-utils.tsx
@@ -1,0 +1,33 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        queryFn: async ({ queryKey }) => {
+          const response = await fetch(queryKey.join(""));
+          if (!response.ok) {
+            throw new Error("Network response was not ok");
+          }
+          return response.json();
+        },
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+export function getRequestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input.url;
+}

--- a/client/__tests__/use-mobile.test.tsx
+++ b/client/__tests__/use-mobile.test.tsx
@@ -4,13 +4,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { useIsMobile } from "../src/hooks/use-mobile";
 
-const originalMatchMedia = window.matchMedia;
-const originalInnerWidth = window.innerWidth;
+const originalMatchMedia = globalThis.matchMedia;
+const originalInnerWidth = globalThis.innerWidth;
 
 describe("useIsMobile", () => {
   afterEach(() => {
-    window.matchMedia = originalMatchMedia;
-    window.innerWidth = originalInnerWidth;
+    globalThis.matchMedia = originalMatchMedia;
+    globalThis.innerWidth = originalInnerWidth;
     vi.restoreAllMocks();
   });
 
@@ -18,15 +18,15 @@ describe("useIsMobile", () => {
     const addListener = vi.fn();
     const removeListener = vi.fn();
 
-    window.innerWidth = 767;
-    window.matchMedia = vi.fn().mockReturnValue({
+    globalThis.innerWidth = 767;
+    globalThis.matchMedia = vi.fn().mockReturnValue({
       matches: true,
       media: "(max-width: 767px)",
       onchange: null,
       addListener,
       removeListener,
       dispatchEvent: vi.fn(),
-    }) as typeof window.matchMedia;
+    }) as typeof globalThis.matchMedia;
 
     const { result, unmount } = renderHook(() => useIsMobile());
 

--- a/client/__tests__/use-mobile.test.tsx
+++ b/client/__tests__/use-mobile.test.tsx
@@ -1,0 +1,40 @@
+/** @vitest-environment jsdom */
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useIsMobile } from "../src/hooks/use-mobile";
+
+const originalMatchMedia = window.matchMedia;
+const originalInnerWidth = window.innerWidth;
+
+describe("useIsMobile", () => {
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    window.innerWidth = originalInnerWidth;
+    vi.restoreAllMocks();
+  });
+
+  it("supports legacy MediaQueryList listeners used by jsdom environments", () => {
+    const addListener = vi.fn();
+    const removeListener = vi.fn();
+
+    window.innerWidth = 767;
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      media: "(max-width: 767px)",
+      onchange: null,
+      addListener,
+      removeListener,
+      dispatchEvent: vi.fn(),
+    }) as typeof window.matchMedia;
+
+    const { result, unmount } = renderHook(() => useIsMobile());
+
+    expect(result.current).toBe(true);
+    expect(addListener).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(removeListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/__tests__/use-mobile.test.tsx
+++ b/client/__tests__/use-mobile.test.tsx
@@ -14,6 +14,30 @@ describe("useIsMobile", () => {
     vi.restoreAllMocks();
   });
 
+  it("supports modern MediaQueryList event listeners", () => {
+    const addEventListener = vi.fn();
+    const removeEventListener = vi.fn();
+
+    globalThis.innerWidth = 1024;
+    globalThis.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      media: "(max-width: 767px)",
+      onchange: null,
+      addEventListener,
+      removeEventListener,
+      dispatchEvent: vi.fn(),
+    }) as typeof globalThis.matchMedia;
+
+    const { result, unmount } = renderHook(() => useIsMobile());
+
+    expect(result.current).toBe(false);
+    expect(addEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+
+    unmount();
+
+    expect(removeEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+  });
+
   it("supports legacy MediaQueryList listeners used by jsdom environments", () => {
     const addListener = vi.fn();
     const removeListener = vi.fn();

--- a/client/src/components/AddGameModal.tsx
+++ b/client/src/components/AddGameModal.tsx
@@ -8,18 +8,27 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
-import { Search, Plus, Star, AlertCircle, Calendar } from "lucide-react";
+import { Search, Plus, Star, AlertCircle, Calendar, Check } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { type Game, type InsertGame, type Config } from "@shared/schema";
 import { mapGameToInsertGame } from "@/lib/utils";
 import { Link } from "wouter";
 import { apiRequest } from "@/lib/queryClient";
 import { getAddGamePendingQuery, clearAddGamePendingQuery } from "@/lib/add-game-store";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 interface SearchResult extends Game {
   inCollection?: boolean;
@@ -37,6 +46,7 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
   const [showUndatedGames, setShowUndatedGames] = useState(false);
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
 
   const { data: config } = useQuery<Config>({
     queryKey: ["/api/config"],
@@ -142,6 +152,168 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
     inCollection: userGames.some((userGame) => userGame.igdbId === game.igdbId),
   }));
 
+  const igdbNotConfigured = config && !config.igdb?.configured;
+
+  // ─── Mobile layout (bottom sheet) ────────────────────────────────────────────
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={setOpen} shouldScaleBackground={false}>
+        <DrawerTrigger asChild>{children}</DrawerTrigger>
+        <DrawerContent className="h-[92vh] flex flex-col">
+          <DrawerHeader className="pt-2 pb-0 px-4">
+            <DrawerTitle className="text-base">Add Game</DrawerTitle>
+            <DrawerDescription className="sr-only">
+              Search for games to add to your collection
+            </DrawerDescription>
+          </DrawerHeader>
+
+          {igdbNotConfigured ? (
+            <div className="flex flex-col items-center justify-center flex-1 py-8 text-center space-y-4 px-6">
+              <div className="bg-muted p-4 rounded-full">
+                <AlertCircle className="h-8 w-8 text-muted-foreground" />
+              </div>
+              <h3 className="font-semibold text-lg">IGDB Configuration Required</h3>
+              <p className="text-muted-foreground text-sm">
+                Please configure IGDB credentials in settings to search for and add games.
+              </p>
+              <Link href="/settings">
+                <Button className="w-full" onClick={() => setOpen(false)}>
+                  Go to Settings
+                </Button>
+              </Link>
+            </div>
+          ) : (
+            <div className="flex-1 flex flex-col overflow-hidden min-h-0">
+              {/* Sticky search + filter strip */}
+              <div className="flex-shrink-0 px-4 pt-3 pb-3 space-y-2 border-b border-border/50">
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground w-4 h-4 pointer-events-none" />
+                  <Input
+                    type="search"
+                    placeholder="Search for games..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    className="pl-10 h-11"
+                    data-testid="input-game-search"
+                    aria-label="Search games"
+                  />
+                </div>
+                <div className="flex items-center justify-between gap-2 px-0.5">
+                  <span className="text-xs text-muted-foreground">Show undated games first</span>
+                  <Switch
+                    checked={showUndatedGames}
+                    onCheckedChange={setShowUndatedGames}
+                    aria-label="Show undated games first"
+                  />
+                </div>
+              </div>
+
+              {/* Scrollable results */}
+              <div
+                className="flex-1 overflow-y-auto min-h-0 px-4 py-3 space-y-2"
+                aria-live="polite"
+              >
+                {isSearching && (
+                  <div className="text-center py-10 text-sm text-muted-foreground">
+                    Searching games…
+                  </div>
+                )}
+
+                {!isSearching && !debouncedQuery && (
+                  <div className="text-center py-10 text-sm text-muted-foreground">
+                    Type at least 3 characters to search.
+                  </div>
+                )}
+
+                {!isSearching && debouncedQuery && resultsWithCollectionStatus.length === 0 && (
+                  <div className="text-center py-10 text-sm text-muted-foreground">
+                    No games found. Try a different search term.
+                  </div>
+                )}
+
+                {resultsWithCollectionStatus.map((game) => (
+                  <div
+                    key={game.id}
+                    className="flex gap-3 rounded-lg bg-muted/40 p-3"
+                    data-testid={`search-result-${game.id}`}
+                  >
+                    <img
+                      src={game.coverUrl || "/placeholder-game-cover.jpg"}
+                      alt={`${game.title} cover`}
+                      className="w-14 h-20 object-cover rounded-md flex-shrink-0"
+                    />
+                    <div className="flex-1 min-w-0 flex flex-col gap-1">
+                      <div className="flex items-start justify-between gap-2">
+                        <h3
+                          className="font-semibold text-sm leading-snug line-clamp-2 flex-1"
+                          data-testid={`text-game-title-${game.id}`}
+                        >
+                          {game.title}
+                        </h3>
+                        {game.inCollection ? (
+                          <Badge variant="default" className="text-xs flex-shrink-0 mt-0.5 gap-1">
+                            <Check className="w-3 h-3" />
+                            Added
+                          </Badge>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => handleAddGame(game)}
+                            disabled={addGameMutation.isPending}
+                            className="flex-shrink-0 w-8 h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50"
+                            data-testid={`button-add-${game.id}`}
+                            aria-label={`Add ${game.title} to collection`}
+                          >
+                            <Plus className="w-4 h-4" />
+                          </button>
+                        )}
+                      </div>
+
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        {game.releaseDate && (
+                          <span className="flex items-center gap-1">
+                            <Calendar className="w-3 h-3" />
+                            {game.releaseDate.endsWith("-12-31")
+                              ? new Date(game.releaseDate).getFullYear()
+                              : new Date(game.releaseDate).toLocaleDateString(undefined, {
+                                  year: "numeric",
+                                  month: "short",
+                                })}
+                          </span>
+                        )}
+                        {game.rating && (
+                          <span className="flex items-center gap-1">
+                            <Star className="w-3 h-3 text-accent" />
+                            {game.rating}/10
+                          </span>
+                        )}
+                      </div>
+
+                      {game.genres?.[0] && (
+                        <Badge variant="secondary" className="text-xs w-fit">
+                          {game.genres[0]}
+                        </Badge>
+                      )}
+
+                      {game.summary && (
+                        <p className="text-xs text-muted-foreground line-clamp-2 mt-0.5">
+                          {game.summary}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
+
+  // ─── Desktop layout (dialog, unchanged) ──────────────────────────────────────
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{children}</DialogTrigger>
@@ -151,7 +323,7 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
           <DialogDescription>Search for games to add to your collection</DialogDescription>
         </DialogHeader>
 
-        {config && !config.igdb?.configured ? (
+        {igdbNotConfigured ? (
           <div className="flex flex-col items-center justify-center py-8 text-center space-y-4">
             <div className="bg-muted p-4 rounded-full">
               <AlertCircle className="h-8 w-8 text-muted-foreground" />

--- a/client/src/components/AddGameModal.tsx
+++ b/client/src/components/AddGameModal.tsx
@@ -21,7 +21,7 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
-import { Search, Plus, Star, AlertCircle, Calendar, Check } from "lucide-react";
+import { Search, Plus, Star, AlertCircle, Calendar, Check, Loader2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { type Game, type InsertGame, type Config } from "@shared/schema";
 import { mapGameToInsertGame } from "@/lib/utils";
@@ -154,6 +154,9 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
 
   const igdbNotConfigured = config && !config.igdb?.configured;
 
+  const isAddingGame = (igdbId: number | null | undefined) =>
+    addGameMutation.isPending && addGameMutation.variables?.igdbId === igdbId;
+
   // ─── Mobile layout (bottom sheet) ────────────────────────────────────────────
 
   if (isMobile) {
@@ -265,7 +268,11 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
                             data-testid={`button-add-${game.id}`}
                             aria-label={`Add ${game.title} to collection`}
                           >
-                            <Plus className="w-4 h-4" />
+                            {isAddingGame(game.igdbId) ? (
+                              <Loader2 className="w-4 h-4 animate-spin" />
+                            ) : (
+                              <Plus className="w-4 h-4" />
+                            )}
                           </button>
                         )}
                       </div>
@@ -460,8 +467,12 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
                               data-testid={`button-add-${game.id}`}
                               aria-label={`Add ${game.title} to collection`}
                             >
-                              <Plus className="w-4 h-4 mr-1" />
-                              Add
+                              {isAddingGame(game.igdbId) ? (
+                                <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                              ) : (
+                                <Plus className="w-4 h-4 mr-1" />
+                              )}
+                              {isAddingGame(game.igdbId) ? "Adding..." : "Add"}
                             </Button>
                           )}
                         </div>

--- a/client/src/components/CompactGameCard.tsx
+++ b/client/src/components/CompactGameCard.tsx
@@ -194,7 +194,7 @@ const CompactGameCard = ({
 
               <div className="mt-2 flex flex-wrap gap-1">
                 {game.genres && game.genres.length > 0 ? (
-                  game.genres.slice(0, 2).map((genre) => (
+                  game.genres.slice(0, 1).map((genre) => (
                     <span
                       key={genre}
                       className="rounded-full bg-muted/70 px-2 py-1 text-[11px] text-muted-foreground"

--- a/client/src/components/DiscoverSettingsModal.tsx
+++ b/client/src/components/DiscoverSettingsModal.tsx
@@ -8,12 +8,20 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Switch } from "@/components/ui/switch";
 import { Eye, BookMarked, CheckCircle2 } from "lucide-react";
 import { type Game } from "@shared/schema";
 import { useToast } from "@/hooks/use-toast";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 interface DiscoverSettingsModalProps {
   open: boolean;
@@ -36,8 +44,8 @@ export default function DiscoverSettingsModal({
 }: DiscoverSettingsModalProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
 
-  // Unhide game mutation
   const unhideMutation = useMutation({
     mutationFn: async (gameId: string) => {
       const response = await apiRequest("PATCH", `/api/games/${gameId}/hidden`, { hidden: false });
@@ -48,16 +56,104 @@ export default function DiscoverSettingsModal({
       toast({ description: "Game unhidden" });
     },
     onError: () => {
-      toast({
-        description: "Failed to unhide game",
-        variant: "destructive",
-      });
+      toast({ description: "Failed to unhide game", variant: "destructive" });
     },
   });
 
   const handleUnhide = (gameId: string) => {
     unhideMutation.mutate(gameId);
   };
+
+  const innerContent = (
+    <div className="flex flex-col flex-1 overflow-hidden min-h-0 px-4 pb-4">
+      {/* Toggles */}
+      <div className="space-y-4 py-4 border-b flex-shrink-0">
+        <div className="flex items-center justify-between space-x-2">
+          <div className="flex flex-col space-y-1">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <CheckCircle2 className="w-4 h-4 text-green-500" />
+              Hide Owned Games
+            </div>
+            <span className="text-xs text-muted-foreground">
+              Do not show games already in your "Owned" or "Completed" library.
+            </span>
+          </div>
+          <Switch checked={hideOwned} onCheckedChange={onHideOwnedChange} />
+        </div>
+
+        <div className="flex items-center justify-between space-x-2">
+          <div className="flex flex-col space-y-1">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <BookMarked className="w-4 h-4 text-primary" />
+              Hide Wanted Games
+            </div>
+            <span className="text-xs text-muted-foreground">
+              Do not show games already in your watchlist.
+            </span>
+          </div>
+          <Switch checked={hideWanted} onCheckedChange={onHideWantedChange} />
+        </div>
+      </div>
+
+      {/* Hidden games list */}
+      <div className="flex flex-col flex-1 overflow-hidden min-h-0 mt-4">
+        <h3 className="font-semibold mb-2 flex items-center gap-2 flex-shrink-0">
+          <Eye className="h-4 w-4" />
+          Hidden Games ({hiddenGames.length})
+        </h3>
+
+        <ScrollArea className="flex-1 border rounded-md p-2">
+          {hiddenGames.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground text-sm">
+              No manually hidden games.
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {hiddenGames.map((game) => (
+                <div
+                  key={game.id}
+                  className="flex items-center justify-between bg-muted/30 p-2 rounded hover:bg-muted/50 transition-colors"
+                >
+                  <div className="flex items-center gap-3 overflow-hidden">
+                    <img
+                      src={game.coverUrl || "/placeholder-game-cover.jpg"}
+                      alt={game.title}
+                      className="w-10 h-14 object-cover rounded"
+                    />
+                    <span className="font-medium truncate text-sm">{game.title}</span>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => handleUnhide(game.id)}
+                    disabled={unhideMutation.isPending}
+                  >
+                    Unhide
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+      </div>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange} shouldScaleBackground={false}>
+        <DrawerContent className="h-[80vh] flex flex-col">
+          <DrawerHeader className="pt-2 pb-0 px-4 flex-shrink-0">
+            <DrawerTitle>Discovery Settings</DrawerTitle>
+            <DrawerDescription className="sr-only">
+              Customize your discovery experience.
+            </DrawerDescription>
+          </DrawerHeader>
+          {innerContent}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -66,75 +162,7 @@ export default function DiscoverSettingsModal({
           <DialogTitle>Discovery Settings</DialogTitle>
           <DialogDescription>Customize your discovery experience.</DialogDescription>
         </DialogHeader>
-
-        <div className="space-y-4 py-4 border-b">
-          <div className="flex items-center justify-between space-x-2">
-            <div className="flex flex-col space-y-1">
-              <div className="flex items-center gap-2 text-sm font-medium">
-                <CheckCircle2 className="w-4 h-4 text-green-500" />
-                Hide Owned Games
-              </div>
-              <span className="text-xs text-muted-foreground">
-                Do not show games already in your "Owned" or "Completed" library.
-              </span>
-            </div>
-            <Switch checked={hideOwned} onCheckedChange={onHideOwnedChange} />
-          </div>
-
-          <div className="flex items-center justify-between space-x-2">
-            <div className="flex flex-col space-y-1">
-              <div className="flex items-center gap-2 text-sm font-medium">
-                <BookMarked className="w-4 h-4 text-primary" />
-                Hide Wanted Games
-              </div>
-              <span className="text-xs text-muted-foreground">
-                Do not show games already in your watchlist.
-              </span>
-            </div>
-            <Switch checked={hideWanted} onCheckedChange={onHideWantedChange} />
-          </div>
-        </div>
-
-        <div className="flex-1 overflow-hidden flex flex-col mt-4">
-          <h3 className="font-semibold mb-2 flex items-center gap-2">
-            <Eye className="h-4 w-4" />
-            Hidden Games ({hiddenGames.length})
-          </h3>
-
-          <ScrollArea className="flex-1 border rounded-md p-2">
-            {hiddenGames.length === 0 ? (
-              <div className="text-center py-8 text-muted-foreground text-sm">
-                No manually hidden games.
-              </div>
-            ) : (
-              <div className="space-y-2">
-                {hiddenGames.map((game) => (
-                  <div
-                    key={game.id}
-                    className="flex items-center justify-between bg-muted/30 p-2 rounded hover:bg-muted/50 transition-colors"
-                  >
-                    <div className="flex items-center gap-3 overflow-hidden">
-                      <img
-                        src={game.coverUrl || "/placeholder-game-cover.jpg"}
-                        alt={game.title}
-                        className="w-10 h-14 object-cover rounded"
-                      />
-                      <span className="font-medium truncate text-sm">{game.title}</span>
-                    </div>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => handleUnhide(game.id)}
-                      disabled={unhideMutation.isPending}
-                    >
-                      Unhide
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            )}
-          </ScrollArea>
-        </div>
+        {innerContent}
       </DialogContent>
     </Dialog>
   );

--- a/client/src/components/DiscoverSettingsModal.tsx
+++ b/client/src/components/DiscoverSettingsModal.tsx
@@ -128,7 +128,9 @@ export default function DiscoverSettingsModal({
                     onClick={() => handleUnhide(game.id)}
                     disabled={unhideMutation.isPending}
                   >
-                    Unhide
+                    {unhideMutation.isPending && unhideMutation.variables === game.id
+                      ? "Unhiding..."
+                      : "Unhide"}
                   </Button>
                 </div>
               ))}

--- a/client/src/components/DownloadDetailsModal.tsx
+++ b/client/src/components/DownloadDetailsModal.tsx
@@ -6,6 +6,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -24,6 +31,7 @@ import {
 } from "lucide-react";
 import { formatBytes } from "@/lib/utils";
 import type { DownloadFile, DownloadTracker, DownloadDetails } from "@shared/schema";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 interface DownloadDetailsModalProps {
   downloaderId: string;
@@ -80,6 +88,8 @@ export default function DownloadDetailsModal({
   open,
   onOpenChange,
 }: DownloadDetailsModalProps) {
+  const isMobile = useIsMobile();
+
   const {
     data: details,
     isLoading,
@@ -91,6 +101,302 @@ export default function DownloadDetailsModal({
     refetchIntervalInBackground: false,
     refetchOnWindowFocus: false,
   });
+
+  const innerContent = (
+    <div className="flex-1 flex flex-col overflow-hidden min-h-0 px-4 pb-4">
+      {isLoading && (
+        <div
+          className="flex items-center justify-center py-8"
+          data-testid="download-details-loading"
+        >
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent mr-2" />
+          <span>Loading download details...</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="text-destructive py-4" data-testid="download-details-error">
+          Failed to load download details:{" "}
+          {error instanceof Error ? error.message : "Unknown error"}
+        </div>
+      )}
+
+      {details && (
+        <Tabs defaultValue="info" className="flex-1 flex flex-col overflow-hidden min-h-0">
+          <TabsList className="grid w-full grid-cols-3 flex-shrink-0">
+            <TabsTrigger value="info" data-testid="tab-info">
+              <Activity className="w-4 h-4 mr-2" />
+              Info
+            </TabsTrigger>
+            <TabsTrigger value="files" data-testid="tab-files">
+              <File className="w-4 h-4 mr-2" />
+              Files ({details.files.length})
+            </TabsTrigger>
+            <TabsTrigger value="trackers" data-testid="tab-trackers">
+              <Server className="w-4 h-4 mr-2" />
+              Trackers ({details.trackers.length})
+            </TabsTrigger>
+          </TabsList>
+
+          {/* Info Tab */}
+          <TabsContent
+            value="info"
+            className="flex-1 overflow-hidden mt-4"
+            data-testid="tab-content-info"
+          >
+            <ScrollArea className="h-full pr-4">
+              <div className="space-y-6">
+                <div className="grid gap-4 md:grid-cols-2">
+                  {details.hash && (
+                    <div className="flex items-start gap-3">
+                      <Hash className="w-5 h-5 text-muted-foreground mt-0.5" />
+                      <div>
+                        <p className="text-sm font-medium text-muted-foreground">Hash</p>
+                        <p className="text-sm font-mono break-all" data-testid="detail-hash">
+                          {details.hash}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  {details.downloadDir && (
+                    <div className="flex items-start gap-3">
+                      <Folder className="w-5 h-5 text-muted-foreground mt-0.5" />
+                      <div>
+                        <p className="text-sm font-medium text-muted-foreground">
+                          Download Location
+                        </p>
+                        <p className="text-sm break-all" data-testid="detail-download-dir">
+                          {details.downloadDir}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  {details.size && (
+                    <div className="flex items-start gap-3">
+                      <HardDrive className="w-5 h-5 text-muted-foreground mt-0.5" />
+                      <div>
+                        <p className="text-sm font-medium text-muted-foreground">Size</p>
+                        <p className="text-sm" data-testid="detail-size">
+                          {formatBytes(details.downloaded || 0)} / {formatBytes(details.size)}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  {details.addedDate && (
+                    <div className="flex items-start gap-3">
+                      <Calendar className="w-5 h-5 text-muted-foreground mt-0.5" />
+                      <div>
+                        <p className="text-sm font-medium text-muted-foreground">Added</p>
+                        <p className="text-sm" data-testid="detail-added-date">
+                          {formatDate(details.addedDate)}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  {details.completedDate && (
+                    <div className="flex items-start gap-3">
+                      <Clock className="w-5 h-5 text-muted-foreground mt-0.5" />
+                      <div>
+                        <p className="text-sm font-medium text-muted-foreground">Completed</p>
+                        <p className="text-sm" data-testid="detail-completed-date">
+                          {formatDate(details.completedDate)}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  {details.connectedPeers !== undefined && (
+                    <div className="flex items-start gap-3">
+                      <Users className="w-5 h-5 text-muted-foreground mt-0.5" />
+                      <div>
+                        <p className="text-sm font-medium text-muted-foreground">Connected Peers</p>
+                        <p className="text-sm" data-testid="detail-peers">
+                          {details.connectedPeers}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                <Separator />
+
+                <div>
+                  <div className="flex justify-between text-sm mb-2">
+                    <span>Progress</span>
+                    <span data-testid="detail-progress">{details.progress.toFixed(1)}%</span>
+                  </div>
+                  <Progress value={details.progress} className="h-2" />
+                </div>
+
+                {(details.comment || details.creator) && (
+                  <>
+                    <Separator />
+                    <div className="space-y-2">
+                      {details.creator && (
+                        <div>
+                          <p className="text-sm font-medium text-muted-foreground">Created By</p>
+                          <p className="text-sm" data-testid="detail-creator">
+                            {details.creator}
+                          </p>
+                        </div>
+                      )}
+                      {details.comment && (
+                        <div>
+                          <p className="text-sm font-medium text-muted-foreground">Comment</p>
+                          <p className="text-sm" data-testid="detail-comment">
+                            {details.comment}
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            </ScrollArea>
+          </TabsContent>
+
+          {/* Files Tab */}
+          <TabsContent
+            value="files"
+            className="flex-1 overflow-hidden mt-4"
+            data-testid="tab-content-files"
+          >
+            <ScrollArea className="h-full pr-4">
+              {details.files.length === 0 ? (
+                <div className="text-center text-muted-foreground py-8" data-testid="no-files">
+                  No file information available
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {details.files.map((file, index) => (
+                    <div
+                      key={index}
+                      className="border rounded-lg p-3 space-y-2"
+                      data-testid={`file-${index}`}
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex items-start gap-2 flex-1 min-w-0">
+                          <File className="w-4 h-4 text-muted-foreground mt-1 flex-shrink-0" />
+                          <span className="text-sm break-all">{file.name}</span>
+                        </div>
+                        <div className="flex items-center gap-2 flex-shrink-0">
+                          <Badge
+                            variant={getPriorityBadgeVariant(file.priority)}
+                            className="capitalize"
+                          >
+                            {file.priority}
+                          </Badge>
+                          <span className="text-sm text-muted-foreground whitespace-nowrap">
+                            {formatBytes(file.size)}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Progress value={file.progress} className="h-1 flex-1" />
+                        <span className="text-xs text-muted-foreground whitespace-nowrap">
+                          {file.progress.toFixed(1)}%
+                        </span>
+                      </div>
+                      {!file.wanted && (
+                        <Badge variant="outline" className="text-xs">
+                          Skipped
+                        </Badge>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </ScrollArea>
+          </TabsContent>
+
+          {/* Trackers Tab */}
+          <TabsContent
+            value="trackers"
+            className="flex-1 overflow-hidden mt-4"
+            data-testid="tab-content-trackers"
+          >
+            <ScrollArea className="h-full pr-4">
+              {details.trackers.length === 0 ? (
+                <div className="text-center text-muted-foreground py-8" data-testid="no-trackers">
+                  No tracker information available
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {details.trackers.map((tracker, index) => (
+                    <div
+                      key={index}
+                      className="border rounded-lg p-3 space-y-2"
+                      data-testid={`tracker-${index}`}
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex items-start gap-2 flex-1 min-w-0">
+                          <Server className="w-4 h-4 text-muted-foreground mt-1 flex-shrink-0" />
+                          <span className="text-sm break-all font-mono">{tracker.url}</span>
+                        </div>
+                        <div className="flex items-center gap-2 flex-shrink-0">
+                          <div
+                            className={`w-2 h-2 rounded-full ${getTrackerStatusColor(tracker.status)}`}
+                          />
+                          <span className="text-sm capitalize">{tracker.status}</span>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                        <span>Tier: {tracker.tier}</span>
+                        {tracker.seeders !== undefined && <span>• Seeds: {tracker.seeders}</span>}
+                        {tracker.leechers !== undefined && (
+                          <span>• Leechers: {tracker.leechers}</span>
+                        )}
+                      </div>
+
+                      {tracker.lastAnnounce && (
+                        <div className="text-xs text-muted-foreground">
+                          Last announce: {formatDate(tracker.lastAnnounce)}
+                        </div>
+                      )}
+                      {tracker.nextAnnounce && (
+                        <div className="text-xs text-muted-foreground">
+                          Next announce: {formatDate(tracker.nextAnnounce)}
+                        </div>
+                      )}
+                      {tracker.error && (
+                        <div className="text-xs text-destructive">Error: {tracker.error}</div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </ScrollArea>
+          </TabsContent>
+        </Tabs>
+      )}
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <Drawer open={open} onOpenChange={onOpenChange} shouldScaleBackground={false}>
+        <DrawerContent className="h-[90vh] flex flex-col">
+          <DrawerHeader className="pt-2 pb-3 px-4 flex-shrink-0">
+            <DrawerTitle
+              className="text-base font-bold leading-tight truncate"
+              data-testid="download-details-title"
+            >
+              {downloadName}
+            </DrawerTitle>
+            <DrawerDescription className="sr-only">
+              Download details including files, trackers, and metadata
+            </DrawerDescription>
+          </DrawerHeader>
+          {innerContent}
+        </DrawerContent>
+      </Drawer>
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -106,284 +412,7 @@ export default function DownloadDetailsModal({
             Download details including files, trackers, and metadata
           </DialogDescription>
         </DialogHeader>
-
-        {isLoading && (
-          <div
-            className="flex items-center justify-center py-8"
-            data-testid="download-details-loading"
-          >
-            <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent mr-2" />
-            <span>Loading download details...</span>
-          </div>
-        )}
-
-        {error && (
-          <div className="text-destructive py-4" data-testid="download-details-error">
-            Failed to load download details:{" "}
-            {error instanceof Error ? error.message : "Unknown error"}
-          </div>
-        )}
-
-        {details && (
-          <Tabs defaultValue="info" className="flex-1 flex flex-col overflow-hidden">
-            <TabsList className="grid w-full grid-cols-3 flex-shrink-0">
-              <TabsTrigger value="info" data-testid="tab-info">
-                <Activity className="w-4 h-4 mr-2" />
-                Info
-              </TabsTrigger>
-              <TabsTrigger value="files" data-testid="tab-files">
-                <File className="w-4 h-4 mr-2" />
-                Files ({details.files.length})
-              </TabsTrigger>
-              <TabsTrigger value="trackers" data-testid="tab-trackers">
-                <Server className="w-4 h-4 mr-2" />
-                Trackers ({details.trackers.length})
-              </TabsTrigger>
-            </TabsList>
-
-            {/* Info Tab */}
-            <TabsContent
-              value="info"
-              className="flex-1 overflow-hidden mt-4"
-              data-testid="tab-content-info"
-            >
-              <ScrollArea className="h-full pr-4">
-                <div className="space-y-6">
-                  {/* General Info */}
-                  <div className="grid gap-4 md:grid-cols-2">
-                    {details.hash && (
-                      <div className="flex items-start gap-3">
-                        <Hash className="w-5 h-5 text-muted-foreground mt-0.5" />
-                        <div>
-                          <p className="text-sm font-medium text-muted-foreground">Hash</p>
-                          <p className="text-sm font-mono break-all" data-testid="detail-hash">
-                            {details.hash}
-                          </p>
-                        </div>
-                      </div>
-                    )}
-
-                    {details.downloadDir && (
-                      <div className="flex items-start gap-3">
-                        <Folder className="w-5 h-5 text-muted-foreground mt-0.5" />
-                        <div>
-                          <p className="text-sm font-medium text-muted-foreground">
-                            Download Location
-                          </p>
-                          <p className="text-sm break-all" data-testid="detail-download-dir">
-                            {details.downloadDir}
-                          </p>
-                        </div>
-                      </div>
-                    )}
-
-                    {details.size && (
-                      <div className="flex items-start gap-3">
-                        <HardDrive className="w-5 h-5 text-muted-foreground mt-0.5" />
-                        <div>
-                          <p className="text-sm font-medium text-muted-foreground">Size</p>
-                          <p className="text-sm" data-testid="detail-size">
-                            {formatBytes(details.downloaded || 0)} / {formatBytes(details.size)}
-                          </p>
-                        </div>
-                      </div>
-                    )}
-
-                    {details.addedDate && (
-                      <div className="flex items-start gap-3">
-                        <Calendar className="w-5 h-5 text-muted-foreground mt-0.5" />
-                        <div>
-                          <p className="text-sm font-medium text-muted-foreground">Added</p>
-                          <p className="text-sm" data-testid="detail-added-date">
-                            {formatDate(details.addedDate)}
-                          </p>
-                        </div>
-                      </div>
-                    )}
-
-                    {details.completedDate && (
-                      <div className="flex items-start gap-3">
-                        <Clock className="w-5 h-5 text-muted-foreground mt-0.5" />
-                        <div>
-                          <p className="text-sm font-medium text-muted-foreground">Completed</p>
-                          <p className="text-sm" data-testid="detail-completed-date">
-                            {formatDate(details.completedDate)}
-                          </p>
-                        </div>
-                      </div>
-                    )}
-
-                    {details.connectedPeers !== undefined && (
-                      <div className="flex items-start gap-3">
-                        <Users className="w-5 h-5 text-muted-foreground mt-0.5" />
-                        <div>
-                          <p className="text-sm font-medium text-muted-foreground">
-                            Connected Peers
-                          </p>
-                          <p className="text-sm" data-testid="detail-peers">
-                            {details.connectedPeers}
-                          </p>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-
-                  <Separator />
-
-                  {/* Progress */}
-                  <div>
-                    <div className="flex justify-between text-sm mb-2">
-                      <span>Progress</span>
-                      <span data-testid="detail-progress">{details.progress.toFixed(1)}%</span>
-                    </div>
-                    <Progress value={details.progress} className="h-2" />
-                  </div>
-
-                  {/* Comment / Creator */}
-                  {(details.comment || details.creator) && (
-                    <>
-                      <Separator />
-                      <div className="space-y-2">
-                        {details.creator && (
-                          <div>
-                            <p className="text-sm font-medium text-muted-foreground">Created By</p>
-                            <p className="text-sm" data-testid="detail-creator">
-                              {details.creator}
-                            </p>
-                          </div>
-                        )}
-                        {details.comment && (
-                          <div>
-                            <p className="text-sm font-medium text-muted-foreground">Comment</p>
-                            <p className="text-sm" data-testid="detail-comment">
-                              {details.comment}
-                            </p>
-                          </div>
-                        )}
-                      </div>
-                    </>
-                  )}
-                </div>
-              </ScrollArea>
-            </TabsContent>
-
-            {/* Files Tab */}
-            <TabsContent
-              value="files"
-              className="flex-1 overflow-hidden mt-4"
-              data-testid="tab-content-files"
-            >
-              <ScrollArea className="h-[400px] pr-4">
-                {details.files.length === 0 ? (
-                  <div className="text-center text-muted-foreground py-8" data-testid="no-files">
-                    No file information available
-                  </div>
-                ) : (
-                  <div className="space-y-2">
-                    {details.files.map((file, index) => (
-                      <div
-                        key={index}
-                        className="border rounded-lg p-3 space-y-2"
-                        data-testid={`file-${index}`}
-                      >
-                        <div className="flex items-start justify-between gap-4">
-                          <div className="flex items-start gap-2 flex-1 min-w-0">
-                            <File className="w-4 h-4 text-muted-foreground mt-1 flex-shrink-0" />
-                            <span className="text-sm break-all">{file.name}</span>
-                          </div>
-                          <div className="flex items-center gap-2 flex-shrink-0">
-                            <Badge
-                              variant={getPriorityBadgeVariant(file.priority)}
-                              className="capitalize"
-                            >
-                              {file.priority}
-                            </Badge>
-                            <span className="text-sm text-muted-foreground whitespace-nowrap">
-                              {formatBytes(file.size)}
-                            </span>
-                          </div>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <Progress value={file.progress} className="h-1 flex-1" />
-                          <span className="text-xs text-muted-foreground whitespace-nowrap">
-                            {file.progress.toFixed(1)}%
-                          </span>
-                        </div>
-                        {!file.wanted && (
-                          <Badge variant="outline" className="text-xs">
-                            Skipped
-                          </Badge>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </ScrollArea>
-            </TabsContent>
-
-            {/* Trackers Tab */}
-            <TabsContent
-              value="trackers"
-              className="flex-1 overflow-hidden mt-4"
-              data-testid="tab-content-trackers"
-            >
-              <ScrollArea className="h-[400px] pr-4">
-                {details.trackers.length === 0 ? (
-                  <div className="text-center text-muted-foreground py-8" data-testid="no-trackers">
-                    No tracker information available
-                  </div>
-                ) : (
-                  <div className="space-y-3">
-                    {details.trackers.map((tracker, index) => (
-                      <div
-                        key={index}
-                        className="border rounded-lg p-3 space-y-2"
-                        data-testid={`tracker-${index}`}
-                      >
-                        <div className="flex items-start justify-between gap-4">
-                          <div className="flex items-start gap-2 flex-1 min-w-0">
-                            <Server className="w-4 h-4 text-muted-foreground mt-1 flex-shrink-0" />
-                            <span className="text-sm break-all font-mono">{tracker.url}</span>
-                          </div>
-                          <div className="flex items-center gap-2 flex-shrink-0">
-                            <div
-                              className={`w-2 h-2 rounded-full ${getTrackerStatusColor(tracker.status)}`}
-                            />
-                            <span className="text-sm capitalize">{tracker.status}</span>
-                          </div>
-                        </div>
-
-                        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-                          <span>Tier: {tracker.tier}</span>
-                          {tracker.seeders !== undefined && <span>• Seeds: {tracker.seeders}</span>}
-                          {tracker.leechers !== undefined && (
-                            <span>• Leechers: {tracker.leechers}</span>
-                          )}
-                        </div>
-
-                        {tracker.lastAnnounce && (
-                          <div className="text-xs text-muted-foreground">
-                            Last announce: {formatDate(tracker.lastAnnounce)}
-                          </div>
-                        )}
-
-                        {tracker.nextAnnounce && (
-                          <div className="text-xs text-muted-foreground">
-                            Next announce: {formatDate(tracker.nextAnnounce)}
-                          </div>
-                        )}
-
-                        {tracker.error && (
-                          <div className="text-xs text-destructive">Error: {tracker.error}</div>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </ScrollArea>
-            </TabsContent>
-          </Tabs>
-        )}
+        {innerContent}
       </DialogContent>
     </Dialog>
   );

--- a/client/src/components/GameCard.tsx
+++ b/client/src/components/GameCard.tsx
@@ -234,7 +234,7 @@ const GameCard = ({
           </div>
         )}
       </div>
-      <CardContent className="p-3 flex flex-col flex-1" onClick={(e) => e.stopPropagation()}>
+      <CardContent className="p-3 flex flex-col flex-1">
         <h3
           className="font-semibold text-sm mb-2 line-clamp-2"
           data-testid={`text-title-${game.id}`}
@@ -365,7 +365,10 @@ const GameCard = ({
               variant="default"
               size="sm"
               className="h-10 w-full sm:h-9"
-              onClick={() => onTrackGame?.(game)}
+              onClick={(e) => {
+                e.stopPropagation();
+                onTrackGame?.(game);
+              }}
               disabled={addGameMutation.isPending}
               data-testid={`button-track-${game.id}`}
               aria-label={`Track ${game.title}`}

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -255,7 +255,8 @@ function StarRatingInput({
   const display = hovered ?? value;
 
   return (
-    <div className="flex items-center gap-2 sm:gap-1" role="group" aria-label="Your rating">
+    <fieldset className="flex items-center gap-2 border-0 p-0 sm:gap-1">
+      <legend className="sr-only">Your rating</legend>
       {[1, 2, 3, 4, 5].map((star) => {
         const fullValue = star * 2; // e.g. star=3 → fullValue=6
         const halfValue = star * 2 - 1; // e.g. star=3 → halfValue=5
@@ -310,7 +311,7 @@ function StarRatingInput({
           "Not rated"
         )}
       </span>
-    </div>
+    </fieldset>
   );
 }
 

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -719,127 +719,131 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
             </TabsList>
 
             {/* ── Overview tab ── */}
-            <TabsContent value="overview" className="flex-1 min-h-0 overflow-y-auto">
-              <div className="space-y-5 pb-2">
-                {/* Summary */}
-                {game.summary && (
-                  <div>
-                    <h3 className="font-semibold mb-2 flex items-center gap-2">
-                      <Gamepad2 className="w-4 h-4" />
-                      About
-                    </h3>
-                    <p
-                      className={cn(
-                        "text-sm text-muted-foreground leading-relaxed break-words [overflow-wrap:anywhere]",
-                        !isSummaryExpanded && "line-clamp-3 sm:line-clamp-5"
-                      )}
-                      data-testid={`text-summary-${game.id}`}
-                    >
-                      {game.summary}
-                    </p>
-                    {isSummaryLong && (
-                      <Button
-                        variant="link"
-                        className="p-0 h-auto mt-1 font-semibold"
-                        onClick={() => setIsSummaryExpanded(!isSummaryExpanded)}
+            <TabsContent value="overview" className="flex-1 min-h-0">
+              <ScrollArea className="h-full">
+                <div className="space-y-5 pr-4 pb-2">
+                  {/* Summary */}
+                  {game.summary && (
+                    <div>
+                      <h3 className="font-semibold mb-2 flex items-center gap-2">
+                        <Gamepad2 className="w-4 h-4" />
+                        About
+                      </h3>
+                      <p
+                        className={cn(
+                          "text-sm text-muted-foreground leading-relaxed break-words [overflow-wrap:anywhere]",
+                          !isSummaryExpanded && "line-clamp-3 sm:line-clamp-5"
+                        )}
+                        data-testid={`text-summary-${game.id}`}
                       >
-                        {isSummaryExpanded ? "Show less" : "Read more"}
-                      </Button>
+                        {game.summary}
+                      </p>
+                      {isSummaryLong && (
+                        <Button
+                          variant="link"
+                          className="p-0 h-auto mt-1 font-semibold"
+                          onClick={() => setIsSummaryExpanded(!isSummaryExpanded)}
+                        >
+                          {isSummaryExpanded ? "Show less" : "Read more"}
+                        </Button>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Metadata grid */}
+                  <div className="grid grid-cols-2 gap-4">
+                    {game.rating && (
+                      <div>
+                        <h4 className="font-medium text-sm text-muted-foreground mb-1">
+                          IGDB score
+                        </h4>
+                        <div className="flex items-center gap-1">
+                          <Star className="w-4 h-4 text-accent fill-current" />
+                          <span className="text-sm font-medium">{game.rating}/10</span>
+                        </div>
+                      </div>
+                    )}
+                    {game.releaseDate && (
+                      <div>
+                        <h4 className="font-medium text-sm text-muted-foreground mb-1">
+                          Release Date
+                        </h4>
+                        <p className="text-sm" data-testid={`text-full-release-date-${game.id}`}>
+                          {new Date(game.releaseDate).toLocaleDateString()}
+                        </p>
+                      </div>
+                    )}
+                    {game.addedAt && (
+                      <div>
+                        <h4 className="font-medium text-sm text-muted-foreground mb-1">
+                          Added to Collection
+                        </h4>
+                        <p className="text-sm">{new Date(game.addedAt).toLocaleDateString()}</p>
+                      </div>
+                    )}
+                    {game.developers && game.developers.length > 0 && (
+                      <div>
+                        <h4 className="font-medium text-sm text-muted-foreground mb-1 flex items-center gap-1">
+                          <Building2 className="w-3.5 h-3.5" />
+                          Developer{game.developers.length > 1 ? "s" : ""}
+                        </h4>
+                        <p className="text-sm">{game.developers.join(", ")}</p>
+                      </div>
+                    )}
+                    {game.publishers && game.publishers.length > 0 && (
+                      <div>
+                        <h4 className="font-medium text-sm text-muted-foreground mb-1 flex items-center gap-1">
+                          <Building2 className="w-3.5 h-3.5" />
+                          Publisher{game.publishers.length > 1 ? "s" : ""}
+                        </h4>
+                        <p className="text-sm">{game.publishers.join(", ")}</p>
+                      </div>
                     )}
                   </div>
-                )}
 
-                {/* Metadata grid */}
-                <div className="grid grid-cols-2 gap-4">
-                  {game.rating && (
-                    <div>
-                      <h4 className="font-medium text-sm text-muted-foreground mb-1">IGDB score</h4>
-                      <div className="flex items-center gap-1">
-                        <Star className="w-4 h-4 text-accent fill-current" />
-                        <span className="text-sm font-medium">{game.rating}/10</span>
+                  {/* Genres and Platforms */}
+                  <div className="grid grid-cols-2 gap-4">
+                    {game.genres && game.genres.length > 0 && (
+                      <div>
+                        <h3 className="font-semibold mb-2 flex items-center gap-2">
+                          <Tag className="w-4 h-4" />
+                          Genres
+                        </h3>
+                        <div className="flex flex-wrap gap-2">
+                          {game.genres.map((genre, i) => (
+                            <Badge
+                              key={i}
+                              variant="secondary"
+                              data-testid={`badge-genre-${genre.toLowerCase().replace(/\s+/g, "-")}`}
+                            >
+                              {genre}
+                            </Badge>
+                          ))}
+                        </div>
                       </div>
-                    </div>
-                  )}
-                  {game.releaseDate && (
-                    <div>
-                      <h4 className="font-medium text-sm text-muted-foreground mb-1">
-                        Release Date
-                      </h4>
-                      <p className="text-sm" data-testid={`text-full-release-date-${game.id}`}>
-                        {new Date(game.releaseDate).toLocaleDateString()}
-                      </p>
-                    </div>
-                  )}
-                  {game.addedAt && (
-                    <div>
-                      <h4 className="font-medium text-sm text-muted-foreground mb-1">
-                        Added to Collection
-                      </h4>
-                      <p className="text-sm">{new Date(game.addedAt).toLocaleDateString()}</p>
-                    </div>
-                  )}
-                  {game.developers && game.developers.length > 0 && (
-                    <div>
-                      <h4 className="font-medium text-sm text-muted-foreground mb-1 flex items-center gap-1">
-                        <Building2 className="w-3.5 h-3.5" />
-                        Developer{game.developers.length > 1 ? "s" : ""}
-                      </h4>
-                      <p className="text-sm">{game.developers.join(", ")}</p>
-                    </div>
-                  )}
-                  {game.publishers && game.publishers.length > 0 && (
-                    <div>
-                      <h4 className="font-medium text-sm text-muted-foreground mb-1 flex items-center gap-1">
-                        <Building2 className="w-3.5 h-3.5" />
-                        Publisher{game.publishers.length > 1 ? "s" : ""}
-                      </h4>
-                      <p className="text-sm">{game.publishers.join(", ")}</p>
-                    </div>
-                  )}
+                    )}
+                    {game.platforms && game.platforms.length > 0 && (
+                      <div>
+                        <h3 className="font-semibold mb-2 flex items-center gap-2">
+                          <Monitor className="w-4 h-4" />
+                          Platforms
+                        </h3>
+                        <div className="flex flex-wrap gap-2">
+                          {game.platforms.map((platform, i) => (
+                            <Badge
+                              key={i}
+                              variant="outline"
+                              data-testid={`badge-platform-${platform.toLowerCase().replace(/\s+/g, "-")}`}
+                            >
+                              {platform}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
                 </div>
-
-                {/* Genres and Platforms */}
-                <div className="grid grid-cols-2 gap-4">
-                  {game.genres && game.genres.length > 0 && (
-                    <div>
-                      <h3 className="font-semibold mb-2 flex items-center gap-2">
-                        <Tag className="w-4 h-4" />
-                        Genres
-                      </h3>
-                      <div className="flex flex-wrap gap-2">
-                        {game.genres.map((genre, i) => (
-                          <Badge
-                            key={i}
-                            variant="secondary"
-                            data-testid={`badge-genre-${genre.toLowerCase().replace(/\s+/g, "-")}`}
-                          >
-                            {genre}
-                          </Badge>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                  {game.platforms && game.platforms.length > 0 && (
-                    <div>
-                      <h3 className="font-semibold mb-2 flex items-center gap-2">
-                        <Monitor className="w-4 h-4" />
-                        Platforms
-                      </h3>
-                      <div className="flex flex-wrap gap-2">
-                        {game.platforms.map((platform, i) => (
-                          <Badge
-                            key={i}
-                            variant="outline"
-                            data-testid={`badge-platform-${platform.toLowerCase().replace(/\s+/g, "-")}`}
-                          >
-                            {platform}
-                          </Badge>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
+              </ScrollArea>
             </TabsContent>
 
             {/* ── Downloads tab ── */}

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -38,6 +38,7 @@ import {
   Users,
   Building2,
   ThumbsUp,
+  FlaskConical,
 } from "lucide-react";
 import { FaSteam, FaRedditAlien, FaDiscord, FaWikipediaW, FaTwitch } from "react-icons/fa";
 import {
@@ -53,7 +54,7 @@ import { io } from "socket.io-client";
 import { useToast } from "@/hooks/use-toast";
 import { useHiddenMutation } from "@/hooks/use-hidden-mutation";
 import { type Game, type GameDownload } from "@shared/schema";
-import StatusBadge from "./StatusBadge";
+import StatusBadge, { getStatusLabel } from "./StatusBadge";
 import { apiRequest } from "@/lib/queryClient";
 import { cn, safeUrl, formatBytes, isDiscoveryId } from "@/lib/utils";
 
@@ -183,12 +184,18 @@ function DownloadStatusIcon({ status }: { status: string }) {
 
 // ── Source badge ──────────────────────────────────────────────────────────────
 
+function getSourceLabel(source: string | null | undefined): string {
+  if (source === "steam") return "Steam Wishlist";
+  if (source === "api") return "Via API";
+  return "Added Manually";
+}
+
 function SourceBadge({ source }: { source: string | null | undefined }) {
   if (source === "steam") {
     return (
       <Badge variant="outline" className="gap-1.5 text-sky-400 border-sky-400/30">
         <FaSteam size={11} />
-        Steam Wishlist
+        <span className="hidden sm:inline">Steam Wishlist</span>
       </Badge>
     );
   }
@@ -196,14 +203,14 @@ function SourceBadge({ source }: { source: string | null | undefined }) {
     return (
       <Badge variant="outline" className="gap-1.5 text-purple-400 border-purple-400/30">
         <Zap className="w-3 h-3" />
-        Via API
+        <span className="hidden sm:inline">Via API</span>
       </Badge>
     );
   }
   return (
     <Badge variant="outline" className="gap-1.5 text-muted-foreground">
       <UserRound className="w-3 h-3" />
-      Added Manually
+      <span className="hidden sm:inline">Added Manually</span>
     </Badge>
   );
 }
@@ -248,7 +255,7 @@ function StarRatingInput({
   const display = hovered ?? value;
 
   return (
-    <div className="flex items-center gap-1" role="group" aria-label="Your rating">
+    <div className="flex items-center gap-2 sm:gap-1" role="group" aria-label="Your rating">
       {[1, 2, 3, 4, 5].map((star) => {
         const fullValue = star * 2; // e.g. star=3 → fullValue=6
         const halfValue = star * 2 - 1; // e.g. star=3 → halfValue=5
@@ -256,7 +263,7 @@ function StarRatingInput({
         const isHalf = display !== null && display >= halfValue && display < fullValue;
 
         return (
-          <span key={star} className="relative inline-flex w-5 h-5 overflow-visible">
+          <span key={star} className="relative inline-flex w-7 h-7 sm:w-5 sm:h-5 overflow-visible">
             <StarHitTarget
               ratingValue={halfValue}
               currentValue={value}
@@ -274,13 +281,13 @@ function StarRatingInput({
             {/* Background star first so the accent star renders on top */}
             {isHalf && (
               <Star
-                className="w-5 h-5 pointer-events-none text-muted-foreground absolute inset-0"
+                className="w-7 h-7 sm:w-5 sm:h-5 pointer-events-none text-muted-foreground absolute inset-0"
                 aria-hidden="true"
               />
             )}
             {/* Visual star (accent-filled when full/half, muted otherwise) */}
             <Star
-              className={`w-5 h-5 pointer-events-none transition-colors ${
+              className={`w-7 h-7 sm:w-5 sm:h-5 pointer-events-none transition-colors ${
                 isFull
                   ? "text-accent fill-current"
                   : isHalf
@@ -493,14 +500,14 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
     : (game.userRating ?? null);
 
   return (
-    <>
+    <TooltipProvider>
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent
-          className="max-w-4xl max-h-[90vh] flex flex-col"
+          className="max-w-4xl max-h-[95svh] sm:max-h-[90vh] flex flex-col overflow-hidden"
           onClick={(e) => e.stopPropagation()}
         >
           {/* ── Header ── */}
-          <DialogHeader className="flex-shrink-0 pb-0 pr-8">
+          <DialogHeader className="flex-shrink-0 pb-0 pr-8 text-left">
             <div className="flex items-start justify-between gap-4">
               <div className="flex-1 min-w-0">
                 <DialogTitle
@@ -513,11 +520,28 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                   Detailed information about {game.title}
                 </DialogDescription>
                 <div className="flex flex-wrap items-center gap-2">
-                  <StatusBadge status={game.status} />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="cursor-default">
+                        <StatusBadge status={game.status} />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent className="sm:hidden">
+                      {getStatusLabel(game.status)}
+                    </TooltipContent>
+                  </Tooltip>
                   {game.earlyAccess && (
-                    <Badge className="text-xs bg-amber-500 border-amber-600 text-white">
-                      Early Access
-                    </Badge>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="cursor-default">
+                          <Badge className="text-xs bg-amber-500 border-amber-600 text-white gap-1">
+                            <FlaskConical className="w-3 h-3" />
+                            <span className="hidden sm:inline">Early Access</span>
+                          </Badge>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent className="sm:hidden">Early Access</TooltipContent>
+                    </Tooltip>
                   )}
                   {game.rating ? (
                     <div className="flex items-center gap-1 text-sm">
@@ -546,13 +570,24 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                           data-testid={`badge-search-results-${game.id}`}
                         >
                           <Search className="w-3 h-3" />
-                          Results available
+                          <span className="hidden sm:inline">Results available</span>
                         </Badge>
                       </TooltipTrigger>
-                      <TooltipContent>Downloads found on indexers</TooltipContent>
+                      <TooltipContent className="sm:hidden">
+                        Downloads found on indexers
+                      </TooltipContent>
                     </Tooltip>
                   )}
-                  <SourceBadge source={game.source} />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="cursor-default">
+                        <SourceBadge source={game.source} />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent className="sm:hidden">
+                      {getSourceLabel(game.source)}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
               </div>
               {game.coverUrl && (
@@ -560,7 +595,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                   <img
                     src={game.coverUrl}
                     alt={`${game.title} cover`}
-                    className="w-32 object-cover rounded-lg shadow-md"
+                    className="w-20 sm:w-32 object-cover rounded-lg shadow-md"
                     style={{ aspectRatio: "3/4" }}
                     data-testid={`img-cover-${game.id}`}
                   />
@@ -580,7 +615,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                   }
                 }}
                 placeholder="Personal notes..."
-                className="resize-none min-h-[72px] text-sm"
+                className="resize-none min-h-[56px] sm:min-h-[72px] text-sm"
                 maxLength={10000}
                 aria-label="Personal notes for this game"
                 disabled={notesMutation.isPending}
@@ -591,45 +626,69 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
             </div>
 
             {/* Quick Actions */}
-            <div className="flex flex-wrap gap-2 mt-3">
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-2"
-                onClick={() => setDownloadOpen(true)}
-                data-testid="button-download-game"
-              >
-                <Download className="w-4 h-4" />
-                Download
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => hiddenMutation.mutate({ gameId: game.id, hidden: !game.hidden })}
-                disabled={hiddenMutation.isPending}
-                className="gap-2"
-                data-testid={`button-toggle-hidden-quick-${game.id}`}
-              >
-                {game.hidden ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
-                {hiddenMutation.isPending ? "Updating..." : game.hidden ? "Unhide" : "Hide"}
-              </Button>
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={() => removeGameMutation.mutate(game.id)}
-                disabled={removeGameMutation.isPending}
-                className="gap-2"
-                data-testid={`button-remove-game-quick-${game.id}`}
-              >
-                <X className="w-4 h-4" />
-                {removeGameMutation.isPending ? "Removing..." : "Remove"}
-              </Button>
+            <div className="flex gap-2 mt-3">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-10 w-10 sm:h-9 sm:w-auto sm:px-3 sm:gap-2"
+                    aria-label="Download"
+                    onClick={() => setDownloadOpen(true)}
+                    data-testid="button-download-game"
+                  >
+                    <Download className="w-4 h-4" />
+                    <span className="hidden sm:inline">Download</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className="sm:hidden">Download</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => hiddenMutation.mutate({ gameId: game.id, hidden: !game.hidden })}
+                    disabled={hiddenMutation.isPending}
+                    className="h-10 w-10 sm:h-9 sm:w-auto sm:px-3 sm:gap-2"
+                    aria-label={game.hidden ? "Unhide" : "Hide"}
+                    data-testid={`button-toggle-hidden-quick-${game.id}`}
+                  >
+                    {game.hidden ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
+                    <span className="hidden sm:inline">
+                      {hiddenMutation.isPending ? "Updating..." : game.hidden ? "Unhide" : "Hide"}
+                    </span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className="sm:hidden">
+                  {game.hidden ? "Unhide" : "Hide"}
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => removeGameMutation.mutate(game.id)}
+                    disabled={removeGameMutation.isPending}
+                    className="h-10 w-10 sm:h-9 sm:w-auto sm:px-3 sm:gap-2"
+                    aria-label="Remove"
+                    data-testid={`button-remove-game-quick-${game.id}`}
+                  >
+                    <X className="w-4 h-4" />
+                    <span className="hidden sm:inline">
+                      {removeGameMutation.isPending ? "Removing..." : "Remove"}
+                    </span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className="sm:hidden">Remove</TooltipContent>
+              </Tooltip>
             </div>
           </DialogHeader>
 
           {/* ── Tabs ── */}
           <Tabs defaultValue="overview" className="flex-1 flex flex-col min-h-0 mt-4">
-            <TabsList className="flex-shrink-0 w-full justify-start">
+            <TabsList className="flex-shrink-0 w-full justify-start overflow-x-auto">
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="downloads">
                 Downloads
@@ -647,7 +706,10 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                   </Badge>
                 )}
               </TabsTrigger>
-              <TabsTrigger value="links">Links & Ratings</TabsTrigger>
+              <TabsTrigger value="links">
+                <span className="sm:hidden">Links</span>
+                <span className="hidden sm:inline">Links &amp; Ratings</span>
+              </TabsTrigger>
               {nexusDomain && (
                 <TabsTrigger value="mods">
                   <SiNexusmods className="h-3.5 w-3.5 text-amber-500 mr-1" />
@@ -657,131 +719,127 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
             </TabsList>
 
             {/* ── Overview tab ── */}
-            <TabsContent value="overview" className="flex-1 min-h-0">
-              <ScrollArea className="h-full">
-                <div className="space-y-5 pr-4 pb-2">
-                  {/* Summary */}
-                  {game.summary && (
-                    <div>
-                      <h3 className="font-semibold mb-2 flex items-center gap-2">
-                        <Gamepad2 className="w-4 h-4" />
-                        About
-                      </h3>
-                      <p
-                        className={cn(
-                          "text-sm text-muted-foreground leading-relaxed break-words [overflow-wrap:anywhere]",
-                          isSummaryExpanded ? "max-h-48 overflow-y-auto" : "line-clamp-5"
-                        )}
-                        data-testid={`text-summary-${game.id}`}
-                      >
-                        {game.summary}
-                      </p>
-                      {isSummaryLong && (
-                        <Button
-                          variant="link"
-                          className="p-0 h-auto mt-1 font-semibold"
-                          onClick={() => setIsSummaryExpanded(!isSummaryExpanded)}
-                        >
-                          {isSummaryExpanded ? "Show less" : "Read more"}
-                        </Button>
+            <TabsContent value="overview" className="flex-1 min-h-0 overflow-y-auto">
+              <div className="space-y-5 pb-2">
+                {/* Summary */}
+                {game.summary && (
+                  <div>
+                    <h3 className="font-semibold mb-2 flex items-center gap-2">
+                      <Gamepad2 className="w-4 h-4" />
+                      About
+                    </h3>
+                    <p
+                      className={cn(
+                        "text-sm text-muted-foreground leading-relaxed break-words [overflow-wrap:anywhere]",
+                        !isSummaryExpanded && "line-clamp-3 sm:line-clamp-5"
                       )}
+                      data-testid={`text-summary-${game.id}`}
+                    >
+                      {game.summary}
+                    </p>
+                    {isSummaryLong && (
+                      <Button
+                        variant="link"
+                        className="p-0 h-auto mt-1 font-semibold"
+                        onClick={() => setIsSummaryExpanded(!isSummaryExpanded)}
+                      >
+                        {isSummaryExpanded ? "Show less" : "Read more"}
+                      </Button>
+                    )}
+                  </div>
+                )}
+
+                {/* Metadata grid */}
+                <div className="grid grid-cols-2 gap-4">
+                  {game.rating && (
+                    <div>
+                      <h4 className="font-medium text-sm text-muted-foreground mb-1">IGDB score</h4>
+                      <div className="flex items-center gap-1">
+                        <Star className="w-4 h-4 text-accent fill-current" />
+                        <span className="text-sm font-medium">{game.rating}/10</span>
+                      </div>
                     </div>
                   )}
-
-                  {/* Metadata grid */}
-                  <div className="grid md:grid-cols-2 gap-4">
-                    {game.rating && (
-                      <div>
-                        <h4 className="font-medium text-sm text-muted-foreground mb-1">
-                          IGDB score
-                        </h4>
-                        <div className="flex items-center gap-1">
-                          <Star className="w-4 h-4 text-accent fill-current" />
-                          <span className="text-sm font-medium">{game.rating}/10</span>
-                        </div>
-                      </div>
-                    )}
-                    {game.releaseDate && (
-                      <div>
-                        <h4 className="font-medium text-sm text-muted-foreground mb-1">
-                          Release Date
-                        </h4>
-                        <p className="text-sm" data-testid={`text-full-release-date-${game.id}`}>
-                          {new Date(game.releaseDate).toLocaleDateString()}
-                        </p>
-                      </div>
-                    )}
-                    {game.addedAt && (
-                      <div>
-                        <h4 className="font-medium text-sm text-muted-foreground mb-1">
-                          Added to Collection
-                        </h4>
-                        <p className="text-sm">{new Date(game.addedAt).toLocaleDateString()}</p>
-                      </div>
-                    )}
-                    {game.developers && game.developers.length > 0 && (
-                      <div>
-                        <h4 className="font-medium text-sm text-muted-foreground mb-1 flex items-center gap-1">
-                          <Building2 className="w-3.5 h-3.5" />
-                          Developer{game.developers.length > 1 ? "s" : ""}
-                        </h4>
-                        <p className="text-sm">{game.developers.join(", ")}</p>
-                      </div>
-                    )}
-                    {game.publishers && game.publishers.length > 0 && (
-                      <div>
-                        <h4 className="font-medium text-sm text-muted-foreground mb-1 flex items-center gap-1">
-                          <Building2 className="w-3.5 h-3.5" />
-                          Publisher{game.publishers.length > 1 ? "s" : ""}
-                        </h4>
-                        <p className="text-sm">{game.publishers.join(", ")}</p>
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Genres and Platforms */}
-                  <div className="grid md:grid-cols-2 gap-5">
-                    {game.genres && game.genres.length > 0 && (
-                      <div>
-                        <h3 className="font-semibold mb-2 flex items-center gap-2">
-                          <Tag className="w-4 h-4" />
-                          Genres
-                        </h3>
-                        <div className="flex flex-wrap gap-2">
-                          {game.genres.map((genre, i) => (
-                            <Badge
-                              key={i}
-                              variant="secondary"
-                              data-testid={`badge-genre-${genre.toLowerCase().replace(/\s+/g, "-")}`}
-                            >
-                              {genre}
-                            </Badge>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    {game.platforms && game.platforms.length > 0 && (
-                      <div>
-                        <h3 className="font-semibold mb-2 flex items-center gap-2">
-                          <Monitor className="w-4 h-4" />
-                          Platforms
-                        </h3>
-                        <div className="flex flex-wrap gap-2">
-                          {game.platforms.map((platform, i) => (
-                            <Badge
-                              key={i}
-                              variant="outline"
-                              data-testid={`badge-platform-${platform.toLowerCase().replace(/\s+/g, "-")}`}
-                            >
-                              {platform}
-                            </Badge>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </div>
+                  {game.releaseDate && (
+                    <div>
+                      <h4 className="font-medium text-sm text-muted-foreground mb-1">
+                        Release Date
+                      </h4>
+                      <p className="text-sm" data-testid={`text-full-release-date-${game.id}`}>
+                        {new Date(game.releaseDate).toLocaleDateString()}
+                      </p>
+                    </div>
+                  )}
+                  {game.addedAt && (
+                    <div>
+                      <h4 className="font-medium text-sm text-muted-foreground mb-1">
+                        Added to Collection
+                      </h4>
+                      <p className="text-sm">{new Date(game.addedAt).toLocaleDateString()}</p>
+                    </div>
+                  )}
+                  {game.developers && game.developers.length > 0 && (
+                    <div>
+                      <h4 className="font-medium text-sm text-muted-foreground mb-1 flex items-center gap-1">
+                        <Building2 className="w-3.5 h-3.5" />
+                        Developer{game.developers.length > 1 ? "s" : ""}
+                      </h4>
+                      <p className="text-sm">{game.developers.join(", ")}</p>
+                    </div>
+                  )}
+                  {game.publishers && game.publishers.length > 0 && (
+                    <div>
+                      <h4 className="font-medium text-sm text-muted-foreground mb-1 flex items-center gap-1">
+                        <Building2 className="w-3.5 h-3.5" />
+                        Publisher{game.publishers.length > 1 ? "s" : ""}
+                      </h4>
+                      <p className="text-sm">{game.publishers.join(", ")}</p>
+                    </div>
+                  )}
                 </div>
-              </ScrollArea>
+
+                {/* Genres and Platforms */}
+                <div className="grid grid-cols-2 gap-4">
+                  {game.genres && game.genres.length > 0 && (
+                    <div>
+                      <h3 className="font-semibold mb-2 flex items-center gap-2">
+                        <Tag className="w-4 h-4" />
+                        Genres
+                      </h3>
+                      <div className="flex flex-wrap gap-2">
+                        {game.genres.map((genre, i) => (
+                          <Badge
+                            key={i}
+                            variant="secondary"
+                            data-testid={`badge-genre-${genre.toLowerCase().replace(/\s+/g, "-")}`}
+                          >
+                            {genre}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {game.platforms && game.platforms.length > 0 && (
+                    <div>
+                      <h3 className="font-semibold mb-2 flex items-center gap-2">
+                        <Monitor className="w-4 h-4" />
+                        Platforms
+                      </h3>
+                      <div className="flex flex-wrap gap-2">
+                        {game.platforms.map((platform, i) => (
+                          <Badge
+                            key={i}
+                            variant="outline"
+                            data-testid={`badge-platform-${platform.toLowerCase().replace(/\s+/g, "-")}`}
+                          >
+                            {platform}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
             </TabsContent>
 
             {/* ── Downloads tab ── */}
@@ -845,7 +903,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                                className="h-10 w-10 sm:h-7 sm:w-7 text-muted-foreground hover:text-destructive"
                                 aria-label="Remove download record"
                                 disabled={
                                   removeDownloadMutation.isPending &&
@@ -961,7 +1019,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                     </div>
                   </div>
 
-                  <TooltipProvider>
+                  <div>
                     {/* IGDB website links */}
                     {igdbWebsites.length > 0 && (
                       <div>
@@ -983,7 +1041,11 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                                       target="_blank"
                                       rel="noopener noreferrer"
                                     >
-                                      <Button variant="outline" size="sm" className="gap-2">
+                                      <Button
+                                        variant="outline"
+                                        size="sm"
+                                        className="gap-2 h-10 sm:h-9"
+                                      >
                                         <Icon size={16} className={colorClass} />
                                         <span className="hidden sm:inline">{label}</span>
                                       </Button>
@@ -1012,7 +1074,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                                 target="_blank"
                                 rel="noopener noreferrer"
                               >
-                                <Button variant="outline" size="sm" className="gap-2">
+                                <Button variant="outline" size="sm" className="gap-2 h-10 sm:h-9">
                                   <link.Icon size={16} className={link.colorClass} />
                                   <span className="hidden sm:inline">{link.label}</span>
                                 </Button>
@@ -1031,7 +1093,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                                   target="_blank"
                                   rel="noopener noreferrer"
                                 >
-                                  <Button variant="outline" size="sm" className="gap-2">
+                                  <Button variant="outline" size="sm" className="gap-2 h-10 sm:h-9">
                                     <SiNexusmods size={16} className="text-amber-500" />
                                     <span className="hidden sm:inline">NexusMods</span>
                                   </Button>
@@ -1049,7 +1111,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                                   target="_blank"
                                   rel="noopener noreferrer"
                                 >
-                                  <Button variant="outline" size="sm" className="gap-2">
+                                  <Button variant="outline" size="sm" className="gap-2 h-10 sm:h-9">
                                     <SiNexusmods size={16} className="text-amber-500" />
                                     <span className="hidden sm:inline">NexusMods</span>
                                   </Button>
@@ -1060,7 +1122,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                           ) : null)}
                       </div>
                     </div>
-                  </TooltipProvider>
+                  </div>
                 </div>
               </ScrollArea>
             </TabsContent>
@@ -1169,6 +1231,6 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
           <GameDownloadDialog game={game} open={downloadOpen} onOpenChange={setDownloadOpen} />
         </Suspense>
       )}
-    </>
+    </TooltipProvider>
   );
 }

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -162,6 +162,9 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
   );
   const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
   const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>([]);
+  // Tracks whether dialog defaults have already been applied for the current open session.
+  // This prevents settings refetches from overwriting user-made changes after initialization.
+  const defaultsAppliedRef = useRef(false);
   // Tracks whether platform preselection has been applied this dialog session to prevent
   // re-applying it (and overriding the user's manual choice) if userSettings refetches.
   const platformPreselectedRef = useRef(false);
@@ -183,6 +186,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     setVisibleCategories(new Set(["main", "update", "dlc", "extra"] as DownloadCategory[]));
     setSelectedGroups([]);
     setSelectedPlatforms([]);
+    defaultsAppliedRef.current = false;
     platformPreselectedRef.current = false;
     hasInvalidatedRef.current = false;
   }, []);
@@ -232,12 +236,14 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     }
   }, [open, game, setDefaults]);
 
-  // Apply download rules whenever settings load or change.
+  // Apply settings-derived defaults only once per dialog session so later refetches
+  // do not overwrite manual adjustments the user makes in the UI.
   useEffect(() => {
-    if (open && game) {
+    if (open && game && userSettings && !defaultsAppliedRef.current) {
       applyDownloadRules();
+      defaultsAppliedRef.current = true;
     }
-  }, [open, game, applyDownloadRules]);
+  }, [open, game, userSettings, applyDownloadRules]);
 
   const searchQueryKey = game?.id
     ? `/api/search?query=${encodeURIComponent(debouncedSearchQuery)}&gameId=${game.id}`
@@ -315,6 +321,13 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
       .map((p) => ({ label: p, value: p }));
   }, [itemsMetadata]);
 
+  const itemPubDateTimestamps = useMemo(() => {
+    if (!searchResults?.items) return new Map<string, number>();
+    return new Map(
+      searchResults.items.map((item) => [item.guid || item.link, new Date(item.pubDate).getTime()])
+    );
+  }, [searchResults?.items]);
+
   // Apply filters and sorting
   const filteredCategorizedDownloads = useMemo(() => {
     const filtered: Record<DownloadCategory, DownloadItem[]> = {
@@ -346,7 +359,10 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
             const bHealth = isUsenetItem(b) ? (b.grabs ?? 0) : (b.seeders ?? 0);
             comparison = bHealth - aHealth;
           } else if (sortBy === "date") {
-            comparison = new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
+            const keyA = a.guid || a.link;
+            const keyB = b.guid || b.link;
+            comparison =
+              (itemPubDateTimestamps.get(keyB) ?? 0) - (itemPubDateTimestamps.get(keyA) ?? 0);
           } else {
             comparison = (b.size ?? 0) - (a.size ?? 0);
           }
@@ -365,6 +381,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     visibleCategories,
     selectedGroups,
     selectedPlatforms,
+    itemPubDateTimestamps,
   ]);
 
   // Sorted items for display (by date)
@@ -424,7 +441,11 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
       }
     },
     onError: (error: Error) => {
-      toast({ title: "Failed to start download", description: error.message });
+      toast({
+        title: "Failed to start download",
+        description: error.message,
+        variant: "destructive",
+      });
     },
     onSettled: () => {
       setDownloadingGuid(null);
@@ -463,7 +484,11 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
       }
     },
     onError: (error: Error) => {
-      toast({ title: "Failed to start download", description: error.message });
+      toast({
+        title: "Failed to start download",
+        description: error.message,
+        variant: "destructive",
+      });
     },
   });
 
@@ -725,7 +750,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
           type="number"
           min="0"
           value={minSeeders}
-          onChange={(e) => setMinSeeders(parseInt(e.target.value) || 0)}
+          onChange={(e) => setMinSeeders(Number.parseInt(e.target.value) || 0)}
           className="w-full"
         />
       </div>

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -137,17 +137,19 @@ import { useDebounce } from "@/hooks/use-debounce";
 import { formatBytes, formatAge, isUsenetItem } from "@/lib/downloads-utils";
 import { useIsMobile } from "@/hooks/use-mobile";
 
+type ReleaseMetadataBadgesProps = Readonly<{
+  metadata: ReleaseMetadata;
+  isUsenet: boolean;
+  downloadVolumeFactor?: number;
+  className?: string;
+}>;
+
 function ReleaseMetadataBadges({
   metadata,
   isUsenet,
   downloadVolumeFactor,
   className,
-}: {
-  metadata: ReleaseMetadata;
-  isUsenet: boolean;
-  downloadVolumeFactor?: number;
-  className?: string;
-}) {
+}: ReleaseMetadataBadgesProps) {
   const hasMetadata =
     metadata.version ||
     (metadata.languages && metadata.languages.length > 0) ||

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -8,6 +8,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerDescription,
+} from "@/components/ui/drawer";
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -126,10 +133,12 @@ function formatDate(dateString: string): string {
 import { apiRequest } from "@/lib/queryClient";
 import { useDebounce } from "@/hooks/use-debounce";
 import { formatBytes, formatAge, isUsenetItem } from "@/lib/downloads-utils";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 export default function GameDownloadDialog({ game, open, onOpenChange }: GameDownloadDialogProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
   const [searchQuery, setSearchQuery] = useState("");
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
   const [downloadingGuid, setDownloadingGuid] = useState<string | null>(null);
@@ -189,7 +198,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
         const rules = downloadRulesSchema.parse(JSON.parse(userSettings.downloadRules));
         setMinSeeders(rules.minSeeders);
         setSortBy(rules.sortBy);
-        setSortOrder("desc"); // Default to desc when applying rules
+        setSortOrder("desc");
         if (rules.visibleCategories) {
           setVisibleCategories(new Set(rules.visibleCategories as DownloadCategory[]));
         }
@@ -215,8 +224,6 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
   ]);
 
   // Initialize search query only when the dialog opens or game changes — not on settings refetch.
-  // Keeping this separate from applyDownloadRules prevents a settings re-fetch (e.g. on window
-  // focus) from overwriting a query the user has already edited.
   useEffect(() => {
     if (open && game) {
       setSearchQuery(game.title);
@@ -225,8 +232,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     }
   }, [open, game, setDefaults]);
 
-  // Apply download rules whenever settings load or change (applyDownloadRules identity changes
-  // whenever its userSettings deps change, so this fires at the right times).
+  // Apply download rules whenever settings load or change.
   useEffect(() => {
     if (open && game) {
       applyDownloadRules();
@@ -242,9 +248,8 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     enabled: open && debouncedSearchQuery.trim().length > 0,
   });
 
-  // When a canonical search (game title = search query) returns results, refresh the games list
-  // so the "Has results" badge reflects the updated searchResultsAvailable flag from the server.
-  // Only invalidate once per dialog session to avoid re-rendering the full library on every result.
+  // When a canonical search returns results, refresh the games list so the "Has results" badge
+  // reflects the updated searchResultsAvailable flag. Only invalidate once per dialog session.
   useEffect(() => {
     if (!searchResults || !game) return;
     if (searchResults.items.length === 0) return;
@@ -273,14 +278,12 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
   const availableIndexers = useMemo(() => {
     if (!searchResults?.items) return [];
     const indexers = new Set(searchResults.items.map((item) => item.indexerName).filter(Boolean));
-
     if (enabledIndexers) {
       const enabledNames = new Set(enabledIndexers.map((i) => i.name));
       return Array.from(indexers)
         .filter((name) => enabledNames.has(name as string))
         .sort();
     }
-
     return Array.from(indexers).sort();
   }, [searchResults?.items, enabledIndexers]);
 
@@ -339,14 +342,12 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
         .sort((a, b) => {
           let comparison = 0;
           if (sortBy === "seeders") {
-            // Health metric: seeders for torrents, grabs for Usenet
             const aHealth = isUsenetItem(a) ? (a.grabs ?? 0) : (a.seeders ?? 0);
             const bHealth = isUsenetItem(b) ? (b.grabs ?? 0) : (b.seeders ?? 0);
             comparison = bHealth - aHealth;
           } else if (sortBy === "date") {
             comparison = new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
           } else {
-            // size
             comparison = (b.size ?? 0) - (a.size ?? 0);
           }
           return sortOrder === "desc" ? comparison : -comparison;
@@ -378,7 +379,6 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
 
   const downloadMutation = useMutation({
     mutationFn: async (downloads: DownloadItem[]) => {
-      // Download multiple items sequentially
       const results = [];
       for (const download of downloads) {
         const response = await apiRequest("POST", "/api/downloads", {
@@ -424,11 +424,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
       }
     },
     onError: (error: Error) => {
-      toast({
-        title: "Failed to start download",
-        description: error.message,
-        variant: "destructive",
-      });
+      toast({ title: "Failed to start download", description: error.message });
     },
     onSettled: () => {
       setDownloadingGuid(null);
@@ -467,11 +463,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
       }
     },
     onError: (error: Error) => {
-      toast({
-        title: "Failed to start download",
-        description: error.message,
-        variant: "destructive",
-      });
+      toast({ title: "Failed to start download", description: error.message });
     },
   });
 
@@ -489,8 +481,6 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
         return { ...old, items: old.items.filter((i) => i.title !== item.title) };
       });
       queryClient.invalidateQueries({ queryKey: ["/api/blacklist"] });
-      // Re-fetch the search so the server can recalculate searchResultsAvailable
-      // with the updated blacklist applied (blacklisted item is now excluded server-side).
       queryClient.invalidateQueries({ queryKey: [searchQueryKey] });
       toast({ description: "Release blacklisted" });
     },
@@ -500,40 +490,30 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
   });
 
   const handleDownload = (download: DownloadItem) => {
-    // Check if this is a main game download and we have updates available
     if (categorizedDownloads.update.length > 0) {
       const downloadCategory = groupDownloadsByCategory([download]);
-
       if (downloadCategory.main.length > 0) {
-        // This is a main game download, ask if user wants to include updates
         setSelectedMainDownload(download);
         setIsDirectDownloadMode(false);
-        // Select all updates by default
         setSelectedUpdateIndices(new Set(filteredCategorizedDownloads.update.map((_, i) => i)));
         setShowBundleDialog(true);
         return;
       }
     }
-
-    // Otherwise, download normally
     setDownloadingGuid(download.guid || download.link);
     downloadMutation.mutate([download]);
   };
 
   const handleBundleDownload = (includeUpdates: boolean) => {
     if (!selectedMainDownload) return;
-
     const guid = selectedMainDownload.guid || selectedMainDownload.link;
     setDownloadingGuid(guid);
-
     if (includeUpdates && selectedUpdateIndices.size > 0) {
-      // Download main game + selected updates
       const selectedUpdates = Array.from(selectedUpdateIndices).map(
         (i) => filteredCategorizedDownloads.update[i]
       );
       downloadMutation.mutate([selectedMainDownload, ...selectedUpdates]);
     } else {
-      // Download only main game
       downloadMutation.mutate([selectedMainDownload]);
     }
   };
@@ -551,62 +531,42 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
 
   // Unused currently, can this be removed?
   const _handleDirectDownload = (download: DownloadItem) => {
-    // Check if this is a main game download and we have updates available
     if (categorizedDownloads.update.length > 0) {
       const downloadCategory = groupDownloadsByCategory([download]);
-
       if (downloadCategory.main.length > 0) {
-        // This is a main game download, ask if user wants to include updates
         setSelectedMainDownload(download);
         setIsDirectDownloadMode(true);
-        // Select all updates by default
         setSelectedUpdateIndices(new Set(filteredCategorizedDownloads.update.map((_, i) => i)));
         setShowBundleDialog(true);
         return;
       }
     }
-
-    // Otherwise, download normally
     downloadFile(download);
-    toast({
-      title: "Download started",
-      description: "File download initiated",
-    });
+    toast({ title: "Download started", description: "File download initiated" });
   };
 
   // Unused currently, can this be removed?
   const _handleDirectDownloadWithUpdates = async (mainDownload: DownloadItem) => {
-    // Check if there are updates to bundle
     if (categorizedDownloads.update.length === 0) {
       downloadFile(mainDownload);
-      toast({
-        title: "Download started",
-        description: "File download initiated",
-      });
+      toast({ title: "Download started", description: "File download initiated" });
       return;
     }
-
     setSelectedMainDownload(mainDownload);
     setIsDirectDownloadMode(true);
-    // Select all updates by default
     setSelectedUpdateIndices(new Set(filteredCategorizedDownloads.update.map((_, i) => i)));
     setShowBundleDialog(true);
   };
 
   const handleBundleDirectDownload = async (includeUpdates: boolean) => {
     if (!selectedMainDownload) return;
-
     if (includeUpdates && selectedUpdateIndices.size > 0) {
-      // Download selected updates as a ZIP bundle
       const selectedUpdates = Array.from(selectedUpdateIndices).map(
         (i) => filteredCategorizedDownloads.update[i]
       );
       const downloads = [selectedMainDownload, ...selectedUpdates];
-
       try {
         const response = await apiRequest("POST", "/api/downloads/bundle", { downloads });
-
-        // Download the ZIP file
         const blob = await response.blob();
         const url = window.URL.createObjectURL(blob);
         const link = document.createElement("a");
@@ -616,7 +576,6 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
         link.click();
         document.body.removeChild(link);
         window.URL.revokeObjectURL(url);
-
         toast({
           title: `Bundle downloaded`,
           description: `ZIP file with ${downloads.length} item(s)`,
@@ -630,12 +589,8 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
       }
     } else {
       downloadFile(selectedMainDownload);
-      toast({
-        title: "Download started",
-        description: "File download initiated",
-      });
+      toast({ title: "Download started", description: "File download initiated" });
     }
-
     setShowBundleDialog(false);
     setSelectedMainDownload(null);
   };
@@ -643,31 +598,21 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
   const toggleUpdateSelection = (index: number) => {
     setSelectedUpdateIndices((prev) => {
       const next = new Set(prev);
-      if (next.has(index)) {
-        next.delete(index);
-      } else {
-        next.add(index);
-      }
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
       return next;
     });
   };
 
-  const selectAllUpdates = () => {
+  const selectAllUpdates = () =>
     setSelectedUpdateIndices(new Set(filteredCategorizedDownloads.update.map((_, i) => i)));
-  };
-
-  const deselectAllUpdates = () => {
-    setSelectedUpdateIndices(new Set());
-  };
+  const deselectAllUpdates = () => setSelectedUpdateIndices(new Set());
 
   const toggleCategory = (category: DownloadCategory) => {
     setVisibleCategories((prev) => {
       const next = new Set(prev);
-      if (next.has(category)) {
-        next.delete(category);
-      } else {
-        next.add(category);
-      }
+      if (next.has(category)) next.delete(category);
+      else next.add(category);
       return next;
     });
   };
@@ -713,690 +658,864 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
 
   if (!game) return null;
 
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-6xl max-h-[90vh] flex flex-col ">
-        <DialogHeader className="flex-shrink-0">
-          <DialogTitle>Download {game.title}</DialogTitle>
-          <DialogDescription>
-            Search results for torrents and NZBs matching this game.{" "}
-            <span className="text-muted-foreground/80">
-              Tip: Enable auto-download in Settings to automatically download new releases.
-            </span>
-          </DialogDescription>
-        </DialogHeader>
+  // ─── Shared: Filter panel ─────────────────────────────────────────────────────
 
-        <div className="flex-shrink-0 mt-4 space-y-3">
-          <Input
-            type="text"
-            placeholder="Search for downloads..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full"
-          />
+  const filterPanel = showFilters && (
+    <div
+      className={cn(
+        "p-4 border rounded-md bg-muted/50",
+        isMobile ? "grid grid-cols-1 gap-3" : "grid grid-cols-4 gap-4"
+      )}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="indexer" className="text-sm">
+          Indexer
+        </Label>
+        <Select
+          value={selectedIndexer}
+          onValueChange={setSelectedIndexer}
+          disabled={availableIndexers.length === 1}
+        >
+          <SelectTrigger id="indexer">
+            <SelectValue placeholder="All Indexers" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">
+              {availableIndexers.length === 1 ? availableIndexers[0] : "All Indexers"}
+            </SelectItem>
+            {availableIndexers.length > 1 &&
+              availableIndexers.map((indexer) => (
+                <SelectItem key={indexer} value={indexer as string}>
+                  {indexer}
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
+      </div>
 
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setShowFilters(!showFilters)}
-              className="flex items-center gap-2"
-            >
-              <SlidersHorizontal className="h-4 w-4" />
-              {showFilters ? "Hide Filters" : "Show Filters"}
-            </Button>
-            {minSeeders > 0 && (
-              <Badge variant="secondary" className="text-xs">
-                Min Seeders: {minSeeders}
-              </Badge>
-            )}
-            <Badge variant="outline" className="text-xs capitalize">
-              Sorted by: {sortBy} ({sortOrder === "asc" ? "Asc" : "Desc"})
-            </Badge>
-          </div>
+      <div className="space-y-2">
+        <Label className="text-sm">Release Groups</Label>
+        <MultiSelect
+          options={availableGroups.map((g) => ({ label: g as string, value: g as string }))}
+          selected={selectedGroups}
+          onChange={setSelectedGroups}
+          placeholder="Select groups..."
+          className="w-full"
+        />
+      </div>
 
-          {showFilters && (
-            <div className="grid grid-cols-4 gap-4 p-4 border rounded-md bg-muted/50">
-              <div className="space-y-2">
-                <Label htmlFor="indexer" className="text-sm">
-                  Indexer
-                </Label>
-                <Select
-                  value={selectedIndexer}
-                  onValueChange={setSelectedIndexer}
-                  disabled={availableIndexers.length === 1}
-                >
-                  <SelectTrigger id="indexer">
-                    <SelectValue placeholder="All Indexers" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">
-                      {availableIndexers.length === 1 ? availableIndexers[0] : "All Indexers"}
-                    </SelectItem>
-                    {availableIndexers.length > 1 &&
-                      availableIndexers.map((indexer) => (
-                        <SelectItem key={indexer} value={indexer as string}>
-                          {indexer}
-                        </SelectItem>
-                      ))}
-                  </SelectContent>
-                </Select>
-              </div>
+      <div className="space-y-2">
+        <Label className="text-sm">Platform</Label>
+        <MultiSelect
+          options={availablePlatforms}
+          selected={selectedPlatforms}
+          onChange={setSelectedPlatforms}
+          placeholder={availablePlatforms.length === 0 ? "No platforms detected" : "All platforms"}
+          className="w-full"
+          disabled={availablePlatforms.length === 0}
+        />
+      </div>
 
-              <div className="space-y-2">
-                <Label className="text-sm">Release Groups</Label>
-                <MultiSelect
-                  options={availableGroups.map((g) => ({ label: g as string, value: g as string }))}
-                  selected={selectedGroups}
-                  onChange={setSelectedGroups}
-                  placeholder="Select groups..."
-                  className="w-full"
-                />
-              </div>
+      <div className="space-y-2">
+        <Label htmlFor="minSeeders" className="text-sm">
+          Min Seeders
+        </Label>
+        <Input
+          id="minSeeders"
+          type="number"
+          min="0"
+          value={minSeeders}
+          onChange={(e) => setMinSeeders(parseInt(e.target.value) || 0)}
+          className="w-full"
+        />
+      </div>
 
-              <div className="space-y-2">
-                <Label className="text-sm">Platform</Label>
-                <MultiSelect
-                  options={availablePlatforms}
-                  selected={selectedPlatforms}
-                  onChange={setSelectedPlatforms}
-                  placeholder={
-                    availablePlatforms.length === 0 ? "No platforms detected" : "All platforms"
-                  }
-                  className="w-full"
-                  disabled={availablePlatforms.length === 0}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="minSeeders" className="text-sm">
-                  Min Seeders
-                </Label>
-                <Input
-                  id="minSeeders"
-                  type="number"
-                  min="0"
-                  value={minSeeders}
-                  onChange={(e) => setMinSeeders(parseInt(e.target.value) || 0)}
-                  className="w-full"
-                />
-              </div>
-
-              <div className="col-span-4 space-y-2">
-                <Label className="text-sm">Categories</Label>
-                <div className="flex flex-wrap gap-2">
-                  {(["main", "update", "dlc", "extra"] as const).map((cat) => (
-                    <div key={cat} className="flex items-center">
-                      <Checkbox
-                        id={`cat-${cat}`}
-                        checked={visibleCategories.has(cat)}
-                        onCheckedChange={() => toggleCategory(cat)}
-                      />
-                      <label
-                        htmlFor={`cat-${cat}`}
-                        className="ml-2 text-sm cursor-pointer capitalize"
-                      >
-                        {cat === "main"
-                          ? "Main Game"
-                          : cat === "update"
-                            ? "Updates"
-                            : cat === "dlc"
-                              ? "DLC"
-                              : "Extras"}
-                      </label>
-                    </div>
-                  ))}
-                </div>
-              </div>
+      <div className={cn("space-y-2", !isMobile && "col-span-4")}>
+        <Label className="text-sm">Categories</Label>
+        <div className="flex flex-wrap gap-2">
+          {(["main", "update", "dlc", "extra"] as const).map((cat) => (
+            <div key={cat} className="flex items-center">
+              <Checkbox
+                id={`cat-${cat}`}
+                checked={visibleCategories.has(cat)}
+                onCheckedChange={() => toggleCategory(cat)}
+              />
+              <label htmlFor={`cat-${cat}`} className="ml-2 text-sm cursor-pointer capitalize">
+                {cat === "main"
+                  ? "Main Game"
+                  : cat === "update"
+                    ? "Updates"
+                    : cat === "dlc"
+                      ? "DLC"
+                      : "Extras"}
+              </label>
             </div>
-          )}
+          ))}
         </div>
+      </div>
+    </div>
+  );
 
-        <div className="flex-1 mt-4 overflow-y-auto min-h-0">
-          <div className="space-y-4 pr-4">
-            {isSearching && (
-              <div className="flex items-center justify-center py-8">
-                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-                <span className="ml-2 text-muted-foreground">Searching...</span>
-              </div>
-            )}
+  // ─── Shared: Search + filter bar ─────────────────────────────────────────────
 
-            {!isSearching && searchResults && searchResults.items.length === 0 && (
-              <Card>
-                <CardHeader>
-                  <CardTitle>No Results Found</CardTitle>
-                  <CardDescription>
-                    {searchResults.blacklistedCount
-                      ? `${searchResults.blacklistedCount} release(s) were found but are all blacklisted. Review your blacklist in the game settings.`
-                      : "No downloads found for this game. Try configuring indexers in settings."}
-                  </CardDescription>
-                </CardHeader>
-              </Card>
-            )}
+  const searchBar = (
+    <div className="space-y-3">
+      <Input
+        type="text"
+        placeholder="Search for downloads..."
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        className="w-full"
+      />
+      <div className="flex items-center gap-2 flex-wrap">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowFilters(!showFilters)}
+          className="flex items-center gap-2"
+        >
+          <SlidersHorizontal className="h-4 w-4" />
+          {showFilters ? "Hide Filters" : "Show Filters"}
+        </Button>
+        {minSeeders > 0 && (
+          <Badge variant="secondary" className="text-xs">
+            Min Seeders: {minSeeders}
+          </Badge>
+        )}
+        <Badge variant="outline" className="text-xs capitalize">
+          Sorted by: {sortBy} ({sortOrder === "asc" ? "Asc" : "Desc"})
+        </Badge>
+      </div>
+      {filterPanel}
+    </div>
+  );
 
-            {!isSearching &&
-              searchResults &&
-              searchResults.items.length > 0 &&
-              (() => {
-                const totalFiltered = Object.values(filteredCategorizedDownloads).reduce(
-                  (sum, arr) => sum + arr.length,
-                  0
-                );
-                // Count items that pass all active filters *except* platform so the banner
-                // only appears when platform filtering is specifically the cause of an empty
-                // list, not when other filters (e.g. minSeeders) already hide everything.
-                const totalWithoutPlatformFilter = Object.entries(categorizedDownloads).reduce(
-                  (sum, [cat, downloads]) => {
-                    if (!visibleCategories.has(cat as DownloadCategory)) return sum;
-                    return (
-                      sum +
-                      downloads
-                        .filter((t) => meetsSeederThreshold(t))
-                        .filter(
-                          (t) => selectedIndexer === "all" || t.indexerName === selectedIndexer
-                        )
-                        .filter(
-                          (t) =>
-                            selectedGroups.length === 0 ||
-                            (t.group && selectedGroups.includes(t.group))
-                        ).length
-                    );
-                  },
-                  0
-                );
-                const platformFilterHidesAll =
-                  selectedPlatforms.length > 0 &&
-                  totalFiltered === 0 &&
-                  totalWithoutPlatformFilter > 0;
+  // ─── Shared: Results body ─────────────────────────────────────────────────────
+
+  const resultsBody = (
+    <div className="space-y-4">
+      {isSearching && (
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          <span className="ml-2 text-muted-foreground">Searching...</span>
+        </div>
+      )}
+
+      {!isSearching && searchResults && searchResults.items.length === 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>No Results Found</CardTitle>
+            <CardDescription>
+              {searchResults.blacklistedCount
+                ? `${searchResults.blacklistedCount} release(s) were found but are all blacklisted. Review your blacklist in the game settings.`
+                : "No downloads found for this game. Try configuring indexers in settings."}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      )}
+
+      {!isSearching &&
+        searchResults &&
+        searchResults.items.length > 0 &&
+        (() => {
+          const totalFiltered = Object.values(filteredCategorizedDownloads).reduce(
+            (sum, arr) => sum + arr.length,
+            0
+          );
+          const totalWithoutPlatformFilter = Object.entries(categorizedDownloads).reduce(
+            (sum, [cat, downloads]) => {
+              if (!visibleCategories.has(cat as DownloadCategory)) return sum;
+              return (
+                sum +
+                downloads
+                  .filter((t) => meetsSeederThreshold(t))
+                  .filter((t) => selectedIndexer === "all" || t.indexerName === selectedIndexer)
+                  .filter(
+                    (t) =>
+                      selectedGroups.length === 0 || (t.group && selectedGroups.includes(t.group))
+                  ).length
+              );
+            },
+            0
+          );
+          const platformFilterHidesAll =
+            selectedPlatforms.length > 0 && totalFiltered === 0 && totalWithoutPlatformFilter > 0;
+
+          return (
+            <div className="space-y-8">
+              {platformFilterHidesAll && (
+                <div className="flex items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-300">
+                  <Info className="mt-0.5 h-4 w-4 shrink-0" />
+                  <div className="flex-1">
+                    <span>
+                      No results match your preferred platform (
+                      <strong>{selectedPlatforms.join(", ")}</strong>).
+                    </span>{" "}
+                    <button
+                      type="button"
+                      className="underline hover:text-amber-100 transition-colors"
+                      onClick={() => setSelectedPlatforms([])}
+                    >
+                      Show all results
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {(["main", "update", "dlc", "extra"] as const).map((category) => {
+                const downloadsInCategory = filteredCategorizedDownloads[category] || [];
+                if (downloadsInCategory.length === 0) return null;
+
                 return (
-                  <div className="space-y-8">
-                    {/* Platform filter banner: shown when the preferred platform leaves no results */}
-                    {platformFilterHidesAll && (
-                      <div className="flex items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-300">
-                        <Info className="mt-0.5 h-4 w-4 shrink-0" />
-                        <div className="flex-1">
-                          <span>
-                            No results match your preferred platform (
-                            <strong>{selectedPlatforms.join(", ")}</strong>).
-                          </span>{" "}
-                          <button
-                            type="button"
-                            className="underline hover:text-amber-100 transition-colors"
-                            onClick={() => setSelectedPlatforms([])}
-                          >
-                            Show all results
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                    {/* Render each category separately */}
-                    {(["main", "update", "dlc", "extra"] as const).map((category) => {
-                      const downloadsInCategory = filteredCategorizedDownloads[category] || [];
-                      if (downloadsInCategory.length === 0) return null;
+                  <div key={category} className="relative">
+                    <div className="flex items-center gap-2 mb-3 px-1">
+                      <h3 className="font-bold text-lg capitalize tracking-tight">
+                        {category === "main"
+                          ? "Main Game"
+                          : category === "update"
+                            ? "Updates & Patches"
+                            : category === "dlc"
+                              ? "DLC & Expansions"
+                              : "Extras"}
+                      </h3>
+                      <Badge variant="secondary" className="text-xs font-semibold">
+                        {downloadsInCategory.length}
+                      </Badge>
+                    </div>
 
-                      return (
-                        <div key={category} className="relative">
-                          {/* Category Header */}
-                          <div className="flex items-center gap-2 mb-3 px-1">
-                            <h3 className="font-bold text-lg capitalize tracking-tight">
-                              {category === "main"
-                                ? "Main Game"
-                                : category === "update"
-                                  ? "Updates & Patches"
-                                  : category === "dlc"
-                                    ? "DLC & Expansions"
-                                    : "Extras"}
-                            </h3>
-                            <Badge variant="secondary" className="text-xs font-semibold">
-                              {downloadsInCategory.length}
-                            </Badge>
+                    <div className="border rounded-md divide-y mb-4 bg-card">
+                      {/* Desktop sticky sort header */}
+                      {!isMobile && (
+                        <div className="sticky top-0 z-10 bg-muted/95 backdrop-blur-md p-3 text-xs font-bold flex items-center px-4 border-b rounded-t-md group">
+                          <div className="flex-1 flex items-center">
+                            <span className="text-muted-foreground/70 uppercase tracking-widest">
+                              Release Information
+                            </span>
                           </div>
-
-                          {/* Downloads in this category */}
-                          <div className="border rounded-md divide-y mb-4 bg-card">
-                            {/* Sticky Sort Header */}
-                            <div className="sticky top-0 z-10 bg-muted/95 backdrop-blur-md p-3 text-xs font-bold flex items-center px-4 border-b rounded-t-md group">
-                              <div className="flex-1 flex items-center">
-                                <span className="text-muted-foreground/70 uppercase tracking-widest">
-                                  Release Information
-                                </span>
-                              </div>
-                              <div className="flex items-center gap-6 md:gap-10">
-                                <SortHeader
-                                  field="date"
-                                  label="Date"
-                                  className="min-w-[70px] justify-end"
-                                />
-                                <SortHeader
-                                  field="size"
-                                  label="Size"
-                                  className="min-w-[70px] justify-end"
-                                />
-                                <SortHeader
-                                  field="seeders"
-                                  label="Health"
-                                  className="min-w-[70px] justify-end"
-                                />
-                                <div className="w-[80px] text-right text-muted-foreground/70 uppercase tracking-widest">
-                                  Actions
-                                </div>
-                              </div>
+                          <div className="flex items-center gap-6 md:gap-10">
+                            <SortHeader
+                              field="date"
+                              label="Date"
+                              className="min-w-[70px] justify-end"
+                            />
+                            <SortHeader
+                              field="size"
+                              label="Size"
+                              className="min-w-[70px] justify-end"
+                            />
+                            <SortHeader
+                              field="seeders"
+                              label="Health"
+                              className="min-w-[70px] justify-end"
+                            />
+                            <div className="w-[80px] text-right text-muted-foreground/70 uppercase tracking-widest">
+                              Actions
                             </div>
+                          </div>
+                        </div>
+                      )}
 
-                            {downloadsInCategory.map((download: DownloadItem) => {
-                              const isUsenet = isUsenetItem(download);
-                              const metadata =
-                                itemsMetadata.get(download.title) ??
-                                parseReleaseMetadata(download.title);
+                      {downloadsInCategory.map((download: DownloadItem) => {
+                        const isUsenet = isUsenetItem(download);
+                        const metadata =
+                          itemsMetadata.get(download.title) ?? parseReleaseMetadata(download.title);
 
-                              // Health calculation
-                              let healthColor = "text-muted-foreground";
+                        let healthColor = "text-muted-foreground";
+                        if (isUsenet) {
+                          const grabs = download.grabs ?? 0;
+                          if (grabs > 100) healthColor = "text-green-500";
+                          else if (grabs > 20) healthColor = "text-amber-500";
+                          else healthColor = "text-red-500";
+                        } else {
+                          const seeders = download.seeders ?? 0;
+                          if (seeders >= 20) healthColor = "text-green-500";
+                          else if (seeders >= 5) healthColor = "text-amber-500";
+                          else healthColor = "text-red-500";
+                        }
 
-                              if (isUsenet) {
-                                const grabs = download.grabs ?? 0;
-                                if (grabs > 100) healthColor = "text-green-500";
-                                else if (grabs > 20) healthColor = "text-amber-500";
-                                else healthColor = "text-red-500";
-                              } else {
-                                const seeders = download.seeders ?? 0;
-                                if (seeders >= 20) healthColor = "text-green-500";
-                                else if (seeders >= 5) healthColor = "text-amber-500";
-                                else healthColor = "text-red-500";
-                              }
+                        const pubDate = new Date(download.pubDate);
+                        const hoursOld = (Date.now() - pubDate.getTime()) / (1000 * 60 * 60);
+                        const isNew = hoursOld <= 24;
 
-                              const pubDate = new Date(download.pubDate);
-                              const hoursOld = (Date.now() - pubDate.getTime()) / (1000 * 60 * 60);
-                              const isNew = hoursOld <= 24;
+                        // ── Shared: actions dropdown ────────────────────────
+                        const actionsDropdown = (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-9 w-9"
+                                aria-label="More options"
+                              >
+                                <MoreVertical className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem
+                                onClick={() => {
+                                  navigator.clipboard.writeText(download.link);
+                                  toast({ description: "Link copied to clipboard" });
+                                }}
+                              >
+                                <Copy className="h-4 w-4 mr-2" />
+                                Copy {isUsenet ? "NZB" : "Torrent"} Link
+                              </DropdownMenuItem>
 
-                              return (
+                              {(() => {
+                                const compatibleDownloaders = downloaders.filter((d) =>
+                                  isUsenet
+                                    ? isUsenetDownloaderType(d.type)
+                                    : isTorrentDownloaderType(d.type)
+                                );
+                                if (compatibleDownloaders.length <= 1) return null;
+                                return (
+                                  <DropdownMenuSub>
+                                    <DropdownMenuSubTrigger>
+                                      <Download className="h-4 w-4 mr-2" />
+                                      Send to downloader
+                                    </DropdownMenuSubTrigger>
+                                    <DropdownMenuPortal>
+                                      <DropdownMenuSubContent>
+                                        {compatibleDownloaders.map((d) => (
+                                          <DropdownMenuItem
+                                            key={d.id}
+                                            onClick={() =>
+                                              sendToDownloaderMutation.mutate({
+                                                download,
+                                                downloaderId: d.id,
+                                                downloaderName: d.name,
+                                              })
+                                            }
+                                          >
+                                            {d.name}
+                                          </DropdownMenuItem>
+                                        ))}
+                                      </DropdownMenuSubContent>
+                                    </DropdownMenuPortal>
+                                  </DropdownMenuSub>
+                                );
+                              })()}
+
+                              <DropdownMenuItem
+                                onClick={() => blacklistMutation.mutate(download)}
+                                disabled={blacklistMutation.isPending}
+                                className="text-destructive focus:text-destructive"
+                              >
+                                <Ban className="h-4 w-4 mr-2" />
+                                Blacklist release
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        );
+
+                        // ── Mobile: stacked card ────────────────────────────
+                        if (isMobile) {
+                          return (
+                            <div
+                              key={download.guid || download.link}
+                              className="p-3 text-sm overflow-hidden"
+                            >
+                              <div className="flex items-start gap-2 min-w-0">
+                                {/* Type icon */}
                                 <div
-                                  key={download.guid || download.link}
-                                  className="p-4 text-sm hover:bg-muted/30 transition-colors group/row"
+                                  className={cn(
+                                    "h-5 w-5 flex items-center justify-center rounded-full flex-shrink-0 mt-0.5",
+                                    isUsenet ? "text-amber-500" : "text-violet-500"
+                                  )}
                                 >
-                                  <div className="flex items-center gap-4">
-                                    {/* Left Side: Title and Metadata */}
-                                    <div className="flex-1 min-w-0 space-y-1">
-                                      <div className="flex items-center gap-2 min-w-0">
-                                        <Tooltip>
-                                          <TooltipTrigger asChild>
-                                            <div
-                                              className={cn(
-                                                "h-5 w-5 flex items-center justify-center rounded-full flex-shrink-0",
-                                                isUsenet ? "text-amber-500" : "text-violet-500"
-                                              )}
-                                            >
-                                              {isUsenet ? (
-                                                <Newspaper className="h-4 w-4" />
-                                              ) : (
-                                                <Magnet className="h-4 w-4" />
-                                              )}
-                                            </div>
-                                          </TooltipTrigger>
-                                          <TooltipContent>
-                                            {isUsenet ? "Usenet (NZB)" : "Torrent"}
-                                          </TooltipContent>
-                                        </Tooltip>
+                                  {isUsenet ? (
+                                    <Newspaper className="h-4 w-4" />
+                                  ) : (
+                                    <Magnet className="h-4 w-4" />
+                                  )}
+                                </div>
 
-                                        <h4 className="font-bold text-base leading-tight break-words min-w-0">
+                                <div className="flex-1 min-w-0 overflow-hidden">
+                                  {/* Title row + actions */}
+                                  <div className="flex items-start justify-between gap-2">
+                                    <div className="flex-1 min-w-0">
+                                      <div className="flex items-start gap-1.5 min-w-0">
+                                        <h4 className="font-semibold text-sm leading-snug break-all line-clamp-2 min-w-0 flex-1">
                                           {download.title}
                                         </h4>
-
                                         {isNew && (
                                           <Badge
                                             variant="default"
-                                            className="h-4 px-1 text-[8px] uppercase bg-blue-600 hover:bg-blue-600"
+                                            className="h-4 px-1 text-[8px] uppercase bg-blue-600 hover:bg-blue-600 flex-shrink-0 mt-0.5"
                                           >
                                             NEW
                                           </Badge>
                                         )}
                                       </div>
-
-                                      {/* Metadata Line */}
-                                      <div className="flex flex-wrap items-center gap-1.5">
-                                        {metadata.version && (
-                                          <Badge
-                                            variant="secondary"
-                                            className="h-5 px-1.5 text-xs font-mono bg-blue-500/10 text-blue-600 dark:text-blue-400 border-none"
-                                          >
-                                            {metadata.version}
-                                          </Badge>
-                                        )}
-                                        {metadata.languages?.map((lang) => (
-                                          <Badge
-                                            key={lang}
-                                            variant="secondary"
-                                            className="h-5 px-1.5 text-xs bg-green-500/10 text-green-600 dark:text-green-400 border-none"
-                                          >
-                                            {lang}
-                                          </Badge>
-                                        ))}
-                                        {metadata.drm && (
-                                          <Badge
-                                            variant="secondary"
-                                            className="h-5 px-1.5 text-xs bg-purple-500/10 text-purple-600 dark:text-purple-400 border-none"
-                                          >
-                                            {metadata.drm}
-                                          </Badge>
-                                        )}
-                                        {metadata.platform && (
-                                          <Badge
-                                            variant="secondary"
-                                            className="h-5 px-1.5 text-xs bg-orange-500/10 text-orange-600 dark:text-orange-400 border-none"
-                                          >
-                                            {metadata.platform}
-                                          </Badge>
-                                        )}
-                                        {metadata.isScene && (
-                                          <Badge
-                                            variant="outline"
-                                            className="h-5 px-1.5 text-xs border-muted-foreground/30 text-muted-foreground uppercase tracking-tighter"
-                                          >
-                                            Scene
-                                          </Badge>
-                                        )}
-                                        {!isUsenet && download.downloadVolumeFactor === 0 && (
-                                          <Badge
-                                            variant="secondary"
-                                            className="h-5 px-1.5 text-[10px] bg-emerald-500/15 text-emerald-500 dark:text-emerald-400 border-none uppercase tracking-tighter"
-                                          >
-                                            Freeleech
-                                          </Badge>
-                                        )}
-                                      </div>
-
-                                      {/* Release info line */}
-                                      <div className="flex items-center gap-2 text-[11px] text-muted-foreground/70">
-                                        {metadata.group && (
-                                          <span className="font-bold text-foreground/50">
-                                            {metadata.group}
-                                          </span>
-                                        )}
-                                        {metadata.group && <span>•</span>}
-                                        <span>{download.indexerName}</span>
-                                        {isUsenet && download.poster && (
-                                          <>
-                                            <span>•</span>
-                                            <span
-                                              className="truncate max-w-[160px]"
-                                              title={download.poster}
-                                            >
-                                              {download.poster}
-                                            </span>
-                                          </>
-                                        )}
-                                      </div>
                                     </div>
-
-                                    {/* Right Side: Metrics and Actions */}
-                                    <div className="flex items-center gap-6 md:gap-10 flex-shrink-0">
-                                      {/* Date Column */}
-                                      <div className="min-w-[70px] text-right">
-                                        <div className="text-xs font-medium">
-                                          {formatDate(download.pubDate)}
-                                        </div>
-                                        <div className="text-xs text-muted-foreground/50">
-                                          {formatAge(isUsenet ? download.age : hoursOld / 24)}
-                                        </div>
-                                      </div>
-
-                                      {/* Size Column */}
-                                      <div className="min-w-[70px] text-right font-mono text-xs font-bold">
-                                        {download.size ? formatBytes(download.size) : "-"}
-                                      </div>
-
-                                      {/* Health Column */}
-                                      <div
-                                        className={cn(
-                                          "min-w-[70px] text-right flex flex-col items-end justify-center",
-                                          healthColor
-                                        )}
+                                    <div className="flex items-center flex-shrink-0 self-start">
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        onClick={() => handleDownload(download)}
+                                        disabled={
+                                          downloadingGuid === (download.guid || download.link)
+                                        }
+                                        className="h-9 w-9 hover:bg-primary hover:text-primary-foreground transition-all"
+                                        aria-label={`Download ${download.title.replace(/[._]/g, " ")}`}
                                       >
-                                        <div className="flex items-center gap-1 font-bold">
-                                          <Activity className="h-3 w-3" />
-                                          {isUsenet
-                                            ? (download.grabs ?? 0)
-                                            : (download.seeders ?? 0)}
-                                        </div>
-                                        <div className="text-xs uppercase font-bold opacity-70">
-                                          {isUsenet ? "Grabs" : "Seeds"}
-                                        </div>
-                                        {!isUsenet && download.leechers != null && (
-                                          <div className="text-[10px] text-muted-foreground/60">
-                                            {download.leechers}L
-                                          </div>
+                                        {downloadingGuid === (download.guid || download.link) ? (
+                                          <Loader2 className="h-4 w-4 animate-spin" />
+                                        ) : (
+                                          <Download className="h-4 w-4" />
                                         )}
-                                      </div>
-
-                                      {/* Actions Column */}
-                                      <div className="w-[80px] flex items-center justify-end gap-1">
-                                        <Button
-                                          variant="ghost"
-                                          size="icon"
-                                          onClick={() => handleDownload(download)}
-                                          disabled={
-                                            downloadingGuid === (download.guid || download.link)
-                                          }
-                                          className="h-9 w-9 hover:bg-primary hover:text-primary-foreground transition-all"
-                                          aria-label={`Download ${download.title.replace(/[._]/g, " ")}`}
-                                        >
-                                          {downloadingGuid === (download.guid || download.link) ? (
-                                            <Loader2 className="h-4 w-4 animate-spin" />
-                                          ) : (
-                                            <Download className="h-4 w-4" />
-                                          )}
-                                        </Button>
-
-                                        <DropdownMenu>
-                                          <DropdownMenuTrigger asChild>
-                                            <Button
-                                              variant="ghost"
-                                              size="icon"
-                                              className="h-9 w-9"
-                                              aria-label="More options"
-                                            >
-                                              <MoreVertical className="h-4 w-4" />
-                                            </Button>
-                                          </DropdownMenuTrigger>
-                                          <DropdownMenuContent align="end">
-                                            <DropdownMenuItem
-                                              onClick={() => {
-                                                navigator.clipboard.writeText(download.link);
-                                                toast({ description: "Link copied to clipboard" });
-                                              }}
-                                            >
-                                              <Copy className="h-4 w-4 mr-2" />
-                                              Copy {isUsenet ? "NZB" : "Torrent"} Link
-                                            </DropdownMenuItem>
-
-                                            {(() => {
-                                              const compatibleDownloaders = downloaders.filter(
-                                                (d) =>
-                                                  isUsenet
-                                                    ? isUsenetDownloaderType(d.type)
-                                                    : isTorrentDownloaderType(d.type)
-                                              );
-
-                                              if (compatibleDownloaders.length <= 1) {
-                                                return null;
-                                              }
-
-                                              return (
-                                                <DropdownMenuSub>
-                                                  <DropdownMenuSubTrigger>
-                                                    <Download className="h-4 w-4 mr-2" />
-                                                    Send to downloader
-                                                  </DropdownMenuSubTrigger>
-                                                  <DropdownMenuPortal>
-                                                    <DropdownMenuSubContent>
-                                                      {compatibleDownloaders.map((d) => (
-                                                        <DropdownMenuItem
-                                                          key={d.id}
-                                                          onClick={() =>
-                                                            sendToDownloaderMutation.mutate({
-                                                              download,
-                                                              downloaderId: d.id,
-                                                              downloaderName: d.name,
-                                                            })
-                                                          }
-                                                        >
-                                                          {d.name}
-                                                        </DropdownMenuItem>
-                                                      ))}
-                                                    </DropdownMenuSubContent>
-                                                  </DropdownMenuPortal>
-                                                </DropdownMenuSub>
-                                              );
-                                            })()}
-                                            <DropdownMenuItem
-                                              onClick={() => blacklistMutation.mutate(download)}
-                                              disabled={blacklistMutation.isPending}
-                                              className="text-destructive focus:text-destructive"
-                                            >
-                                              <Ban className="h-4 w-4 mr-2" />
-                                              Blacklist release
-                                            </DropdownMenuItem>
-                                          </DropdownMenuContent>
-                                        </DropdownMenu>
-                                      </div>
+                                      </Button>
+                                      {actionsDropdown}
                                     </div>
                                   </div>
+
+                                  {/* Metadata badges */}
+                                  {(metadata.version ||
+                                    (metadata.languages && metadata.languages.length > 0) ||
+                                    metadata.drm ||
+                                    metadata.platform ||
+                                    metadata.isScene ||
+                                    (!isUsenet && download.downloadVolumeFactor === 0)) && (
+                                    <div className="flex flex-wrap items-center gap-1 mt-1">
+                                      {metadata.version && (
+                                        <Badge
+                                          variant="secondary"
+                                          className="h-5 px-1.5 text-xs font-mono bg-blue-500/10 text-blue-600 dark:text-blue-400 border-none"
+                                        >
+                                          {metadata.version}
+                                        </Badge>
+                                      )}
+                                      {metadata.languages?.map((lang) => (
+                                        <Badge
+                                          key={lang}
+                                          variant="secondary"
+                                          className="h-5 px-1.5 text-xs bg-green-500/10 text-green-600 dark:text-green-400 border-none"
+                                        >
+                                          {lang}
+                                        </Badge>
+                                      ))}
+                                      {metadata.drm && (
+                                        <Badge
+                                          variant="secondary"
+                                          className="h-5 px-1.5 text-xs bg-purple-500/10 text-purple-600 dark:text-purple-400 border-none"
+                                        >
+                                          {metadata.drm}
+                                        </Badge>
+                                      )}
+                                      {metadata.platform && (
+                                        <Badge
+                                          variant="secondary"
+                                          className="h-5 px-1.5 text-xs bg-orange-500/10 text-orange-600 dark:text-orange-400 border-none"
+                                        >
+                                          {metadata.platform}
+                                        </Badge>
+                                      )}
+                                      {metadata.isScene && (
+                                        <Badge
+                                          variant="outline"
+                                          className="h-5 px-1.5 text-xs border-muted-foreground/30 text-muted-foreground uppercase tracking-tighter"
+                                        >
+                                          Scene
+                                        </Badge>
+                                      )}
+                                      {!isUsenet && download.downloadVolumeFactor === 0 && (
+                                        <Badge
+                                          variant="secondary"
+                                          className="h-5 px-1.5 text-[10px] bg-emerald-500/15 text-emerald-500 dark:text-emerald-400 border-none uppercase tracking-tighter"
+                                        >
+                                          Freeleech
+                                        </Badge>
+                                      )}
+                                    </div>
+                                  )}
+
+                                  {/* Group + indexer line */}
+                                  <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70 mt-1 min-w-0 overflow-hidden">
+                                    {metadata.group && (
+                                      <span className="font-bold text-foreground/50 truncate shrink-0 max-w-[120px]">
+                                        {metadata.group}
+                                      </span>
+                                    )}
+                                    {metadata.group && <span className="flex-shrink-0">•</span>}
+                                    <span className="truncate">{download.indexerName}</span>
+                                  </div>
+
+                                  {/* Metrics row */}
+                                  <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-1.5 text-xs text-muted-foreground/70">
+                                    <span className="font-mono font-bold text-foreground/70">
+                                      {download.size ? formatBytes(download.size) : "—"}
+                                    </span>
+                                    <span>•</span>
+                                    <span className={cn("flex items-center gap-0.5", healthColor)}>
+                                      <Activity className="h-3 w-3" />
+                                      {isUsenet
+                                        ? (download.grabs ?? 0)
+                                        : (download.seeders ?? 0)}{" "}
+                                      {isUsenet ? "grabs" : "seeds"}
+                                    </span>
+                                    <span>•</span>
+                                    <span>{formatDate(download.pubDate)}</span>
+                                  </div>
                                 </div>
-                              );
-                            })}
+                              </div>
+                            </div>
+                          );
+                        }
+
+                        // ── Desktop: table row ──────────────────────────────
+                        return (
+                          <div
+                            key={download.guid || download.link}
+                            className="p-4 text-sm hover:bg-muted/30 transition-colors group/row"
+                          >
+                            <div className="flex items-center gap-4">
+                              <div className="flex-1 min-w-0 space-y-1">
+                                <div className="flex items-center gap-2 min-w-0">
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <div
+                                        className={cn(
+                                          "h-5 w-5 flex items-center justify-center rounded-full flex-shrink-0",
+                                          isUsenet ? "text-amber-500" : "text-violet-500"
+                                        )}
+                                      >
+                                        {isUsenet ? (
+                                          <Newspaper className="h-4 w-4" />
+                                        ) : (
+                                          <Magnet className="h-4 w-4" />
+                                        )}
+                                      </div>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      {isUsenet ? "Usenet (NZB)" : "Torrent"}
+                                    </TooltipContent>
+                                  </Tooltip>
+
+                                  <h4 className="font-bold text-base leading-tight break-words min-w-0">
+                                    {download.title}
+                                  </h4>
+
+                                  {isNew && (
+                                    <Badge
+                                      variant="default"
+                                      className="h-4 px-1 text-[8px] uppercase bg-blue-600 hover:bg-blue-600"
+                                    >
+                                      NEW
+                                    </Badge>
+                                  )}
+                                </div>
+
+                                <div className="flex flex-wrap items-center gap-1.5">
+                                  {metadata.version && (
+                                    <Badge
+                                      variant="secondary"
+                                      className="h-5 px-1.5 text-xs font-mono bg-blue-500/10 text-blue-600 dark:text-blue-400 border-none"
+                                    >
+                                      {metadata.version}
+                                    </Badge>
+                                  )}
+                                  {metadata.languages?.map((lang) => (
+                                    <Badge
+                                      key={lang}
+                                      variant="secondary"
+                                      className="h-5 px-1.5 text-xs bg-green-500/10 text-green-600 dark:text-green-400 border-none"
+                                    >
+                                      {lang}
+                                    </Badge>
+                                  ))}
+                                  {metadata.drm && (
+                                    <Badge
+                                      variant="secondary"
+                                      className="h-5 px-1.5 text-xs bg-purple-500/10 text-purple-600 dark:text-purple-400 border-none"
+                                    >
+                                      {metadata.drm}
+                                    </Badge>
+                                  )}
+                                  {metadata.platform && (
+                                    <Badge
+                                      variant="secondary"
+                                      className="h-5 px-1.5 text-xs bg-orange-500/10 text-orange-600 dark:text-orange-400 border-none"
+                                    >
+                                      {metadata.platform}
+                                    </Badge>
+                                  )}
+                                  {metadata.isScene && (
+                                    <Badge
+                                      variant="outline"
+                                      className="h-5 px-1.5 text-xs border-muted-foreground/30 text-muted-foreground uppercase tracking-tighter"
+                                    >
+                                      Scene
+                                    </Badge>
+                                  )}
+                                  {!isUsenet && download.downloadVolumeFactor === 0 && (
+                                    <Badge
+                                      variant="secondary"
+                                      className="h-5 px-1.5 text-[10px] bg-emerald-500/15 text-emerald-500 dark:text-emerald-400 border-none uppercase tracking-tighter"
+                                    >
+                                      Freeleech
+                                    </Badge>
+                                  )}
+                                </div>
+
+                                <div className="flex items-center gap-2 text-[11px] text-muted-foreground/70">
+                                  {metadata.group && (
+                                    <span className="font-bold text-foreground/50">
+                                      {metadata.group}
+                                    </span>
+                                  )}
+                                  {metadata.group && <span>•</span>}
+                                  <span>{download.indexerName}</span>
+                                  {isUsenet && download.poster && (
+                                    <>
+                                      <span>•</span>
+                                      <span
+                                        className="truncate max-w-[160px]"
+                                        title={download.poster}
+                                      >
+                                        {download.poster}
+                                      </span>
+                                    </>
+                                  )}
+                                </div>
+                              </div>
+
+                              <div className="flex items-center gap-6 md:gap-10 flex-shrink-0">
+                                <div className="min-w-[70px] text-right">
+                                  <div className="text-xs font-medium">
+                                    {formatDate(download.pubDate)}
+                                  </div>
+                                  <div className="text-xs text-muted-foreground/50">
+                                    {formatAge(isUsenet ? download.age : hoursOld / 24)}
+                                  </div>
+                                </div>
+
+                                <div className="min-w-[70px] text-right font-mono text-xs font-bold">
+                                  {download.size ? formatBytes(download.size) : "-"}
+                                </div>
+
+                                <div
+                                  className={cn(
+                                    "min-w-[70px] text-right flex flex-col items-end justify-center",
+                                    healthColor
+                                  )}
+                                >
+                                  <div className="flex items-center gap-1 font-bold">
+                                    <Activity className="h-3 w-3" />
+                                    {isUsenet ? (download.grabs ?? 0) : (download.seeders ?? 0)}
+                                  </div>
+                                  <div className="text-xs uppercase font-bold opacity-70">
+                                    {isUsenet ? "Grabs" : "Seeds"}
+                                  </div>
+                                  {!isUsenet && download.leechers != null && (
+                                    <div className="text-[10px] text-muted-foreground/60">
+                                      {download.leechers}L
+                                    </div>
+                                  )}
+                                </div>
+
+                                <div className="w-[80px] flex items-center justify-end gap-1">
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={() => handleDownload(download)}
+                                    disabled={downloadingGuid === (download.guid || download.link)}
+                                    className="h-9 w-9 hover:bg-primary hover:text-primary-foreground transition-all"
+                                    aria-label={`Download ${download.title.replace(/[._]/g, " ")}`}
+                                  >
+                                    {downloadingGuid === (download.guid || download.link) ? (
+                                      <Loader2 className="h-4 w-4 animate-spin" />
+                                    ) : (
+                                      <Download className="h-4 w-4" />
+                                    )}
+                                  </Button>
+                                  {actionsDropdown}
+                                </div>
+                              </div>
+                            </div>
                           </div>
-                        </div>
-                      );
-                    })}
+                        );
+                      })}
+                    </div>
                   </div>
                 );
-              })()}
+              })}
+            </div>
+          );
+        })()}
 
-            {searchResults?.errors && searchResults.errors.length > 0 && (
-              <Card className="border-destructive">
-                <CardHeader>
-                  <CardTitle className="text-sm text-destructive">Indexer Errors</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ul className="text-sm space-y-1">
-                    {searchResults.errors.map((error, index) => (
-                      <li key={index} className="text-muted-foreground">
-                        • {error}
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            )}
-          </div>
-        </div>
-      </DialogContent>
+      {searchResults?.errors && searchResults.errors.length > 0 && (
+        <Card className="border-destructive">
+          <CardHeader>
+            <CardTitle className="text-sm text-destructive">Indexer Errors</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="text-sm space-y-1">
+              {searchResults.errors.map((error, index) => (
+                <li key={index} className="text-muted-foreground">
+                  • {error}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
 
-      {/* Bundle Confirmation Dialog */}
-      <AlertDialog open={showBundleDialog} onOpenChange={setShowBundleDialog}>
-        <AlertDialogContent className="max-w-2xl">
-          <AlertDialogHeader>
-            <AlertDialogTitle>Download with Updates?</AlertDialogTitle>
-            <AlertDialogDescription>
-              {filteredCategorizedDownloads.update.length} update(s) are available for this game.
-              Select which updates you want to download with the main game.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+  // ─── Bundle dialog (shared) ───────────────────────────────────────────────────
 
-          {/* List of updates with checkboxes */}
-          {filteredCategorizedDownloads.update.length > 0 && (
-            <div className="my-4">
-              <div className="flex items-center justify-between mb-2">
-                <div className="text-sm font-semibold">Available Updates:</div>
-                <div className="flex gap-2">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={selectAllUpdates}
-                    className="h-7 text-xs"
-                  >
-                    Select All
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={deselectAllUpdates}
-                    className="h-7 text-xs"
-                  >
-                    Deselect All
-                  </Button>
-                </div>
-              </div>
-              <div className="border rounded-md">
-                <ScrollArea className="h-[300px]">
-                  <div className="p-3 space-y-3">
-                    {filteredCategorizedDownloads.update.map((update, index) => (
-                      <div
-                        key={update.guid || update.link}
-                        className="flex items-start gap-3 p-2 rounded hover:bg-muted/50 transition-colors"
-                      >
-                        <Checkbox
-                          id={`update-${index}`}
-                          checked={selectedUpdateIndices.has(index)}
-                          onCheckedChange={() => toggleUpdateSelection(index)}
-                          className="mt-1"
-                        />
-                        <label
-                          htmlFor={`update-${index}`}
-                          className="flex-1 cursor-pointer text-sm"
-                        >
-                          <div className="font-medium">{update.title}</div>
-                          <div className="text-xs text-muted-foreground flex items-center gap-2 mt-1">
-                            {update.size && <span>{formatBytes(update.size)}</span>}
-                            {update.seeders !== undefined && (
-                              <>
-                                <span>•</span>
-                                <span className="text-green-600">{update.seeders} seeders</span>
-                              </>
-                            )}
-                          </div>
-                        </label>
-                      </div>
-                    ))}
-                  </div>
-                </ScrollArea>
-              </div>
-              <div className="text-xs text-muted-foreground mt-2">
-                {selectedUpdateIndices.size} of {filteredCategorizedDownloads.update.length} updates
-                selected
+  const bundleDialog = (
+    <AlertDialog open={showBundleDialog} onOpenChange={setShowBundleDialog}>
+      <AlertDialogContent className="max-w-2xl">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Download with Updates?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {filteredCategorizedDownloads.update.length} update(s) are available for this game.
+            Select which updates you want to download with the main game.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {filteredCategorizedDownloads.update.length > 0 && (
+          <div className="my-4">
+            <div className="flex items-center justify-between mb-2">
+              <div className="text-sm font-semibold">Available Updates:</div>
+              <div className="flex gap-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={selectAllUpdates}
+                  className="h-7 text-xs"
+                >
+                  Select All
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={deselectAllUpdates}
+                  className="h-7 text-xs"
+                >
+                  Deselect All
+                </Button>
               </div>
             </div>
-          )}
+            <div className="border rounded-md">
+              <ScrollArea className="h-[300px]">
+                <div className="p-3 space-y-3">
+                  {filteredCategorizedDownloads.update.map((update, index) => (
+                    <div
+                      key={update.guid || update.link}
+                      className="flex items-start gap-3 p-2 rounded hover:bg-muted/50 transition-colors"
+                    >
+                      <Checkbox
+                        id={`update-${index}`}
+                        checked={selectedUpdateIndices.has(index)}
+                        onCheckedChange={() => toggleUpdateSelection(index)}
+                        className="mt-1"
+                      />
+                      <label htmlFor={`update-${index}`} className="flex-1 cursor-pointer text-sm">
+                        <div className="font-medium">{update.title}</div>
+                        <div className="text-xs text-muted-foreground flex items-center gap-2 mt-1">
+                          {update.size && <span>{formatBytes(update.size)}</span>}
+                          {update.seeders !== undefined && (
+                            <>
+                              <span>•</span>
+                              <span className="text-green-600">{update.seeders} seeders</span>
+                            </>
+                          )}
+                        </div>
+                      </label>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+            </div>
+            <div className="text-xs text-muted-foreground mt-2">
+              {selectedUpdateIndices.size} of {filteredCategorizedDownloads.update.length} updates
+              selected
+            </div>
+          </div>
+        )}
 
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              className={buttonVariants({ variant: "outline" })}
-              onClick={() => {
-                if (isDirectDownloadMode) {
-                  handleBundleDirectDownload(false);
-                } else {
-                  handleBundleDownload(false);
-                }
-              }}
-            >
-              Only the main game
-            </AlertDialogAction>
-            <AlertDialogAction
-              onClick={() => {
-                if (isDirectDownloadMode) {
-                  handleBundleDirectDownload(true);
-                } else {
-                  handleBundleDownload(true);
-                }
-              }}
-              disabled={selectedUpdateIndices.size === 0}
-            >
-              <PackagePlus className="w-4 h-4 mr-2" />
-              Download with {selectedUpdateIndices.size} update(s)
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </Dialog>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className={buttonVariants({ variant: "outline" })}
+            onClick={() => {
+              if (isDirectDownloadMode) handleBundleDirectDownload(false);
+              else handleBundleDownload(false);
+            }}
+          >
+            Only the main game
+          </AlertDialogAction>
+          <AlertDialogAction
+            onClick={() => {
+              if (isDirectDownloadMode) handleBundleDirectDownload(true);
+              else handleBundleDownload(true);
+            }}
+            disabled={selectedUpdateIndices.size === 0}
+          >
+            <PackagePlus className="w-4 h-4 mr-2" />
+            Download with {selectedUpdateIndices.size} update(s)
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
+  // ─── Mobile: Drawer ───────────────────────────────────────────────────────────
+
+  if (isMobile) {
+    return (
+      <>
+        <Drawer open={open} onOpenChange={onOpenChange} shouldScaleBackground={false}>
+          <DrawerContent className="h-[95vh] flex flex-col">
+            <DrawerHeader className="pt-2 pb-0 px-4 flex-shrink-0">
+              <DrawerTitle className="text-base font-bold truncate">
+                Download {game.title}
+              </DrawerTitle>
+              <DrawerDescription className="sr-only">
+                Search results for torrents and NZBs matching this game.
+              </DrawerDescription>
+            </DrawerHeader>
+
+            {/* Sticky search + filter */}
+            <div className="flex-shrink-0 px-4 pt-3 pb-3 space-y-3 border-b border-border/50">
+              {searchBar}
+            </div>
+
+            {/* Scrollable results */}
+            <div className="flex-1 overflow-y-auto min-h-0 px-4 py-3">{resultsBody}</div>
+          </DrawerContent>
+        </Drawer>
+        {bundleDialog}
+      </>
+    );
+  }
+
+  // ─── Desktop: Dialog ──────────────────────────────────────────────────────────
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-6xl max-h-[90vh] flex flex-col ">
+          <DialogHeader className="flex-shrink-0">
+            <DialogTitle>Download {game.title}</DialogTitle>
+            <DialogDescription>
+              Search results for torrents and NZBs matching this game.{" "}
+              <span className="text-muted-foreground/80">
+                Tip: Enable auto-download in Settings to automatically download new releases.
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex-shrink-0 mt-4">{searchBar}</div>
+
+          <div className="flex-1 mt-4 overflow-y-auto min-h-0">
+            <div className="space-y-4 pr-4">{resultsBody}</div>
+          </div>
+        </DialogContent>
+      </Dialog>
+      {bundleDialog}
+    </>
   );
 }

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -122,6 +122,8 @@ interface GameDownloadDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+type ReleaseMetadata = ReturnType<typeof parseReleaseMetadata>;
+
 function formatDate(dateString: string): string {
   try {
     return new Date(dateString).toLocaleDateString();
@@ -134,6 +136,84 @@ import { apiRequest } from "@/lib/queryClient";
 import { useDebounce } from "@/hooks/use-debounce";
 import { formatBytes, formatAge, isUsenetItem } from "@/lib/downloads-utils";
 import { useIsMobile } from "@/hooks/use-mobile";
+
+function ReleaseMetadataBadges({
+  metadata,
+  isUsenet,
+  downloadVolumeFactor,
+  className,
+}: {
+  metadata: ReleaseMetadata;
+  isUsenet: boolean;
+  downloadVolumeFactor?: number;
+  className?: string;
+}) {
+  const hasMetadata =
+    metadata.version ||
+    (metadata.languages && metadata.languages.length > 0) ||
+    metadata.drm ||
+    metadata.platform ||
+    metadata.isScene ||
+    (!isUsenet && downloadVolumeFactor === 0);
+
+  if (!hasMetadata) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-1", className)}>
+      {metadata.version && (
+        <Badge
+          variant="secondary"
+          className="h-5 px-1.5 text-xs font-mono bg-blue-500/10 text-blue-600 dark:text-blue-400 border-none"
+        >
+          {metadata.version}
+        </Badge>
+      )}
+      {metadata.languages?.map((lang) => (
+        <Badge
+          key={lang}
+          variant="secondary"
+          className="h-5 px-1.5 text-xs bg-green-500/10 text-green-600 dark:text-green-400 border-none"
+        >
+          {lang}
+        </Badge>
+      ))}
+      {metadata.drm && (
+        <Badge
+          variant="secondary"
+          className="h-5 px-1.5 text-xs bg-purple-500/10 text-purple-600 dark:text-purple-400 border-none"
+        >
+          {metadata.drm}
+        </Badge>
+      )}
+      {metadata.platform && (
+        <Badge
+          variant="secondary"
+          className="h-5 px-1.5 text-xs bg-orange-500/10 text-orange-600 dark:text-orange-400 border-none"
+        >
+          {metadata.platform}
+        </Badge>
+      )}
+      {metadata.isScene && (
+        <Badge
+          variant="outline"
+          className="h-5 px-1.5 text-xs border-muted-foreground/30 text-muted-foreground uppercase tracking-tighter"
+        >
+          Scene
+        </Badge>
+      )}
+      {!isUsenet && downloadVolumeFactor === 0 && (
+        <Badge
+          variant="secondary"
+          className="h-5 px-1.5 text-[10px] bg-emerald-500/15 text-emerald-500 dark:text-emerald-400 border-none uppercase tracking-tighter"
+        >
+          Freeleech
+        </Badge>
+      )}
+    </div>
+  );
+}
 
 export default function GameDownloadDialog({ game, open, onOpenChange }: GameDownloadDialogProps) {
   const { toast } = useToast();
@@ -1095,64 +1175,12 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                   </div>
 
                                   {/* Metadata badges */}
-                                  {(metadata.version ||
-                                    (metadata.languages && metadata.languages.length > 0) ||
-                                    metadata.drm ||
-                                    metadata.platform ||
-                                    metadata.isScene ||
-                                    (!isUsenet && download.downloadVolumeFactor === 0)) && (
-                                    <div className="flex flex-wrap items-center gap-1 mt-1">
-                                      {metadata.version && (
-                                        <Badge
-                                          variant="secondary"
-                                          className="h-5 px-1.5 text-xs font-mono bg-blue-500/10 text-blue-600 dark:text-blue-400 border-none"
-                                        >
-                                          {metadata.version}
-                                        </Badge>
-                                      )}
-                                      {metadata.languages?.map((lang) => (
-                                        <Badge
-                                          key={lang}
-                                          variant="secondary"
-                                          className="h-5 px-1.5 text-xs bg-green-500/10 text-green-600 dark:text-green-400 border-none"
-                                        >
-                                          {lang}
-                                        </Badge>
-                                      ))}
-                                      {metadata.drm && (
-                                        <Badge
-                                          variant="secondary"
-                                          className="h-5 px-1.5 text-xs bg-purple-500/10 text-purple-600 dark:text-purple-400 border-none"
-                                        >
-                                          {metadata.drm}
-                                        </Badge>
-                                      )}
-                                      {metadata.platform && (
-                                        <Badge
-                                          variant="secondary"
-                                          className="h-5 px-1.5 text-xs bg-orange-500/10 text-orange-600 dark:text-orange-400 border-none"
-                                        >
-                                          {metadata.platform}
-                                        </Badge>
-                                      )}
-                                      {metadata.isScene && (
-                                        <Badge
-                                          variant="outline"
-                                          className="h-5 px-1.5 text-xs border-muted-foreground/30 text-muted-foreground uppercase tracking-tighter"
-                                        >
-                                          Scene
-                                        </Badge>
-                                      )}
-                                      {!isUsenet && download.downloadVolumeFactor === 0 && (
-                                        <Badge
-                                          variant="secondary"
-                                          className="h-5 px-1.5 text-[10px] bg-emerald-500/15 text-emerald-500 dark:text-emerald-400 border-none uppercase tracking-tighter"
-                                        >
-                                          Freeleech
-                                        </Badge>
-                                      )}
-                                    </div>
-                                  )}
+                                  <ReleaseMetadataBadges
+                                    metadata={metadata}
+                                    isUsenet={isUsenet}
+                                    downloadVolumeFactor={download.downloadVolumeFactor}
+                                    className="mt-1"
+                                  />
 
                                   {/* Group + indexer line */}
                                   <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground/70 mt-1 min-w-0 overflow-hidden">
@@ -1230,57 +1258,12 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                   )}
                                 </div>
 
-                                <div className="flex flex-wrap items-center gap-1.5">
-                                  {metadata.version && (
-                                    <Badge
-                                      variant="secondary"
-                                      className="h-5 px-1.5 text-xs font-mono bg-blue-500/10 text-blue-600 dark:text-blue-400 border-none"
-                                    >
-                                      {metadata.version}
-                                    </Badge>
-                                  )}
-                                  {metadata.languages?.map((lang) => (
-                                    <Badge
-                                      key={lang}
-                                      variant="secondary"
-                                      className="h-5 px-1.5 text-xs bg-green-500/10 text-green-600 dark:text-green-400 border-none"
-                                    >
-                                      {lang}
-                                    </Badge>
-                                  ))}
-                                  {metadata.drm && (
-                                    <Badge
-                                      variant="secondary"
-                                      className="h-5 px-1.5 text-xs bg-purple-500/10 text-purple-600 dark:text-purple-400 border-none"
-                                    >
-                                      {metadata.drm}
-                                    </Badge>
-                                  )}
-                                  {metadata.platform && (
-                                    <Badge
-                                      variant="secondary"
-                                      className="h-5 px-1.5 text-xs bg-orange-500/10 text-orange-600 dark:text-orange-400 border-none"
-                                    >
-                                      {metadata.platform}
-                                    </Badge>
-                                  )}
-                                  {metadata.isScene && (
-                                    <Badge
-                                      variant="outline"
-                                      className="h-5 px-1.5 text-xs border-muted-foreground/30 text-muted-foreground uppercase tracking-tighter"
-                                    >
-                                      Scene
-                                    </Badge>
-                                  )}
-                                  {!isUsenet && download.downloadVolumeFactor === 0 && (
-                                    <Badge
-                                      variant="secondary"
-                                      className="h-5 px-1.5 text-[10px] bg-emerald-500/15 text-emerald-500 dark:text-emerald-400 border-none uppercase tracking-tighter"
-                                    >
-                                      Freeleech
-                                    </Badge>
-                                  )}
-                                </div>
+                                <ReleaseMetadataBadges
+                                  metadata={metadata}
+                                  isUsenet={isUsenet}
+                                  downloadVolumeFactor={download.downloadVolumeFactor}
+                                  className="gap-1.5"
+                                />
 
                                 <div className="flex items-center gap-2 text-[11px] text-muted-foreground/70">
                                   {metadata.group && (

--- a/client/src/components/GameFilterPills.tsx
+++ b/client/src/components/GameFilterPills.tsx
@@ -22,16 +22,21 @@ export default function GameFilterPills({
 }: Readonly<GameFilterPillsProps>) {
   return (
     <>
-      <Button
-        variant={showSearchResultsOnly ? "default" : "outline"}
-        size="sm"
-        className="h-7 gap-1.5 text-xs"
-        onClick={() => setShowSearchResultsOnly(!showSearchResultsOnly)}
-        aria-label="Show games with search results only"
-      >
-        <Search className="h-3 w-3" />
-        Has Results
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant={showSearchResultsOnly ? "default" : "outline"}
+            size="sm"
+            className="h-7 gap-1.5 text-xs"
+            onClick={() => setShowSearchResultsOnly(!showSearchResultsOnly)}
+            aria-label="Show games with search results only"
+          >
+            <Search className="h-3 w-3" />
+            <span className="hidden sm:inline">Has Results</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent className="sm:hidden">Has Results</TooltipContent>
+      </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
@@ -42,10 +47,10 @@ export default function GameFilterPills({
             aria-label={showDownloadsOnly ? "Show all games" : "Show games with downloads only"}
           >
             <Download className="h-3 w-3" />
-            Has Downloads
+            <span className="hidden sm:inline">Has Downloads</span>
           </Button>
         </TooltipTrigger>
-        <TooltipContent>{showDownloadsOnly ? "Show all" : "Has downloads"}</TooltipContent>
+        <TooltipContent className="sm:hidden">Has Downloads</TooltipContent>
       </Tooltip>
       {setShowUpdateAvailableOnly && (
         <Tooltip>
@@ -60,12 +65,10 @@ export default function GameFilterPills({
               }
             >
               <RefreshCw className="h-3 w-3" />
-              Update Available
+              <span className="hidden sm:inline">Update Available</span>
             </Button>
           </TooltipTrigger>
-          <TooltipContent>
-            {showUpdateAvailableOnly ? "Show all" : "Has update downloads"}
-          </TooltipContent>
+          <TooltipContent className="sm:hidden">Update Available</TooltipContent>
         </Tooltip>
       )}
     </>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -108,17 +108,19 @@ export default function Header({ title = "Library" }: HeaderProps) {
       <header className="border-b bg-background/95 px-3 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/60 sm:px-4 sm:py-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-3 sm:gap-4">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <SidebarTrigger
-                  className="h-10 w-10 rounded-xl md:h-7 md:w-7 md:rounded-md"
-                  data-testid="button-sidebar-toggle"
-                />
-              </TooltipTrigger>
-              <TooltipContent side="right">
-                <p>Toggle Sidebar</p>
-              </TooltipContent>
-            </Tooltip>
+            <span className="hidden md:contents">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <SidebarTrigger
+                    className="h-7 w-7 rounded-md"
+                    data-testid="button-sidebar-toggle"
+                  />
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  <p>Toggle Sidebar</p>
+                </TooltipContent>
+              </Tooltip>
+            </span>
             <h1 className="truncate text-lg font-semibold sm:text-xl" data-testid="text-page-title">
               {title}
             </h1>

--- a/client/src/components/Library.tsx
+++ b/client/src/components/Library.tsx
@@ -24,6 +24,7 @@ import { useDebounce } from "@/hooks/use-debounce";
 import { calculateLibraryStats } from "@/lib/stats";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -223,7 +224,7 @@ export default function Library() {
         <div>
           <h1 className="text-2xl font-bold tracking-tight">My Library</h1>
           {stableLibStats.totalGames > 0 && (
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 text-sm text-muted-foreground">
+            <div className="hidden sm:flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 text-sm text-muted-foreground">
               <span>
                 <span className="font-medium text-foreground">
                   {filtersActive ? filteredGames.length : stableLibStats.totalGames}
@@ -283,12 +284,14 @@ export default function Library() {
           onSearchChange={setSearchQuery}
           searchPlaceholder="Search your library..."
           filterPills={
-            <GameFilterPills
-              showSearchResultsOnly={showSearchResultsOnly}
-              setShowSearchResultsOnly={setShowSearchResultsOnly}
-              showDownloadsOnly={showDownloadsOnly}
-              setShowDownloadsOnly={setShowDownloadsOnly}
-            />
+            <div className="hidden sm:contents">
+              <GameFilterPills
+                showSearchResultsOnly={showSearchResultsOnly}
+                setShowSearchResultsOnly={setShowSearchResultsOnly}
+                showDownloadsOnly={showDownloadsOnly}
+                setShowDownloadsOnly={setShowDownloadsOnly}
+              />
+            </div>
           }
           viewControls={{
             viewMode,
@@ -298,22 +301,35 @@ export default function Library() {
           }}
           actions={
             <>
-              <Button
-                variant={showFilters ? "secondary" : "outline"}
-                size="sm"
-                className="h-8 gap-1.5"
-                onClick={() => setShowFilters((v) => !v)}
-                aria-label="Toggle filters"
-                aria-expanded={showFilters}
-              >
-                <Filter className="h-3.5 w-3.5" />
-                <span className="hidden sm:inline">Filters</span>
-                {activeFilters.length > 0 && (
-                  <span className="ml-0.5 rounded-full bg-primary text-primary-foreground text-[10px] font-semibold w-4 h-4 flex items-center justify-center">
-                    {activeFilters.length}
-                  </span>
-                )}
-              </Button>
+              <div className="flex sm:hidden items-center gap-2">
+                <GameFilterPills
+                  showSearchResultsOnly={showSearchResultsOnly}
+                  setShowSearchResultsOnly={setShowSearchResultsOnly}
+                  showDownloadsOnly={showDownloadsOnly}
+                  setShowDownloadsOnly={setShowDownloadsOnly}
+                />
+              </div>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant={showFilters ? "secondary" : "outline"}
+                    size="sm"
+                    className="h-8 gap-1.5"
+                    onClick={() => setShowFilters((v) => !v)}
+                    aria-label="Toggle filters"
+                    aria-expanded={showFilters}
+                  >
+                    <Filter className="h-3.5 w-3.5" />
+                    <span className="hidden sm:inline">Filters</span>
+                    {activeFilters.length > 0 && (
+                      <span className="ml-0.5 rounded-full bg-primary text-primary-foreground text-[10px] font-semibold w-4 h-4 flex items-center justify-center">
+                        {activeFilters.length}
+                      </span>
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className="sm:hidden">Filters</TooltipContent>
+              </Tooltip>
               <Popover>
                 <PopoverTrigger asChild>
                   <Button variant="outline" size="sm" className="h-8" aria-label="Grid settings">

--- a/client/src/components/MobileBottomNav.tsx
+++ b/client/src/components/MobileBottomNav.tsx
@@ -1,44 +1,154 @@
+import { useState } from "react";
+import { MoreHorizontal } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { mobileBottomNavigation } from "@/components/navigation-items";
+import {
+  mobileBottomNavigation,
+  primaryNavigation,
+  managementNavigation,
+  type AppNavItem,
+} from "@/components/navigation-items";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 
 interface MobileBottomNavProps {
   activeItem: string;
   onNavigate: (url: string) => void;
 }
 
+const pinnedUrls = new Set(mobileBottomNavigation.map((i) => i.url));
+
+const morePages: AppNavItem[] = primaryNavigation.filter((i) => !pinnedUrls.has(i.url));
+
+const isMoreActive = (activeItem: string) =>
+  !pinnedUrls.has(activeItem) && activeItem !== "/login" && activeItem !== "/setup";
+
 export default function MobileBottomNav({
   activeItem,
   onNavigate,
 }: Readonly<MobileBottomNavProps>) {
-  return (
-    <nav
-      className="fixed inset-x-0 bottom-0 z-20 border-t border-border bg-background/95 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 backdrop-blur md:hidden"
-      aria-label="Primary"
-    >
-      <div className="grid grid-cols-5 gap-1">
-        {mobileBottomNavigation.map((item) => {
-          const isActive = activeItem === item.url;
+  const [moreOpen, setMoreOpen] = useState(false);
 
-          return (
-            <button
-              key={item.url}
-              type="button"
-              onClick={() => onNavigate(item.url)}
-              className={cn(
-                "flex min-h-14 flex-col items-center justify-center gap-1 rounded-xl px-1 py-2 text-[11px] font-medium transition-colors",
-                isActive
-                  ? "bg-primary text-primary-foreground shadow-sm"
-                  : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-              )}
-              aria-current={isActive ? "page" : undefined}
-              aria-label={item.title}
-            >
-              <item.icon className="h-4 w-4" aria-hidden="true" />
-              <span className="truncate">{item.title}</span>
-            </button>
-          );
-        })}
-      </div>
-    </nav>
+  const handleNavigate = (url: string) => {
+    setMoreOpen(false);
+    onNavigate(url);
+  };
+
+  const moreActive = isMoreActive(activeItem);
+
+  return (
+    <>
+      <nav
+        className="fixed inset-x-0 bottom-0 z-20 border-t border-border bg-background/95 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 backdrop-blur md:hidden"
+        aria-label="Primary"
+      >
+        <div className="grid grid-cols-5 gap-1">
+          {mobileBottomNavigation.map((item) => {
+            const isActive = activeItem === item.url;
+            return (
+              <button
+                key={item.url}
+                type="button"
+                onClick={() => onNavigate(item.url)}
+                className={cn(
+                  "flex min-h-14 flex-col items-center justify-center gap-1 rounded-xl px-1 py-2 text-[11px] font-medium transition-colors",
+                  isActive
+                    ? "bg-primary text-primary-foreground shadow-sm"
+                    : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                )}
+                aria-current={isActive ? "page" : undefined}
+                aria-label={item.title}
+              >
+                <item.icon className="h-4 w-4" aria-hidden="true" />
+                <span className="truncate">{item.title}</span>
+              </button>
+            );
+          })}
+
+          <button
+            type="button"
+            onClick={() => setMoreOpen(true)}
+            className={cn(
+              "flex min-h-14 flex-col items-center justify-center gap-1 rounded-xl px-1 py-2 text-[11px] font-medium transition-colors",
+              moreActive
+                ? "bg-primary text-primary-foreground shadow-sm"
+                : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            )}
+            aria-label="More navigation options"
+            aria-expanded={moreOpen}
+          >
+            <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
+            <span>More</span>
+          </button>
+        </div>
+      </nav>
+
+      <Sheet open={moreOpen} onOpenChange={setMoreOpen}>
+        <SheetContent
+          side="bottom"
+          className="max-h-[70svh] overflow-y-auto rounded-t-2xl pb-[calc(1rem+env(safe-area-inset-bottom))]"
+        >
+          <SheetHeader className="mb-4">
+            <SheetTitle className="text-left text-sm font-semibold">More</SheetTitle>
+          </SheetHeader>
+
+          <div className="space-y-4">
+            <section aria-label="Pages">
+              <p className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                Pages
+              </p>
+              <div className="grid grid-cols-1 gap-0.5">
+                {morePages.map((item) => {
+                  const isActive = activeItem === item.url;
+                  return (
+                    <button
+                      key={item.url}
+                      type="button"
+                      onClick={() => handleNavigate(item.url)}
+                      className={cn(
+                        "flex w-full items-center gap-3 rounded-xl px-3 py-3 text-sm font-medium transition-colors",
+                        isActive
+                          ? "bg-primary text-primary-foreground"
+                          : "text-foreground hover:bg-muted/60"
+                      )}
+                      aria-current={isActive ? "page" : undefined}
+                    >
+                      <item.icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                      {item.title}
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section aria-label="Management">
+              <p className="mb-1 px-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                Management
+              </p>
+              <div className="grid grid-cols-1 gap-0.5">
+                {managementNavigation.map((item) => {
+                  const isActive = activeItem === item.url;
+                  return (
+                    <button
+                      key={item.url}
+                      type="button"
+                      onClick={() => handleNavigate(item.url)}
+                      className={cn(
+                        "flex w-full items-center gap-3 rounded-xl px-3 py-3 text-sm font-medium transition-colors",
+                        isActive
+                          ? "bg-primary text-primary-foreground"
+                          : "text-foreground hover:bg-muted/60"
+                      )}
+                      aria-current={isActive ? "page" : undefined}
+                    >
+                      <item.icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                      {item.title}
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
   );
 }

--- a/client/src/components/PageHeader.tsx
+++ b/client/src/components/PageHeader.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface PageHeaderProps {
+  title: string;
+  description?: string;
+  /**
+   * Action buttons rendered in a column (full-width) on mobile and a row on
+   * desktop. Each button should include `className="h-10 justify-center sm:h-9"`
+   * to get a comfortable touch target on mobile and a compact size on desktop.
+   */
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+export default function PageHeader({ title, description, actions, className }: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between",
+        className
+      )}
+    >
+      <div className="min-w-0">
+        <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+        {description && <p className="mt-0.5 text-sm text-muted-foreground">{description}</p>}
+      </div>
+      {actions && <div className="flex flex-col gap-2 sm:flex-row sm:shrink-0">{actions}</div>}
+    </div>
+  );
+}

--- a/client/src/components/PageHeader.tsx
+++ b/client/src/components/PageHeader.tsx
@@ -13,7 +13,12 @@ interface PageHeaderProps {
   className?: string;
 }
 
-export default function PageHeader({ title, description, actions, className }: PageHeaderProps) {
+export default function PageHeader({
+  title,
+  description,
+  actions,
+  className,
+}: Readonly<PageHeaderProps>) {
   return (
     <div
       className={cn(

--- a/client/src/components/PageToolbar.tsx
+++ b/client/src/components/PageToolbar.tsx
@@ -29,7 +29,7 @@ interface PageToolbarProps {
   search?: string;
   onSearchChange?: (value: string) => void;
   searchPlaceholder?: string;
-  /** Content rendered on the left (filter pills, custom toggles). */
+  /** Content rendered in the filter row (filter pills, custom toggles). */
   filterPills?: React.ReactNode;
   /** Sort select. Rendered when sortOptions is non-empty. */
   sortValue?: string;
@@ -54,13 +54,14 @@ export default function PageToolbar({
 }: PageToolbarProps) {
   const hasSearch = onSearchChange !== undefined;
   const hasSort = Boolean(sortOptions?.length && onSortChange);
+  const hasRow2 = Boolean(filterPills || hasSort || actions);
 
   return (
-    <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-      {/* Left: search input + filter pills */}
-      <div className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:items-center">
+    <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+      {/* Row 1 on mobile: search (flex-1) + view controls */}
+      <div className="flex min-w-0 flex-1 items-center gap-2">
         {hasSearch && (
-          <div className="relative h-10 w-full min-w-0 sm:h-8 sm:min-w-[220px]">
+          <div className="relative h-10 flex-1 min-w-0 sm:h-8 sm:flex-initial sm:min-w-[220px]">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
             <Input
               type="text"
@@ -84,38 +85,56 @@ export default function PageToolbar({
             )}
           </div>
         )}
-        {filterPills && <div className="flex flex-wrap items-center gap-2">{filterPills}</div>}
-      </div>
-
-      {/* Right: sort + view controls + extra actions */}
-      <div className="flex w-full flex-wrap items-center gap-2 md:w-auto md:shrink-0 md:justify-end">
-        {hasSort && (
-          <div className="flex w-full items-center gap-1.5 sm:w-auto">
-            <span className="text-xs text-muted-foreground hidden sm:inline">Sort</span>
-            <Select value={sortValue} onValueChange={onSortChange}>
-              <SelectTrigger className="h-10 w-full text-sm sm:h-8 sm:w-[160px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {sortOptions?.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+        {/* View controls share row 1 on mobile; hidden on desktop (rendered in row 2 below) */}
+        {viewControls && (
+          <div className="shrink-0 md:hidden">
+            <ViewControlsToolbar
+              viewMode={viewControls.viewMode}
+              onViewModeChange={viewControls.onViewModeChange}
+              listDensity={viewControls.listDensity}
+              onListDensityChange={viewControls.onListDensityChange}
+            />
           </div>
         )}
-        {viewControls && (
-          <ViewControlsToolbar
-            viewMode={viewControls.viewMode}
-            onViewModeChange={viewControls.onViewModeChange}
-            listDensity={viewControls.listDensity}
-            onListDensityChange={viewControls.onListDensityChange}
-          />
-        )}
-        {actions}
       </div>
+
+      {/* Row 2 on mobile / right section on desktop: filter pills + sort + view controls + actions */}
+      {hasRow2 && (
+        <div className="flex w-full flex-wrap items-center gap-2 md:w-auto md:flex-nowrap md:shrink-0 md:justify-end">
+          {filterPills && (
+            <div className="flex flex-wrap items-center gap-1.5 shrink-0">{filterPills}</div>
+          )}
+          {hasSort && (
+            <div className="flex flex-1 items-center gap-1.5 md:flex-initial">
+              <span className="text-xs text-muted-foreground hidden sm:inline">Sort</span>
+              <Select value={sortValue} onValueChange={onSortChange}>
+                <SelectTrigger className="h-8 w-full text-sm md:w-[160px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {sortOptions?.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+          {/* View controls on desktop only (shown above in row 1 on mobile) */}
+          {viewControls && (
+            <div className="hidden md:contents">
+              <ViewControlsToolbar
+                viewMode={viewControls.viewMode}
+                onViewModeChange={viewControls.onViewModeChange}
+                listDensity={viewControls.listDensity}
+                onListDensityChange={viewControls.onListDensityChange}
+              />
+            </div>
+          )}
+          {actions}
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/StatusBadge.tsx
+++ b/client/src/components/StatusBadge.tsx
@@ -1,42 +1,60 @@
 import React from "react";
 import { Badge } from "@/components/ui/badge";
+import { Star, HardDrive, CheckCircle2, Loader2 } from "lucide-react";
 
 interface StatusBadgeProps {
   status: string;
 }
 
-const statusConfig = {
-  wanted: { label: "Wanted", variant: "destructive" as const, className: "" },
-  owned: { label: "Owned", variant: "secondary" as const, className: "" },
+type StatusEntry = {
+  label: string;
+  variant: "destructive" | "secondary" | "default";
+  className: string;
+  Icon: React.ComponentType<{ className?: string }> | null;
+};
+
+const statusConfig: Record<string, StatusEntry> = {
+  wanted: { label: "Wanted", variant: "destructive", className: "", Icon: Star },
+  owned: { label: "Owned", variant: "secondary", className: "", Icon: HardDrive },
   shelved: {
     label: "Shelved",
-    variant: "secondary" as const,
+    variant: "secondary",
     className: "bg-amber-700/80 hover:bg-amber-700 text-amber-100 border-amber-600",
+    Icon: null,
   },
-  completed: { label: "Completed", variant: "default" as const, className: "" },
+  completed: { label: "Completed", variant: "default", className: "", Icon: CheckCircle2 },
   downloading: {
     label: "Downloading",
-    variant: "secondary" as const,
+    variant: "secondary",
     className: "bg-purple-600 hover:bg-purple-700 text-white",
+    Icon: Loader2,
   },
 };
 
 export type GameStatus = keyof typeof statusConfig;
 
+export function getStatusLabel(status: string): string {
+  return statusConfig[status]?.label ?? status;
+}
+
 export default function StatusBadge({ status }: StatusBadgeProps) {
-  const config = statusConfig[status as keyof typeof statusConfig] || {
+  const config = statusConfig[status] ?? {
     label: status,
     variant: "secondary" as const,
     className: "",
+    Icon: null,
   };
+
+  const Icon = config.Icon;
 
   return (
     <Badge
       variant={config.variant}
       data-testid={`badge-status-${status}`}
-      className={`text-xs ${config.className || ""}`}
+      className={`text-xs gap-1 ${config.className}`}
     >
-      {config.label}
+      {Icon && <Icon className={`w-3 h-3 ${status === "downloading" ? "animate-spin" : ""}`} />}
+      <span className="hidden sm:inline">{config.label}</span>
     </Badge>
   );
 }

--- a/client/src/components/ViewControlsToolbar.tsx
+++ b/client/src/components/ViewControlsToolbar.tsx
@@ -23,23 +23,25 @@ export default function ViewControlsToolbar({
   return (
     <>
       {viewMode === "list" && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="outline" size="sm" className="h-8 gap-1.5" onClick={toggleDensity}>
-              {listDensity === "comfortable" ? (
-                <Rows3 className="h-3.5 w-3.5" />
-              ) : (
-                <Rows2 className="h-3.5 w-3.5" />
-              )}
-              <span className="sr-only sm:not-sr-only sm:inline-block">
-                {listDensity === "comfortable" ? "Comfortable" : "Compact"}
-              </span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            Switch to {listDensity === "comfortable" ? "compact" : "comfortable"}
-          </TooltipContent>
-        </Tooltip>
+        <span className="hidden sm:contents">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="outline" size="sm" className="h-8 gap-1.5" onClick={toggleDensity}>
+                {listDensity === "comfortable" ? (
+                  <Rows3 className="h-3.5 w-3.5" />
+                ) : (
+                  <Rows2 className="h-3.5 w-3.5" />
+                )}
+                <span className="sr-only sm:not-sr-only sm:inline-block">
+                  {listDensity === "comfortable" ? "Comfortable" : "Compact"}
+                </span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Switch to {listDensity === "comfortable" ? "compact" : "comfortable"}
+            </TooltipContent>
+          </Tooltip>
+        </span>
       )}
       <ToggleGroup
         type="single"

--- a/client/src/components/navigation-items.ts
+++ b/client/src/components/navigation-items.ts
@@ -46,7 +46,6 @@ export const mobileBottomNavigation: AppNavItem[] = [
   { title: "Discover", url: "/discover", icon: Compass },
   { title: "Downloads", url: "/downloads", icon: Download },
   { title: "Wishlist", url: "/wishlist", icon: Star },
-  { title: "Settings", url: "/settings", icon: Settings },
 ];
 
 const allNavigation: AppNavItem[] = [

--- a/client/src/hooks/use-mobile.tsx
+++ b/client/src/hooks/use-mobile.tsx
@@ -6,23 +6,29 @@ export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mql = globalThis.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const legacyMql = mql as MediaQueryList & {
+      addListener?: (listener: (event: MediaQueryListEvent) => void) => void;
+      removeListener?: (listener: (event: MediaQueryListEvent) => void) => void;
+    };
+    const addLegacyListener = legacyMql["addListener"];
+    const removeLegacyListener = legacyMql["removeListener"];
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT);
     };
 
     if (typeof mql.addEventListener === "function") {
       mql.addEventListener("change", onChange);
-    } else if (typeof mql.addListener === "function") {
-      mql.addListener(onChange);
+    } else if (typeof addLegacyListener === "function") {
+      addLegacyListener.call(legacyMql, onChange);
     }
 
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsMobile(globalThis.innerWidth < MOBILE_BREAKPOINT);
     return () => {
       if (typeof mql.removeEventListener === "function") {
         mql.removeEventListener("change", onChange);
-      } else if (typeof mql.removeListener === "function") {
-        mql.removeListener(onChange);
+      } else if (typeof removeLegacyListener === "function") {
+        removeLegacyListener.call(legacyMql, onChange);
       }
     };
   }, []);

--- a/client/src/hooks/use-mobile.tsx
+++ b/client/src/hooks/use-mobile.tsx
@@ -10,9 +10,21 @@ export function useIsMobile() {
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     };
-    mql.addEventListener("change", onChange);
+
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", onChange);
+    } else if (typeof mql.addListener === "function") {
+      mql.addListener(onChange);
+    }
+
     setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener("change", onChange);
+    return () => {
+      if (typeof mql.removeEventListener === "function") {
+        mql.removeEventListener("change", onChange);
+      } else if (typeof mql.removeListener === "function") {
+        mql.removeListener(onChange);
+      }
+    };
   }, []);
 
   return !!isMobile;

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -25,7 +25,10 @@ interface GamesByDate {
 }
 
 function formatDate(date: Date): string {
-  return date.toISOString().split("T")[0];
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
 }
 
 function getMonthName(month: number): string {
@@ -124,11 +127,10 @@ export default function CalendarPage() {
     const grouped: GamesByDate = {};
     wantedGames.forEach((game) => {
       if (game.releaseDate) {
-        const date = formatDate(new Date(game.releaseDate));
-        if (!grouped[date]) {
-          grouped[date] = [];
+        if (!grouped[game.releaseDate]) {
+          grouped[game.releaseDate] = [];
         }
-        grouped[date].push(game);
+        grouped[game.releaseDate].push(game);
       }
     });
     return grouped;
@@ -189,7 +191,7 @@ export default function CalendarPage() {
   }
 
   return (
-    <div className="h-full overflow-auto p-6">
+    <div className="h-full overflow-auto p-4 md:p-6">
       <div className="space-y-3 mb-6">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Release Calendar</h1>
@@ -366,42 +368,81 @@ function MonthView({
   const month = currentDate.getMonth();
   const days = getDaysInMonth(year, month);
   const weekDays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+  const [selectedDayKey, setSelectedDayKey] = useState<string | null>(null);
+
+  const handleCellClick = (dateKey: string, gamesOnDay: Game[]) => {
+    if (gamesOnDay.length === 0) {
+      setSelectedDayKey(null);
+      return;
+    }
+    setSelectedDayKey(selectedDayKey === dateKey ? null : dateKey);
+  };
+
+  const selectedGames = selectedDayKey ? (gamesByDate[selectedDayKey] ?? []) : [];
 
   return (
-    <div className="bg-card border rounded-lg p-4">
-      <div className="grid grid-cols-7 gap-2 mb-2">
+    <div className="bg-card border rounded-lg p-2 md:p-4">
+      <div className="grid grid-cols-7 gap-1 md:gap-2 mb-2">
         {weekDays.map((day) => (
-          <div key={day} className="text-center font-semibold text-sm text-muted-foreground py-2">
-            {day}
+          <div
+            key={day}
+            className="text-center font-semibold text-xs md:text-sm text-muted-foreground py-1 md:py-2"
+          >
+            <span className="md:hidden">{day[0]}</span>
+            <span className="hidden md:inline">{day}</span>
           </div>
         ))}
       </div>
-      <div className="grid grid-cols-7 gap-2">
+      <div className="grid grid-cols-7 gap-1 md:gap-2">
         {days.map((day, idx) => {
           const isCurrentMonth = day.getMonth() === month;
           const dateKey = formatDate(day);
           const gamesOnDay = gamesByDate[dateKey] || [];
           const isToday = formatDate(new Date()) === dateKey;
+          const isSelected = selectedDayKey === dateKey;
 
           return (
             <div
               key={idx}
+              onClick={() => handleCellClick(dateKey, gamesOnDay)}
               className={cn(
-                "min-h-[120px] border rounded-lg p-2",
+                "min-h-[48px] md:min-h-[120px] border rounded-lg p-1 md:p-2 transition-colors",
                 !isCurrentMonth && "bg-muted/30",
-                isToday && "border-primary border-2"
+                isToday && "border-primary border-2",
+                isSelected && "border-primary/60 bg-primary/5",
+                gamesOnDay.length > 0 ? "cursor-pointer" : "cursor-default"
               )}
             >
               <div
                 className={cn(
-                  "text-sm font-medium mb-2",
+                  "text-xs md:text-sm font-medium mb-0.5 md:mb-2",
                   !isCurrentMonth && "text-muted-foreground",
                   isToday && "text-primary font-bold"
                 )}
               >
                 {day.getDate()}
               </div>
-              <div className="space-y-1">
+              {/* Mobile: colored dots per game */}
+              {gamesOnDay.length > 0 && (
+                <div className="flex flex-wrap gap-0.5 md:hidden">
+                  {gamesOnDay.slice(0, 3).map((game) => (
+                    <div
+                      key={game.id}
+                      className={cn(
+                        "w-1.5 h-1.5 rounded-full",
+                        game.releaseStatus === "delayed" ? "bg-destructive" : "bg-primary"
+                      )}
+                    />
+                  ))}
+                  {gamesOnDay.length > 3 && (
+                    <span className="text-[9px] leading-none text-muted-foreground">
+                      +{gamesOnDay.length - 3}
+                    </span>
+                  )}
+                </div>
+              )}
+              {/* Desktop: full compact badges */}
+              <div className="hidden md:block space-y-1">
                 {gamesOnDay.map((game) => (
                   <GameBadge key={game.id} game={game} compact onClick={() => onGameClick(game)} />
                 ))}
@@ -410,6 +451,23 @@ function MonthView({
           );
         })}
       </div>
+      {/* Mobile day detail — shown below grid when a day with games is tapped */}
+      {selectedDayKey && selectedGames.length > 0 && (
+        <div className="mt-3 p-3 bg-muted/50 rounded-lg md:hidden">
+          <p className="text-xs font-semibold text-muted-foreground mb-2">
+            {new Date(selectedDayKey).toLocaleDateString(undefined, {
+              weekday: "long",
+              month: "long",
+              day: "numeric",
+            })}
+          </p>
+          <div className="space-y-2">
+            {selectedGames.map((game) => (
+              <GameBadge key={game.id} game={game} onClick={() => onGameClick(game)} />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -424,14 +482,67 @@ function WeekView({
   onGameClick: (game: Game) => void;
 }) {
   const weekDays = getWeekDays(new Date(currentDate));
+  const todayKey = formatDate(new Date());
 
   return (
     <div className="bg-card border rounded-lg p-4">
-      <div className="grid grid-cols-7 gap-4">
+      {/* Mobile: vertical list — one full-width row per day */}
+      <div className="space-y-2 md:hidden">
         {weekDays.map((day, idx) => {
           const dateKey = formatDate(day);
           const gamesOnDay = gamesByDate[dateKey] || [];
-          const isToday = formatDate(new Date()) === dateKey;
+          const isToday = todayKey === dateKey;
+          const dayName = day.toLocaleDateString(undefined, { weekday: "short" });
+          const monthName = day.toLocaleDateString(undefined, { month: "short" });
+
+          return (
+            <div
+              key={idx}
+              className={cn(
+                "flex gap-3 rounded-lg border p-3",
+                isToday ? "border-primary border-2" : "border-border",
+                gamesOnDay.length === 0 && "opacity-60"
+              )}
+            >
+              {/* Date column */}
+              <div className="flex w-12 shrink-0 flex-col items-center justify-center">
+                <span
+                  className={cn(
+                    "text-xs font-semibold uppercase tracking-wide",
+                    isToday ? "text-primary" : "text-muted-foreground"
+                  )}
+                >
+                  {dayName}
+                </span>
+                <span className={cn("text-xl font-bold leading-tight", isToday && "text-primary")}>
+                  {day.getDate()}
+                </span>
+                <span className="text-xs text-muted-foreground">{monthName}</span>
+              </div>
+              <div className="w-px shrink-0 bg-border" />
+              {/* Games column */}
+              <div className="flex min-w-0 flex-1 items-center">
+                {gamesOnDay.length > 0 ? (
+                  <div className="w-full space-y-2">
+                    {gamesOnDay.map((game) => (
+                      <GameBadge key={game.id} game={game} onClick={() => onGameClick(game)} />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">No releases</p>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Desktop: 7-column grid */}
+      <div className="hidden md:grid md:grid-cols-7 md:gap-4">
+        {weekDays.map((day, idx) => {
+          const dateKey = formatDate(day);
+          const gamesOnDay = gamesByDate[dateKey] || [];
+          const isToday = todayKey === dateKey;
           const dayName = day.toLocaleDateString(undefined, { weekday: "short" });
 
           return (

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -400,28 +400,25 @@ function MonthView({
         ))}
       </div>
       <div className="grid grid-cols-7 gap-1 md:gap-2">
-        {days.map((day, idx) => {
+        {days.map((day) => {
           const isCurrentMonth = day.getMonth() === month;
           const dateKey = formatDate(day);
           const gamesOnDay = gamesByDate[dateKey] || [];
           const isToday = todayKey === dateKey;
           const isSelected = selectedDayKey === dateKey;
+          const formattedDayLabel = day.toLocaleDateString(undefined, {
+            weekday: "long",
+            month: "long",
+            day: "numeric",
+          });
+          const releaseLabel =
+            gamesOnDay.length === 1 ? "1 release" : `${gamesOnDay.length} releases`;
           const mobileButtonLabel =
-            gamesOnDay.length > 0
-              ? `${day.toLocaleDateString(undefined, {
-                  weekday: "long",
-                  month: "long",
-                  day: "numeric",
-                })}, ${gamesOnDay.length} release${gamesOnDay.length === 1 ? "" : "s"}`
-              : day.toLocaleDateString(undefined, {
-                  weekday: "long",
-                  month: "long",
-                  day: "numeric",
-                });
+            gamesOnDay.length > 0 ? `${formattedDayLabel}, ${releaseLabel}` : formattedDayLabel;
 
           return (
             <div
-              key={idx}
+              key={dateKey}
               className={cn(
                 "min-h-[48px] md:min-h-[120px] border rounded-lg p-1 md:p-2 transition-colors",
                 !isCurrentMonth && "bg-muted/30",
@@ -518,7 +515,7 @@ function WeekView({
     <div className="bg-card border rounded-lg p-4">
       {/* Mobile: vertical list — one full-width row per day */}
       <div className="space-y-2 md:hidden">
-        {weekDays.map((day, idx) => {
+        {weekDays.map((day) => {
           const dateKey = formatDate(day);
           const gamesOnDay = gamesByDate[dateKey] || [];
           const isToday = todayKey === dateKey;
@@ -527,7 +524,7 @@ function WeekView({
 
           return (
             <div
-              key={idx}
+              key={dateKey}
               className={cn(
                 "flex gap-3 rounded-lg border p-3",
                 isToday ? "border-primary border-2" : "border-border",
@@ -569,7 +566,7 @@ function WeekView({
 
       {/* Desktop: 7-column grid */}
       <div className="hidden md:grid md:grid-cols-7 md:gap-4">
-        {weekDays.map((day, idx) => {
+        {weekDays.map((day) => {
           const dateKey = formatDate(day);
           const gamesOnDay = gamesByDate[dateKey] || [];
           const isToday = todayKey === dateKey;
@@ -577,7 +574,7 @@ function WeekView({
 
           return (
             <div
-              key={idx}
+              key={dateKey}
               className={cn("border rounded-lg p-3", isToday && "border-primary border-2")}
             >
               <div className="text-center mb-3">

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -406,49 +406,71 @@ function MonthView({
           const gamesOnDay = gamesByDate[dateKey] || [];
           const isToday = todayKey === dateKey;
           const isSelected = selectedDayKey === dateKey;
+          const mobileButtonLabel =
+            gamesOnDay.length > 0
+              ? `${day.toLocaleDateString(undefined, {
+                  weekday: "long",
+                  month: "long",
+                  day: "numeric",
+                })}, ${gamesOnDay.length} release${gamesOnDay.length === 1 ? "" : "s"}`
+              : day.toLocaleDateString(undefined, {
+                  weekday: "long",
+                  month: "long",
+                  day: "numeric",
+                });
 
           return (
             <div
               key={idx}
-              onClick={() => handleCellClick(dateKey, gamesOnDay)}
               className={cn(
                 "min-h-[48px] md:min-h-[120px] border rounded-lg p-1 md:p-2 transition-colors",
                 !isCurrentMonth && "bg-muted/30",
                 isToday && "border-primary border-2",
-                isSelected && "border-primary/60 bg-primary/5",
-                gamesOnDay.length > 0 ? "cursor-pointer" : "cursor-default"
+                isSelected && "border-primary/60 bg-primary/5"
               )}
             >
-              <div
+              <button
+                type="button"
+                onClick={() => handleCellClick(dateKey, gamesOnDay)}
                 className={cn(
-                  "text-xs md:text-sm font-medium mb-0.5 md:mb-2",
-                  !isCurrentMonth && "text-muted-foreground",
-                  isToday && "text-primary font-bold"
+                  "w-full text-left md:pointer-events-none",
+                  gamesOnDay.length > 0 ? "cursor-pointer" : "cursor-default"
                 )}
+                aria-label={mobileButtonLabel}
               >
-                {day.getDate()}
-              </div>
-              {/* Mobile: colored dots per game */}
-              {gamesOnDay.length > 0 && (
-                <div className="flex flex-wrap gap-0.5 md:hidden">
-                  {gamesOnDay.slice(0, 3).map((game) => (
-                    <div
-                      key={game.id}
-                      className={cn(
-                        "w-1.5 h-1.5 rounded-full",
-                        game.releaseStatus === "delayed" ? "bg-destructive" : "bg-primary"
-                      )}
-                    />
-                  ))}
-                  {gamesOnDay.length > 3 && (
-                    <span className="text-[9px] leading-none text-muted-foreground">
-                      +{gamesOnDay.length - 3}
-                    </span>
+                <div
+                  className={cn(
+                    "text-xs md:text-sm font-medium mb-0.5 md:mb-2",
+                    !isCurrentMonth && "text-muted-foreground",
+                    isToday && "text-primary font-bold"
                   )}
+                >
+                  {day.getDate()}
                 </div>
-              )}
-              {/* Desktop: full compact badges */}
-              <div className="hidden md:block space-y-1">
+                {/* Mobile: colored dots per game */}
+                {gamesOnDay.length > 0 && (
+                  <div className="flex flex-wrap gap-0.5 md:hidden">
+                    {gamesOnDay.slice(0, 3).map((game) => (
+                      <div
+                        key={game.id}
+                        className={cn(
+                          "w-1.5 h-1.5 rounded-full",
+                          game.releaseStatus === "delayed" ? "bg-destructive" : "bg-primary"
+                        )}
+                      />
+                    ))}
+                    {gamesOnDay.length > 3 && (
+                      <span className="text-[9px] leading-none text-muted-foreground">
+                        +{gamesOnDay.length - 3}
+                      </span>
+                    )}
+                  </div>
+                )}
+              </button>
+              <div
+                className="hidden md:block space-y-1"
+                aria-hidden={gamesOnDay.length === 0 ? undefined : true}
+              >
                 {gamesOnDay.map((game) => (
                   <GameBadge key={game.id} game={game} compact onClick={() => onGameClick(game)} />
                 ))}

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -24,7 +24,7 @@ interface GamesByDate {
   [date: string]: Game[];
 }
 
-function formatDate(date: Date): string {
+export function formatDate(date: Date): string {
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, "0");
   const d = String(date.getDate()).padStart(2, "0");
@@ -35,7 +35,7 @@ function getMonthName(month: number): string {
   return new Date(2000, month, 1).toLocaleDateString(undefined, { month: "long" });
 }
 
-function getWeekDays(date: Date): Date[] {
+export function getWeekDays(date: Date): Date[] {
   const day = date.getDay();
   const diff = date.getDate() - day + (day === 0 ? -6 : 1); // Adjust when day is sunday
   const monday = new Date(date);
@@ -47,7 +47,7 @@ function getWeekDays(date: Date): Date[] {
   });
 }
 
-function getDaysInMonth(year: number, month: number): Date[] {
+export function getDaysInMonth(year: number, month: number): Date[] {
   const firstDay = new Date(year, month, 1);
   const lastDay = new Date(year, month + 1, 0);
   const days: Date[] = [];
@@ -81,6 +81,7 @@ export default function CalendarPage() {
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
   const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const today = useMemo(() => new Date(), []);
 
   const handleGameClick = (game: Game) => {
     setSelectedGame(game);
@@ -256,6 +257,7 @@ export default function CalendarPage() {
                   currentDate={currentDate}
                   gamesByDate={gamesByDate}
                   onGameClick={handleGameClick}
+                  today={today}
                 />
               )}
               {viewMode === "week" && (
@@ -263,6 +265,7 @@ export default function CalendarPage() {
                   currentDate={currentDate}
                   gamesByDate={gamesByDate}
                   onGameClick={handleGameClick}
+                  today={today}
                 />
               )}
             </>
@@ -359,16 +362,19 @@ function MonthView({
   currentDate,
   gamesByDate,
   onGameClick,
+  today,
 }: {
   currentDate: Date;
   gamesByDate: GamesByDate;
   onGameClick: (game: Game) => void;
+  today: Date;
 }) {
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
   const days = getDaysInMonth(year, month);
   const weekDays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
   const [selectedDayKey, setSelectedDayKey] = useState<string | null>(null);
+  const todayKey = formatDate(today);
 
   const handleCellClick = (dateKey: string, gamesOnDay: Game[]) => {
     if (gamesOnDay.length === 0) {
@@ -398,7 +404,7 @@ function MonthView({
           const isCurrentMonth = day.getMonth() === month;
           const dateKey = formatDate(day);
           const gamesOnDay = gamesByDate[dateKey] || [];
-          const isToday = formatDate(new Date()) === dateKey;
+          const isToday = todayKey === dateKey;
           const isSelected = selectedDayKey === dateKey;
 
           return (
@@ -476,13 +482,15 @@ function WeekView({
   currentDate,
   gamesByDate,
   onGameClick,
+  today,
 }: {
   currentDate: Date;
   gamesByDate: GamesByDate;
   onGameClick: (game: Game) => void;
+  today: Date;
 }) {
   const weekDays = getWeekDays(new Date(currentDate));
-  const todayKey = formatDate(new Date());
+  const todayKey = formatDate(today);
 
   return (
     <div className="bg-card border rounded-lg p-4">

--- a/client/src/pages/downloaders.tsx
+++ b/client/src/pages/downloaders.tsx
@@ -6,6 +6,7 @@ import { Plus, Edit, Trash2, Check, X, Activity } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import {
   Dialog,
@@ -39,6 +40,7 @@ import { insertDownloaderSchema, type Downloader, type InsertDownloader } from "
 import { isUsenetDownloaderType } from "@shared/downloader-types";
 import { useToast } from "@/hooks/use-toast";
 import { getDownloadTypeColor } from "@/lib/downloads-utils";
+import PageHeader from "@/components/PageHeader";
 
 const downloaderTypes = [
   { value: "transmission", label: "Transmission", protocol: "torrent" },
@@ -406,30 +408,55 @@ export default function DownloadersPage() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
-        <div className="flex items-center space-x-2">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-          <span>Loading downloaders...</span>
+      <div className="h-full overflow-auto p-4 md:p-6">
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1.5">
+            <Skeleton className="h-7 w-40" />
+            <Skeleton className="h-4 w-72" />
+          </div>
+          <Skeleton className="h-10 sm:h-9 sm:w-36" />
         </div>
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="mb-4 rounded-lg border bg-card p-4 md:p-6">
+            <div className="flex justify-between items-start gap-3">
+              <div className="space-y-2 flex-1">
+                <Skeleton className="h-5 w-32" />
+                <div className="flex flex-wrap gap-2">
+                  <Skeleton className="h-5 w-24" />
+                  <Skeleton className="h-5 w-20" />
+                  <Skeleton className="h-5 w-16" />
+                  <Skeleton className="h-5 w-20" />
+                </div>
+              </div>
+              <div className="flex gap-1.5">
+                <Skeleton className="h-11 w-11 md:h-9 md:w-9" />
+                <Skeleton className="h-11 w-11 md:h-9 md:w-9" />
+                <Skeleton className="h-11 w-11 md:h-9 md:w-9" />
+                <Skeleton className="h-11 w-11 md:h-9 md:w-9" />
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     );
   }
 
   return (
-    <div className="h-full overflow-auto p-6">
-      <div className="flex justify-between items-center mb-6">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Downloaders</h1>
-          <p className="text-muted-foreground text-sm mt-0.5">
-            Manage download clients for automated downloads. Downloads are sent to enabled clients
-            in priority order (lowest number first), with automatic fallback if a client fails.
-          </p>
-        </div>
-        <Button onClick={handleAdd} data-testid="button-add-downloader">
-          <Plus className="h-4 w-4 mr-2" />
-          Add Downloader
-        </Button>
-      </div>
+    <div className="h-full overflow-auto p-4 md:p-6">
+      <PageHeader
+        title="Downloaders"
+        description="Manage download clients for automated downloads. Downloads are sent to enabled clients in priority order (lowest number first), with automatic fallback if a client fails."
+        actions={
+          <Button
+            className="h-10 justify-center sm:h-9"
+            onClick={handleAdd}
+            data-testid="button-add-downloader"
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Add Downloader
+          </Button>
+        }
+      />
 
       <div className="grid gap-4">
         {sortedActiveDownloaders.length > 0 ? (
@@ -439,45 +466,18 @@ export default function DownloadersPage() {
               className={cn(!downloader.enabled && "bg-muted/30")}
               data-testid={`card-downloader-${downloader.id}`}
             >
-              <CardHeader>
-                <div className="flex justify-between items-start">
-                  <div className="flex items-center space-x-3">
-                    <CardTitle
-                      className={cn("text-lg", !downloader.enabled && "text-muted-foreground")}
-                    >
-                      {downloader.name}
-                    </CardTitle>
-                    <Badge variant="outline" className="capitalize">
-                      {downloader.type}
-                    </Badge>
-                    <Badge
-                      className={`text-xs border-none ${getDownloadTypeColor(isUsenetDownloader(downloader.type) ? "usenet" : "torrent")}`}
-                    >
-                      {isUsenetDownloader(downloader.type) ? "USENET" : "TORRENT"}
-                    </Badge>
-                    <Badge
-                      variant={downloader.enabled ? "default" : "secondary"}
-                      data-testid={`status-downloader-${downloader.id}`}
-                    >
-                      {downloader.enabled ? (
-                        <>
-                          <Check className="h-3 w-3 mr-1" />
-                          Enabled
-                        </>
-                      ) : (
-                        <>
-                          <X className="h-3 w-3 mr-1" />
-                          Disabled
-                        </>
-                      )}
-                    </Badge>
-                    <PriorityControl
-                      id={downloader.id}
-                      priority={downloader.priority}
-                      onSave={(id, priority) => updatePriorityMutation.mutate({ id, priority })}
-                    />
-                  </div>
-                  <div className="flex items-center space-x-2">
+              <CardHeader className="space-y-2">
+                {/* Row 1: name + action buttons */}
+                <div className="flex items-center justify-between gap-3">
+                  <CardTitle
+                    className={cn(
+                      "min-w-0 truncate text-base md:text-lg",
+                      !downloader.enabled && "text-muted-foreground"
+                    )}
+                  >
+                    {downloader.name}
+                  </CardTitle>
+                  <div className="flex shrink-0 items-center gap-1.5">
                     <Button
                       variant="outline"
                       size="icon"
@@ -485,6 +485,7 @@ export default function DownloadersPage() {
                       disabled={testingDownloaderId === downloader.id}
                       title="Test connection"
                       aria-label={`Test connection for ${downloader.name}`}
+                      className="h-11 w-11 md:h-9 md:w-9"
                       data-testid={`button-test-downloader-${downloader.id}`}
                     >
                       <Activity className="h-4 w-4" />
@@ -501,6 +502,7 @@ export default function DownloadersPage() {
                       size="icon"
                       onClick={() => handleEdit(downloader)}
                       aria-label={`Edit ${downloader.name}`}
+                      className="h-11 w-11 md:h-9 md:w-9"
                       data-testid={`button-edit-downloader-${downloader.id}`}
                     >
                       <Edit className="h-4 w-4" />
@@ -510,15 +512,54 @@ export default function DownloadersPage() {
                       size="icon"
                       onClick={() => deleteMutation.mutate(downloader.id)}
                       aria-label={`Delete ${downloader.name}`}
+                      className="h-11 w-11 md:h-9 md:w-9"
                       data-testid={`button-delete-downloader-${downloader.id}`}
                     >
                       <Trash2 className="h-4 w-4" />
                     </Button>
                   </div>
                 </div>
-                <CardDescription className={cn(!downloader.enabled && "text-muted-foreground")}>
+                {/* Row 2: type / protocol / status / priority */}
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <Badge variant="outline" className="capitalize">
+                    {downloader.type}
+                  </Badge>
+                  <Badge
+                    className={`text-xs border-none ${getDownloadTypeColor(isUsenetDownloader(downloader.type) ? "usenet" : "torrent")}`}
+                  >
+                    {isUsenetDownloader(downloader.type) ? "USENET" : "TORRENT"}
+                  </Badge>
+                  <Badge
+                    variant={downloader.enabled ? "default" : "secondary"}
+                    data-testid={`status-downloader-${downloader.id}`}
+                  >
+                    {downloader.enabled ? (
+                      <>
+                        <Check className="h-3 w-3 mr-1" />
+                        Enabled
+                      </>
+                    ) : (
+                      <>
+                        <X className="h-3 w-3 mr-1" />
+                        Disabled
+                      </>
+                    )}
+                  </Badge>
+                  <PriorityControl
+                    id={downloader.id}
+                    priority={downloader.priority}
+                    onSave={(id, priority) => updatePriorityMutation.mutate({ id, priority })}
+                  />
+                </div>
+                {/* Row 3: URL */}
+                <p
+                  className={cn(
+                    "truncate text-sm text-muted-foreground",
+                    !downloader.enabled && "opacity-60"
+                  )}
+                >
                   {downloader.url}
-                </CardDescription>
+                </p>
               </CardHeader>
               <CardContent>
                 <div className="flex flex-wrap gap-2">
@@ -553,7 +594,7 @@ export default function DownloadersPage() {
       </div>
 
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <DialogContent className="sm:max-w-md max-h-[90vh] flex flex-col">
+        <DialogContent className="w-full md:max-w-md max-h-[90vh] flex flex-col">
           <DialogHeader>
             <DialogTitle>{editingDownloader ? "Edit Downloader" : "Add Downloader"}</DialogTitle>
             <DialogDescription>
@@ -1091,7 +1132,7 @@ export default function DownloadersPage() {
                   </div>
                 )}
               </div>
-              <div className="flex justify-end space-x-2 pt-2 border-t">
+              <div className="flex flex-wrap justify-end gap-2 pt-2 border-t">
                 <Button
                   type="button"
                   variant="outline"

--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -37,12 +37,16 @@ import {
   Link2,
   Search,
   X,
+  ArrowUp,
+  CheckCircle2,
+  AlertCircle,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -360,17 +364,49 @@ export default function Downloads() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
-        <div className="flex items-center space-x-2" data-testid="loading-downloads">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-          <span data-testid="text-loading-downloads">Loading downloads...</span>
+      <div className="h-full overflow-auto p-4 md:p-6" data-testid="loading-downloads">
+        {/* Header */}
+        <div className="flex justify-between items-center mb-6">
+          <div className="space-y-1.5">
+            <Skeleton className="h-7 w-36" />
+            <Skeleton className="h-4 w-56" />
+          </div>
+          <Skeleton className="h-8 w-8 md:w-24" />
         </div>
+        {/* Filter row */}
+        <div className="flex gap-3 mb-6">
+          <Skeleton className="h-10 md:h-8 w-full md:w-48" />
+          <Skeleton className="h-8 w-48 hidden md:block" />
+        </div>
+        {/* Download cards */}
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="mb-4 rounded-lg border bg-card p-4 md:p-6">
+            <div className="flex justify-between items-start mb-4">
+              <div className="flex-1 space-y-2 mr-4">
+                <Skeleton className="h-5 w-3/4" />
+                <div className="flex flex-wrap gap-2">
+                  <Skeleton className="h-5 w-20" />
+                  <Skeleton className="h-5 w-24" />
+                  <Skeleton className="h-5 w-16" />
+                </div>
+              </div>
+              <Skeleton className="h-8 w-8 shrink-0" />
+            </div>
+            <div className="space-y-1.5">
+              <div className="flex justify-between">
+                <Skeleton className="h-3.5 w-14" />
+                <Skeleton className="h-3.5 w-10" />
+              </div>
+              <Skeleton className="h-2 w-full" />
+            </div>
+          </div>
+        ))}
       </div>
     );
   }
 
   return (
-    <div className="h-full overflow-auto p-6">
+    <div className="h-full overflow-auto p-4 md:p-6">
       <div className="flex justify-between items-center mb-6">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Downloads</h1>
@@ -378,19 +414,25 @@ export default function Downloads() {
             Monitor and manage active downloads
           </p>
         </div>
-        <Button variant="outline" size="sm" onClick={() => refetch()} data-testid="button-refresh">
-          <RefreshCw className="h-4 w-4 mr-2" />
-          Refresh
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => refetch()}
+          data-testid="button-refresh"
+          aria-label="Refresh downloads"
+        >
+          <RefreshCw className="h-4 w-4 md:mr-2" />
+          <span className="hidden md:inline">Refresh</span>
         </Button>
       </div>
 
       {/* Per-downloader summary */}
       {downloaderSummaries.length > 0 && (
-        <div className="flex flex-wrap gap-3 mb-6">
+        <div className="flex gap-3 mb-6 overflow-x-auto pb-1 md:flex-wrap md:pb-0">
           {downloaderSummaries.map((dl) => (
             <div
               key={dl.name}
-              className="flex items-center gap-3 px-4 py-2 rounded-lg border bg-card text-sm"
+              className="flex items-center gap-3 px-4 py-2 rounded-lg border bg-card text-sm shrink-0"
             >
               <span className="font-medium shrink-0">{dl.name}</span>
               <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
@@ -412,15 +454,15 @@ export default function Downloads() {
       )}
 
       {/* Filter row */}
-      <div className="flex flex-wrap items-center gap-6 mb-6">
-        <div className="relative">
+      <div className="flex flex-col gap-2 md:flex-row md:flex-wrap md:items-center md:gap-6 mb-6">
+        <div className="relative w-full md:w-auto">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
           <Input
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Filter downloads..."
-            className="pl-9 h-8 w-48 text-sm"
+            className="pl-9 h-10 md:h-8 w-full md:w-48 text-sm"
             aria-label="Filter downloads"
           />
           {searchQuery && (
@@ -434,8 +476,8 @@ export default function Downloads() {
             </button>
           )}
         </div>
-        <div className="flex items-center gap-3">
-          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider shrink-0">
+        <div className="flex items-center gap-2 overflow-x-auto pb-1 md:pb-0">
+          <span className="hidden md:block text-xs font-medium text-muted-foreground uppercase tracking-wider shrink-0">
             Status
           </span>
           <Tabs
@@ -447,80 +489,103 @@ export default function Downloads() {
               <TabsTrigger value="all" data-testid="filter-all">
                 All
               </TabsTrigger>
-              <TabsTrigger value="downloading" data-testid="filter-downloading">
-                Downloading
-              </TabsTrigger>
-              <TabsTrigger value="seeding" data-testid="filter-seeding">
-                Seeding
-              </TabsTrigger>
-              <TabsTrigger value="completed" data-testid="filter-completed">
-                Completed
-              </TabsTrigger>
-              <TabsTrigger value="paused" data-testid="filter-paused">
-                Paused
-              </TabsTrigger>
-              <TabsTrigger value="error" data-testid="filter-error">
-                Error
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-        </div>
-
-        <div className="flex items-center gap-3">
-          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider shrink-0">
-            Protocol
-          </span>
-          <Tabs
-            value={typeFilter}
-            onValueChange={(value) => setTypeFilter(value as DownloadType | "all")}
-            aria-label="Filter downloads by protocol"
-          >
-            <TabsList>
-              <TabsTrigger value="all">All</TabsTrigger>
-              <TabsTrigger value="torrent" className="flex items-center gap-2">
-                <Download className="h-3 w-3" /> Torrents
-              </TabsTrigger>
-              <TabsTrigger value="usenet" className="flex items-center gap-2">
-                <Newspaper className="h-3 w-3" /> Usenet
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-        </div>
-
-        <div className="flex items-center gap-3">
-          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider shrink-0">
-            Source
-          </span>
-          <Tabs
-            value={questarrFilter}
-            onValueChange={(value) => setQuestarrFilter(value as "all" | "questarr")}
-            aria-label="Filter downloads by source"
-          >
-            <TabsList>
-              <TabsTrigger value="all" data-testid="filter-source-all">
-                All
+              <TabsTrigger
+                value="downloading"
+                className="flex items-center gap-1"
+                data-testid="filter-downloading"
+              >
+                <Download className="h-3 w-3" />
+                <span className="md:hidden">DL</span>
+                <span className="hidden md:inline">Downloading</span>
               </TabsTrigger>
               <TabsTrigger
-                value="questarr"
-                className="flex items-center gap-2"
-                data-testid="filter-source-questarr"
+                value="seeding"
+                className="flex items-center gap-1"
+                data-testid="filter-seeding"
               >
-                <Download className="h-3 w-3" /> Questarr only
+                <ArrowUp className="h-3 w-3" />
+                <span className="md:hidden">Seed</span>
+                <span className="hidden md:inline">Seeding</span>
+              </TabsTrigger>
+              <TabsTrigger
+                value="completed"
+                className="flex items-center gap-1"
+                data-testid="filter-completed"
+              >
+                <CheckCircle2 className="h-3 w-3" />
+                <span className="md:hidden">Done</span>
+                <span className="hidden md:inline">Completed</span>
+              </TabsTrigger>
+              <TabsTrigger
+                value="paused"
+                className="flex items-center gap-1"
+                data-testid="filter-paused"
+              >
+                <Pause className="h-3 w-3" />
+                <span className="hidden md:inline">Paused</span>
+              </TabsTrigger>
+              <TabsTrigger
+                value="error"
+                className="flex items-center gap-1"
+                data-testid="filter-error"
+              >
+                <AlertCircle className="h-3 w-3" />
+                <span className="hidden md:inline">Error</span>
               </TabsTrigger>
             </TabsList>
           </Tabs>
         </div>
 
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setBatchModalOpen(true)}
-          className="ml-auto flex items-center gap-2"
-          aria-label="Scan unlinked downloads"
-        >
-          <ScanLine className="h-4 w-4" />
-          Scan Unlinked
-        </Button>
+        <div className="flex flex-wrap items-center gap-2 md:contents">
+          <div className="flex items-center gap-2">
+            <span className="hidden md:inline text-xs font-medium text-muted-foreground uppercase tracking-wider shrink-0">
+              Protocol
+            </span>
+            <Tabs
+              value={typeFilter}
+              onValueChange={(value) => setTypeFilter(value as DownloadType | "all")}
+              aria-label="Filter downloads by protocol"
+            >
+              <TabsList>
+                <TabsTrigger value="all">All</TabsTrigger>
+                <TabsTrigger value="torrent">
+                  <span className="md:hidden">Tor</span>
+                  <span className="hidden md:inline">Torrents</span>
+                </TabsTrigger>
+                <TabsTrigger value="usenet">
+                  <span className="md:hidden">NZB</span>
+                  <span className="hidden md:inline">Usenet</span>
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
+
+          <Button
+            variant={questarrFilter === "questarr" ? "default" : "outline"}
+            size="sm"
+            className="flex items-center gap-1.5 h-10 md:h-8"
+            onClick={() => setQuestarrFilter((v) => (v === "questarr" ? "all" : "questarr"))}
+            aria-label={
+              questarrFilter === "questarr" ? "Show all downloads" : "Show Questarr downloads only"
+            }
+            aria-pressed={questarrFilter === "questarr"}
+            data-testid="filter-source-questarr"
+          >
+            <Download className="h-3 w-3" />
+            Questarr only
+          </Button>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setBatchModalOpen(true)}
+            className="hidden sm:flex items-center gap-2 sm:ml-auto"
+            aria-label="Scan unlinked downloads"
+          >
+            <ScanLine className="h-4 w-4" />
+            Scan Unlinked
+          </Button>
+        </div>
       </div>
 
       {/* Category filter banner */}
@@ -549,9 +614,42 @@ export default function Downloads() {
               <CardHeader>
                 <div className="flex justify-between items-start">
                   <div className="flex-1">
-                    <CardTitle className="text-lg leading-tight">{download.name}</CardTitle>
+                    <CardTitle className="text-base sm:text-lg leading-tight line-clamp-2 sm:line-clamp-none">
+                      {download.name}
+                    </CardTitle>
                     <CardDescription className="mt-2">
-                      <div className="flex flex-wrap gap-2 items-center">
+                      {/* Mobile: status + type + the most relevant active metric */}
+                      <div className="flex flex-wrap gap-1.5 sm:hidden">
+                        <Badge
+                          variant={getStatusBadgeVariant(download.status)}
+                          className="capitalize"
+                          aria-label={`Status: ${download.status}`}
+                        >
+                          {download.status}
+                        </Badge>
+                        <Badge
+                          className={`text-xs border-none ${getDownloadTypeColor(download.downloadType || "torrent")}`}
+                        >
+                          {download.downloadType === "usenet" ? "NZB" : "Torrent"}
+                        </Badge>
+                        {shouldShowSpeedBadge(download.downloadSpeed) && (
+                          <Badge variant="outline">↓ {formatSpeed(download.downloadSpeed!)}</Badge>
+                        )}
+                        {shouldShowETABadge(download.eta) && (
+                          <Badge variant="outline">{formatETA(download.eta!)}</Badge>
+                        )}
+                        {!shouldShowSpeedBadge(download.downloadSpeed) &&
+                          shouldShowSizeBadge(download.size) && (
+                            <Badge variant="outline">{formatBytes(download.size!)}</Badge>
+                          )}
+                        {!shouldShowSpeedBadge(download.downloadSpeed) &&
+                          shouldShowRatioBadge(download.ratio) &&
+                          shouldShowTorrentMetrics(download) && (
+                            <Badge variant="outline">{download.ratio?.toFixed(2)}</Badge>
+                          )}
+                      </div>
+                      {/* Desktop: full badge list */}
+                      <div className="hidden sm:flex flex-wrap gap-2 items-center">
                         <Badge
                           variant={getStatusBadgeVariant(download.status)}
                           className="capitalize"
@@ -686,7 +784,7 @@ export default function Downloads() {
                       </div>
                     </CardDescription>
                   </div>
-                  <div className="flex items-center space-x-2 ml-4">
+                  <div className="flex items-center space-x-2 ml-4 shrink-0">
                     {ACTIVE_DOWNLOAD_STATUSES.includes(download.status) && (
                       <>
                         {download.status === "paused" ? (

--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -621,6 +621,24 @@ export default function Downloads() {
                     <CardDescription className="mt-2">
                       {/* Mobile: status + type + the most relevant active metric */}
                       <div className="flex flex-wrap gap-1.5 sm:hidden">
+                        {download.downloadSpeed !== undefined &&
+                          shouldShowSpeedBadge(download.downloadSpeed) && (
+                            <Badge variant="outline">↓ {formatSpeed(download.downloadSpeed)}</Badge>
+                          )}
+                        {download.eta !== undefined && shouldShowETABadge(download.eta) && (
+                          <Badge variant="outline">{formatETA(download.eta)}</Badge>
+                        )}
+                        {!shouldShowSpeedBadge(download.downloadSpeed) &&
+                          download.size !== undefined &&
+                          shouldShowSizeBadge(download.size) && (
+                            <Badge variant="outline">{formatBytes(download.size)}</Badge>
+                          )}
+                        {!shouldShowSpeedBadge(download.downloadSpeed) &&
+                          download.ratio !== undefined &&
+                          shouldShowRatioBadge(download.ratio) &&
+                          shouldShowTorrentMetrics(download) && (
+                            <Badge variant="outline">{download.ratio.toFixed(2)}</Badge>
+                          )}
                         <Badge
                           variant={getStatusBadgeVariant(download.status)}
                           className="capitalize"
@@ -633,21 +651,6 @@ export default function Downloads() {
                         >
                           {download.downloadType === "usenet" ? "NZB" : "Torrent"}
                         </Badge>
-                        {shouldShowSpeedBadge(download.downloadSpeed) && (
-                          <Badge variant="outline">↓ {formatSpeed(download.downloadSpeed!)}</Badge>
-                        )}
-                        {shouldShowETABadge(download.eta) && (
-                          <Badge variant="outline">{formatETA(download.eta!)}</Badge>
-                        )}
-                        {!shouldShowSpeedBadge(download.downloadSpeed) &&
-                          shouldShowSizeBadge(download.size) && (
-                            <Badge variant="outline">{formatBytes(download.size!)}</Badge>
-                          )}
-                        {!shouldShowSpeedBadge(download.downloadSpeed) &&
-                          shouldShowRatioBadge(download.ratio) &&
-                          shouldShowTorrentMetrics(download) && (
-                            <Badge variant="outline">{download.ratio?.toFixed(2)}</Badge>
-                          )}
                       </div>
                       {/* Desktop: full badge list */}
                       <div className="hidden sm:flex flex-wrap gap-2 items-center">

--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -579,11 +579,12 @@ export default function Downloads() {
             variant="outline"
             size="sm"
             onClick={() => setBatchModalOpen(true)}
-            className="hidden sm:flex items-center gap-2 sm:ml-auto"
+            className="ml-auto flex items-center gap-2"
             aria-label="Scan unlinked downloads"
           >
             <ScanLine className="h-4 w-4" />
-            Scan Unlinked
+            <span className="sm:hidden">Scan</span>
+            <span className="hidden sm:inline">Scan Unlinked</span>
           </Button>
         </div>
       </div>

--- a/client/src/pages/indexers.tsx
+++ b/client/src/pages/indexers.tsx
@@ -7,6 +7,7 @@ import { Plus, Edit, Trash2, Check, X, Activity, RefreshCw } from "lucide-react"
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
 import {
   Dialog,
@@ -38,6 +39,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { insertIndexerSchema, type Indexer, type InsertIndexer } from "@shared/schema";
 import { useToast } from "@/hooks/use-toast";
 import { MultiSelect, type MultiSelectOption } from "@/components/ui/multi-select";
+import PageHeader from "@/components/PageHeader";
 
 function PriorityControl({
   id,
@@ -421,44 +423,68 @@ export default function IndexersPage() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
-        <div className="flex items-center space-x-2">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-          <span>Loading indexers...</span>
+      <div className="h-full overflow-auto p-4 sm:p-6">
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1.5">
+            <Skeleton className="h-7 w-32" />
+            <Skeleton className="h-4 w-64" />
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Skeleton className="h-10 sm:h-9 sm:w-36" />
+            <Skeleton className="h-10 sm:h-9 sm:w-32" />
+          </div>
         </div>
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="mb-4 rounded-lg border bg-card p-4 sm:p-6">
+            <div className="flex justify-between items-start gap-3">
+              <div className="space-y-2 flex-1">
+                <Skeleton className="h-5 w-40" />
+                <div className="flex flex-wrap gap-2">
+                  <Skeleton className="h-5 w-24" />
+                  <Skeleton className="h-5 w-20" />
+                  <Skeleton className="h-5 w-16" />
+                </div>
+              </div>
+              <div className="flex gap-1.5">
+                <Skeleton className="h-9 w-9" />
+                <Skeleton className="h-9 w-9" />
+                <Skeleton className="h-9 w-9" />
+                <Skeleton className="h-9 w-9" />
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     );
   }
 
   return (
     <div className="h-full overflow-auto p-4 sm:p-6">
-      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Indexers</h1>
-          <p className="text-muted-foreground text-sm mt-0.5">
-            Manage Torznab and Newznab indexers for game discovery
-          </p>
-        </div>
-        <div className="flex flex-col gap-2 sm:flex-row">
-          <Button
-            variant="outline"
-            className="h-10 justify-center sm:h-9"
-            onClick={() => setIsProwlarrDialogOpen(true)}
-            data-testid="button-sync-prowlarr"
-          >
-            <RefreshCw className="h-4 w-4 mr-2" />
-            Sync Prowlarr
-          </Button>
-          <Button
-            className="h-10 justify-center sm:h-9"
-            onClick={handleAdd}
-            data-testid="button-add-indexer"
-          >
-            <Plus className="h-4 w-4 mr-2" />
-            Add Indexer
-          </Button>
-        </div>
-      </div>
+      <PageHeader
+        title="Indexers"
+        description="Manage Torznab and Newznab indexers for game discovery"
+        actions={
+          <>
+            <Button
+              variant="outline"
+              className="h-10 justify-center sm:h-9"
+              onClick={() => setIsProwlarrDialogOpen(true)}
+              data-testid="button-sync-prowlarr"
+            >
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Sync Prowlarr
+            </Button>
+            <Button
+              className="h-10 justify-center sm:h-9"
+              onClick={handleAdd}
+              data-testid="button-add-indexer"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Add Indexer
+            </Button>
+          </>
+        }
+      />
 
       <div className="grid gap-4">
         {sortedIndexers.length > 0 ? (

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -735,7 +735,7 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="h-full overflow-auto p-6">
+    <div className="h-full overflow-auto p-4 pb-20 sm:p-6 md:pb-6">
       <div className="mb-6">
         <h1 className="text-2xl font-bold tracking-tight">Settings</h1>
         <p className="text-muted-foreground text-sm mt-0.5">
@@ -758,7 +758,7 @@ export default function SettingsPage() {
         )}
 
         <Tabs defaultValue="general" className="w-full">
-          <TabsList className="mb-8 flex w-full flex-nowrap overflow-x-auto [&>*]:shrink-0">
+          <TabsList className="mb-4 sm:mb-8 flex w-full flex-nowrap overflow-x-auto [&>*]:shrink-0">
             <TabsTrigger value="general">General</TabsTrigger>
             <TabsTrigger value="rules">Rules</TabsTrigger>
             <TabsTrigger value="notifications">Notifications</TabsTrigger>
@@ -873,7 +873,7 @@ export default function SettingsPage() {
                     value={preferredPlatform || "__none__"}
                     onValueChange={(v) => setPreferredPlatform(v === "__none__" ? "" : v)}
                   >
-                    <SelectTrigger id="preferred-platform" className="w-48">
+                    <SelectTrigger id="preferred-platform" className="w-full sm:w-48">
                       <SelectValue placeholder="No preference" />
                     </SelectTrigger>
                     <SelectContent>
@@ -997,7 +997,7 @@ export default function SettingsPage() {
                     is set.
                   </p>
                 </div>
-                <div className="flex gap-2">
+                <div className="flex flex-col sm:flex-row gap-2">
                   <Button
                     onClick={() =>
                       updateAppriseMutation.mutate({
@@ -1034,13 +1034,13 @@ export default function SettingsPage() {
                   <table className="w-full">
                     <thead>
                       <tr className="border-b">
-                        <th className="text-left text-sm font-medium text-muted-foreground pb-3 pr-4">
+                        <th className="text-left text-sm font-medium text-muted-foreground pb-3 pr-2 sm:pr-4">
                           Event
                         </th>
-                        <th className="text-center text-sm font-medium text-muted-foreground pb-3 px-6 w-24">
+                        <th className="text-center text-sm font-medium text-muted-foreground pb-3 px-3 sm:px-6 w-14 sm:w-24">
                           In-App
                         </th>
-                        <th className="text-center text-sm font-medium text-muted-foreground pb-3 pl-6 w-24">
+                        <th className="text-center text-sm font-medium text-muted-foreground pb-3 pl-3 sm:pl-6 w-14 sm:w-24">
                           Apprise
                         </th>
                       </tr>
@@ -1053,8 +1053,8 @@ export default function SettingsPage() {
                             key={key}
                             className={`border-b last:border-0 ${isGroupStart ? "border-t-2 border-t-muted" : ""}`}
                           >
-                            <td className="py-3 pr-4 text-sm">{label}</td>
-                            <td className="py-3 px-6 text-center">
+                            <td className="py-3 pr-2 sm:pr-4 text-sm">{label}</td>
+                            <td className="py-3 px-3 sm:px-6 text-center">
                               <Switch
                                 aria-label={`In-App: ${label}`}
                                 checked={notifPrefs[key].inApp}
@@ -1063,7 +1063,7 @@ export default function SettingsPage() {
                                 }
                               />
                             </td>
-                            <td className="py-3 pl-6 text-center">
+                            <td className="py-3 pl-3 sm:pl-6 text-center">
                               <div
                                 title={
                                   !appriseSettings?.configured
@@ -1547,7 +1547,7 @@ export default function SettingsPage() {
               <CardContent className="space-y-4">
                 <div className="space-y-2">
                   <Label htmlFor="discord-webhook">Webhook URL</Label>
-                  <div className="flex gap-2">
+                  <div className="flex flex-col sm:flex-row gap-2">
                     <div className="relative flex-1">
                       <Input
                         id="discord-webhook"
@@ -1578,6 +1578,7 @@ export default function SettingsPage() {
                     <Button
                       onClick={() => updateDiscordMutation.mutate(discordWebhookUrl)}
                       disabled={updateDiscordMutation.isPending || !discordWebhookUrl.trim()}
+                      className="shrink-0 w-full sm:w-auto"
                     >
                       {updateDiscordMutation.isPending ? "Saving..." : "Save"}
                     </Button>
@@ -1606,7 +1607,7 @@ export default function SettingsPage() {
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="flex flex-col space-y-2">
-                  <div className="flex justify-between items-center">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <div>
                       <p className="text-sm font-medium">Clear Downloads Cache</p>
                       <p className="text-xs text-muted-foreground">
@@ -1625,7 +1626,7 @@ export default function SettingsPage() {
                             "Search results cache has been cleared. New searches will fetch fresh data.",
                         });
                       }}
-                      className="gap-2"
+                      className="gap-2 w-full sm:w-auto shrink-0"
                     >
                       <RefreshCw className="h-4 w-4" />
                       Clear Cache
@@ -1633,7 +1634,7 @@ export default function SettingsPage() {
                   </div>
                 </div>
                 <div className="flex flex-col space-y-2">
-                  <div className="flex justify-between items-center">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <div>
                       <p className="text-sm font-medium">Refresh Metadata</p>
                       <p className="text-xs text-muted-foreground">
@@ -1645,7 +1646,7 @@ export default function SettingsPage() {
                       size="sm"
                       onClick={() => refreshMetadataMutation.mutate()}
                       disabled={refreshMetadataMutation.isPending}
-                      className="gap-2"
+                      className="gap-2 w-full sm:w-auto shrink-0"
                     >
                       {refreshMetadataMutation.isPending ? (
                         <RefreshCw className="h-4 w-4 animate-spin" />

--- a/client/src/pages/stats.tsx
+++ b/client/src/pages/stats.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { type Game } from "@shared/schema";
 import StatsCard from "@/components/StatsCard";
 import {
@@ -43,6 +44,7 @@ export default function StatsPage() {
     },
   });
 
+  const isMobile = useIsMobile();
   const stats = useMemo(() => calculateLibraryStats(games), [games]);
 
   const pieData = useMemo(() => {
@@ -70,7 +72,7 @@ export default function StatsPage() {
   }
 
   return (
-    <div className="h-full overflow-auto p-6 space-y-8">
+    <div className="h-full overflow-auto p-4 md:p-6 space-y-6 md:space-y-8">
       <div className="flex items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Statistics</h1>
@@ -92,7 +94,7 @@ export default function StatsPage() {
         discordConfigured={discordConfig?.configured}
       />
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5 lg:grid-cols-3">
+      <div className="grid gap-3 grid-cols-2 md:gap-4 lg:grid-cols-3 xl:grid-cols-5">
         <StatsCard
           title="Total Games"
           value={stats.totalGames}
@@ -140,11 +142,15 @@ export default function StatsPage() {
                   data={pieData}
                   cx="50%"
                   cy="50%"
-                  innerRadius={60}
-                  outerRadius={100}
+                  innerRadius={isMobile ? 45 : 60}
+                  outerRadius={isMobile ? 75 : 100}
                   paddingAngle={5}
                   dataKey="value"
-                  label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                  label={
+                    isMobile
+                      ? undefined
+                      : ({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`
+                  }
                 >
                   {pieData.map((entry, index) => (
                     <Cell

--- a/client/src/pages/wishlist.tsx
+++ b/client/src/pages/wishlist.tsx
@@ -225,6 +225,118 @@ export default function WishlistPage() {
     errorMessage: "Failed to update game visibility",
   });
 
+  let wishlistContent: React.ReactNode;
+
+  if (!isLoading && games.length === 0) {
+    wishlistContent = (
+      <EmptyState
+        icon={Star}
+        title="Your wishlist is empty"
+        description="Keep track of games you want to play. Add them from the Discover page to get notified about releases and updates."
+        actionLabel="Find Games"
+        actionLink="/discover"
+      />
+    );
+  } else if (!isLoading && filteredGames.length === 0) {
+    wishlistContent = (
+      <EmptyState
+        icon={Star}
+        title={emptyStateContent.title}
+        description={emptyStateContent.description}
+      />
+    );
+  } else if (isMobile && mobileSections.length > 1) {
+    wishlistContent = (
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList className="w-full">
+          {mobileSections.map((section) => (
+            <TabsTrigger key={section.id} value={section.id} className="flex-1">
+              {section.label}
+              <span className="ml-1.5 text-xs opacity-60">{section.count}</span>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+        {mobileSections.map((section) => (
+          <TabsContent key={section.id} value={section.id} className="mt-4">
+            <GameGrid
+              games={section.games}
+              onStatusChange={(id, status) => statusMutation.mutate({ gameId: id, status })}
+              onToggleHidden={(id, hidden) => hiddenMutation.mutate({ gameId: id, hidden })}
+              isLoading={isLoading}
+              viewMode={viewMode}
+              density={listDensity}
+              downloadSummaries={downloadSummaries}
+            />
+          </TabsContent>
+        ))}
+      </Tabs>
+    );
+  } else {
+    wishlistContent = (
+      <div className="space-y-8 md:space-y-12">
+        {releasedGames.length > 0 && (
+          <section>
+            <div className="flex items-baseline gap-2 mb-3">
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                Released
+              </h2>
+              <span className="text-xs text-muted-foreground/60">{releasedGames.length}</span>
+            </div>
+            <GameGrid
+              games={sortedReleasedGames}
+              onStatusChange={(id, status) => statusMutation.mutate({ gameId: id, status })}
+              onToggleHidden={(id, hidden) => hiddenMutation.mutate({ gameId: id, hidden })}
+              isLoading={isLoading}
+              viewMode={viewMode}
+              density={listDensity}
+              downloadSummaries={downloadSummaries}
+            />
+          </section>
+        )}
+
+        {showUnreleased && upcomingGames.length > 0 && (
+          <section>
+            <div className="flex items-baseline gap-2 mb-3">
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                Upcoming
+              </h2>
+              <span className="text-xs text-muted-foreground/60">{upcomingGames.length}</span>
+            </div>
+            <GameGrid
+              games={sortedUpcomingGames}
+              onStatusChange={(id, status) => statusMutation.mutate({ gameId: id, status })}
+              onToggleHidden={(id, hidden) => hiddenMutation.mutate({ gameId: id, hidden })}
+              isLoading={isLoading}
+              viewMode={viewMode}
+              density={listDensity}
+              downloadSummaries={downloadSummaries}
+            />
+          </section>
+        )}
+
+        {showUnreleased && tbaGames.length > 0 && (
+          <section>
+            <div className="flex items-baseline gap-2 mb-3">
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                To Be Announced
+              </h2>
+              <span className="text-xs text-muted-foreground/60">{tbaGames.length}</span>
+            </div>
+            <GameGrid
+              games={sortedTbaGames}
+              onStatusChange={(id, status) => statusMutation.mutate({ gameId: id, status })}
+              onToggleHidden={(id, hidden) => hiddenMutation.mutate({ gameId: id, hidden })}
+              isLoading={isLoading}
+              viewMode={viewMode}
+              density={listDensity}
+              downloadSummaries={downloadSummaries}
+            />
+          </section>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="h-full overflow-auto p-4 md:p-6">
       <div className="space-y-3">
@@ -275,107 +387,7 @@ export default function WishlistPage() {
           }}
         />
 
-        {!isLoading && games.length === 0 ? (
-          <EmptyState
-            icon={Star}
-            title="Your wishlist is empty"
-            description="Keep track of games you want to play. Add them from the Discover page to get notified about releases and updates."
-            actionLabel="Find Games"
-            actionLink="/discover"
-          />
-        ) : !isLoading && filteredGames.length === 0 ? (
-          <EmptyState
-            icon={Star}
-            title={emptyStateContent.title}
-            description={emptyStateContent.description}
-          />
-        ) : isMobile && mobileSections.length > 1 ? (
-          <Tabs value={activeTab} onValueChange={setActiveTab}>
-            <TabsList className="w-full">
-              {mobileSections.map((section) => (
-                <TabsTrigger key={section.id} value={section.id} className="flex-1">
-                  {section.label}
-                  <span className="ml-1.5 text-xs opacity-60">{section.count}</span>
-                </TabsTrigger>
-              ))}
-            </TabsList>
-            {mobileSections.map((section) => (
-              <TabsContent key={section.id} value={section.id} className="mt-4">
-                <GameGrid
-                  games={section.games}
-                  onStatusChange={(id, status) => statusMutation.mutate({ gameId: id, status })}
-                  onToggleHidden={(id, hidden) => hiddenMutation.mutate({ gameId: id, hidden })}
-                  isLoading={isLoading}
-                  viewMode={viewMode}
-                  density={listDensity}
-                  downloadSummaries={downloadSummaries}
-                />
-              </TabsContent>
-            ))}
-          </Tabs>
-        ) : (
-          <div className="space-y-8 md:space-y-12">
-            {releasedGames.length > 0 && (
-              <section>
-                <div className="flex items-baseline gap-2 mb-3">
-                  <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-                    Released
-                  </h2>
-                  <span className="text-xs text-muted-foreground/60">{releasedGames.length}</span>
-                </div>
-                <GameGrid
-                  games={sortedReleasedGames}
-                  onStatusChange={(id, status) => statusMutation.mutate({ gameId: id, status })}
-                  onToggleHidden={(id, hidden) => hiddenMutation.mutate({ gameId: id, hidden })}
-                  isLoading={isLoading}
-                  viewMode={viewMode}
-                  density={listDensity}
-                  downloadSummaries={downloadSummaries}
-                />
-              </section>
-            )}
-
-            {showUnreleased && upcomingGames.length > 0 && (
-              <section>
-                <div className="flex items-baseline gap-2 mb-3">
-                  <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-                    Upcoming
-                  </h2>
-                  <span className="text-xs text-muted-foreground/60">{upcomingGames.length}</span>
-                </div>
-                <GameGrid
-                  games={sortedUpcomingGames}
-                  onStatusChange={(id, status) => statusMutation.mutate({ gameId: id, status })}
-                  onToggleHidden={(id, hidden) => hiddenMutation.mutate({ gameId: id, hidden })}
-                  isLoading={isLoading}
-                  viewMode={viewMode}
-                  density={listDensity}
-                  downloadSummaries={downloadSummaries}
-                />
-              </section>
-            )}
-
-            {showUnreleased && tbaGames.length > 0 && (
-              <section>
-                <div className="flex items-baseline gap-2 mb-3">
-                  <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-                    To Be Announced
-                  </h2>
-                  <span className="text-xs text-muted-foreground/60">{tbaGames.length}</span>
-                </div>
-                <GameGrid
-                  games={sortedTbaGames}
-                  onStatusChange={(id, status) => statusMutation.mutate({ gameId: id, status })}
-                  onToggleHidden={(id, hidden) => hiddenMutation.mutate({ gameId: id, hidden })}
-                  isLoading={isLoading}
-                  viewMode={viewMode}
-                  density={listDensity}
-                  downloadSummaries={downloadSummaries}
-                />
-              </section>
-            )}
-          </div>
-        )}
+        {wishlistContent}
       </div>
     </div>
   );

--- a/client/src/pages/wishlist.tsx
+++ b/client/src/pages/wishlist.tsx
@@ -18,6 +18,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
 type SortOption = "release-asc" | "release-desc" | "added-desc" | "title-asc";
+type MobileSection = { id: string; label: string; count: number; games: Game[] };
 
 const SORT_OPTIONS = [
   { value: "release-desc", label: "Release (Newest)" },
@@ -128,7 +129,7 @@ export default function WishlistPage() {
   const isMobile = useIsMobile();
 
   const mobileSections = useMemo(() => {
-    const sections: { id: string; label: string; count: number; games: Game[] }[] = [];
+    const sections: MobileSection[] = [];
     if (sortedReleasedGames.length > 0)
       sections.push({
         id: "released",
@@ -156,10 +157,53 @@ export default function WishlistPage() {
   const [activeTab, setActiveTab] = useState(() => mobileSections[0]?.id ?? "released");
 
   useEffect(() => {
-    if (mobileSections.length > 0 && !mobileSections.find((s) => s.id === activeTab)) {
+    if (mobileSections.length > 0 && !mobileSections.some((section) => section.id === activeTab)) {
       setActiveTab(mobileSections[0].id);
     }
   }, [mobileSections, activeTab]);
+
+  const emptyStateContent = useMemo(() => {
+    if (searchQuery) {
+      return {
+        title: "No games match your search",
+        description: `No wishlist games found for "${searchQuery}".`,
+      };
+    }
+
+    if (showDownloadsOnly && showSearchResultsOnly) {
+      return {
+        title: "No games match your filters",
+        description: "Try disabling one or more filters to see more games.",
+      };
+    }
+
+    if (showDownloadsOnly) {
+      return {
+        title: "No games with active downloads",
+        description: "Try disabling one or more filters to see more games.",
+      };
+    }
+
+    if (showSearchResultsOnly) {
+      return {
+        title: "No games with search results",
+        description: "Try disabling one or more filters to see more games.",
+      };
+    }
+
+    if (!showUnreleased) {
+      return {
+        title: "No released games in your wishlist",
+        description:
+          "All your wishlist games are upcoming or unannounced. Enable 'Unreleased' to see them.",
+      };
+    }
+
+    return {
+      title: "No games match your filters",
+      description: "Try adjusting your filters.",
+    };
+  }, [searchQuery, showDownloadsOnly, showSearchResultsOnly, showUnreleased]);
 
   const statusMutation = useMutation({
     mutationFn: async ({ gameId, status }: { gameId: string; status: GameStatus }) => {
@@ -242,28 +286,8 @@ export default function WishlistPage() {
         ) : !isLoading && filteredGames.length === 0 ? (
           <EmptyState
             icon={Star}
-            title={
-              searchQuery
-                ? "No games match your search"
-                : showDownloadsOnly && showSearchResultsOnly
-                  ? "No games match your filters"
-                  : showDownloadsOnly
-                    ? "No games with active downloads"
-                    : showSearchResultsOnly
-                      ? "No games with search results"
-                      : !showUnreleased
-                        ? "No released games in your wishlist"
-                        : "No games match your filters"
-            }
-            description={
-              searchQuery
-                ? `No wishlist games found for "${searchQuery}".`
-                : showDownloadsOnly || showSearchResultsOnly
-                  ? "Try disabling one or more filters to see more games."
-                  : !showUnreleased
-                    ? "All your wishlist games are upcoming or unannounced. Enable 'Unreleased' to see them."
-                    : "Try adjusting your filters."
-            }
+            title={emptyStateContent.title}
+            description={emptyStateContent.description}
           />
         ) : isMobile && mobileSections.length > 1 ? (
           <Tabs value={activeTab} onValueChange={setActiveTab}>

--- a/client/src/pages/wishlist.tsx
+++ b/client/src/pages/wishlist.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import GameGrid from "@/components/GameGrid";
@@ -14,6 +14,8 @@ import { Button } from "@/components/ui/button";
 import { useViewControls } from "@/hooks/use-view-controls";
 import PageToolbar from "@/components/PageToolbar";
 import { useDownloadSummary } from "@/hooks/use-download-summary";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
 type SortOption = "release-asc" | "release-desc" | "added-desc" | "title-asc";
 
@@ -123,6 +125,42 @@ export default function WishlistPage() {
     return sortGames(tbaGames, sortBy);
   }, [tbaGames, sortBy]);
 
+  const isMobile = useIsMobile();
+
+  const mobileSections = useMemo(() => {
+    const sections: { id: string; label: string; count: number; games: Game[] }[] = [];
+    if (sortedReleasedGames.length > 0)
+      sections.push({
+        id: "released",
+        label: "Released",
+        count: sortedReleasedGames.length,
+        games: sortedReleasedGames,
+      });
+    if (showUnreleased && sortedUpcomingGames.length > 0)
+      sections.push({
+        id: "upcoming",
+        label: "Upcoming",
+        count: sortedUpcomingGames.length,
+        games: sortedUpcomingGames,
+      });
+    if (showUnreleased && sortedTbaGames.length > 0)
+      sections.push({
+        id: "tba",
+        label: "TBA",
+        count: sortedTbaGames.length,
+        games: sortedTbaGames,
+      });
+    return sections;
+  }, [sortedReleasedGames, sortedUpcomingGames, sortedTbaGames, showUnreleased]);
+
+  const [activeTab, setActiveTab] = useState(() => mobileSections[0]?.id ?? "released");
+
+  useEffect(() => {
+    if (mobileSections.length > 0 && !mobileSections.find((s) => s.id === activeTab)) {
+      setActiveTab(mobileSections[0].id);
+    }
+  }, [mobileSections, activeTab]);
+
   const statusMutation = useMutation({
     mutationFn: async ({ gameId, status }: { gameId: string; status: GameStatus }) => {
       const response = await apiRequest("PATCH", `/api/games/${gameId}/status`, { status });
@@ -144,7 +182,7 @@ export default function WishlistPage() {
   });
 
   return (
-    <div className="h-full overflow-auto p-6">
+    <div className="h-full overflow-auto p-4 md:p-6">
       <div className="space-y-3">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Wishlist</h1>
@@ -227,8 +265,32 @@ export default function WishlistPage() {
                     : "Try adjusting your filters."
             }
           />
+        ) : isMobile && mobileSections.length > 1 ? (
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList className="w-full">
+              {mobileSections.map((section) => (
+                <TabsTrigger key={section.id} value={section.id} className="flex-1">
+                  {section.label}
+                  <span className="ml-1.5 text-xs opacity-60">{section.count}</span>
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            {mobileSections.map((section) => (
+              <TabsContent key={section.id} value={section.id} className="mt-4">
+                <GameGrid
+                  games={section.games}
+                  onStatusChange={(id, status) => statusMutation.mutate({ gameId: id, status })}
+                  onToggleHidden={(id, hidden) => hiddenMutation.mutate({ gameId: id, hidden })}
+                  isLoading={isLoading}
+                  viewMode={viewMode}
+                  density={listDensity}
+                  downloadSummaries={downloadSummaries}
+                />
+              </TabsContent>
+            ))}
+          </Tabs>
         ) : (
-          <div className="space-y-12">
+          <div className="space-y-8 md:space-y-12">
             {releasedGames.length > 0 && (
               <section>
                 <div className="flex items-baseline gap-2 mb-3">

--- a/client/src/pages/xrel-releases.tsx
+++ b/client/src/pages/xrel-releases.tsx
@@ -121,8 +121,8 @@ export default function XrelReleasesPage() {
   const totalPages = pagination?.total_pages ?? 1;
 
   return (
-    <div className="h-full overflow-auto p-6">
-      <div className="flex flex-wrap items-start justify-between gap-4 mb-6">
+    <div className="h-full overflow-auto p-4 md:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4 mb-4 md:mb-6">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">xREL.to Releases</h1>
           <p className="text-muted-foreground text-sm mt-0.5">
@@ -178,33 +178,53 @@ export default function XrelReleasesPage() {
             <>
               <ul className="space-y-2">
                 {list.map((rel) => (
-                  <li
-                    key={rel.id}
-                    className="flex flex-wrap items-center justify-between gap-2 py-2 border-b border-border/50 last:border-0"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div className="font-medium truncate" title={rel.dirname}>
-                        {rel.dirname}
-                      </div>
-                      {rel.ext_info?.title && (
-                        <div className="text-sm text-muted-foreground truncate">
-                          Title: {rel.ext_info.title}
+                  <li key={rel.id} className="py-2.5 border-b border-border/50 last:border-0">
+                    {/* Title row: dirname + view link anchored top-right */}
+                    <div className="flex items-start gap-2 min-w-0">
+                      <div className="min-w-0 flex-1">
+                        <div
+                          className="font-medium text-sm truncate leading-snug"
+                          title={rel.dirname}
+                        >
+                          {rel.dirname}
                         </div>
-                      )}
+                        {rel.ext_info?.title && (
+                          <div className="text-xs text-muted-foreground truncate mt-0.5">
+                            {rel.ext_info.title}
+                          </div>
+                        )}
+                      </div>
+                      <a
+                        href={safeUrl(rel.link_href)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="shrink-0 text-primary hover:underline inline-flex items-center gap-0.5 text-sm"
+                        aria-label={`View ${rel.ext_info?.title ?? rel.dirname} on xREL`}
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" />
+                        <span className="hidden sm:inline">View</span>
+                      </a>
                     </div>
-                    <div className="flex items-center gap-2 flex-shrink-0">
-                      <span className="text-sm text-muted-foreground whitespace-nowrap">
+                    {/* Meta row: date · size · badges · action — wraps naturally on mobile */}
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mt-1.5">
+                      <span className="text-xs text-muted-foreground whitespace-nowrap">
                         {formatDate(rel.time)}
                       </span>
                       {rel.sizeMb != null && (
-                        <span className="text-sm text-muted-foreground">
+                        <span className="text-xs text-muted-foreground whitespace-nowrap">
                           {formatSize(rel.sizeMb, rel.sizeUnit)}
                         </span>
                       )}
+                      <Badge variant="secondary" className="text-[10px] h-4 px-1.5">
+                        {rel.source}
+                      </Badge>
+                      <Badge variant="outline" className="text-[10px] h-4 px-1.5">
+                        {rel.group_name || "—"}
+                      </Badge>
                       {rel.libraryStatus ? (
                         <Badge
                           variant={rel.libraryStatus === "wanted" ? "default" : "secondary"}
-                          className={`text-xs ${rel.libraryStatus === "wanted" ? "bg-primary text-primary-foreground" : ""}`}
+                          className={`text-[10px] h-4 px-1.5 ${rel.libraryStatus === "wanted" ? "bg-primary text-primary-foreground" : ""}`}
                         >
                           {rel.libraryStatus.charAt(0).toUpperCase() + rel.libraryStatus.slice(1)}
                         </Badge>
@@ -212,15 +232,8 @@ export default function XrelReleasesPage() {
                         <Button
                           variant="ghost"
                           size="sm"
-                          className="h-6 px-2 text-xs gap-1"
+                          className="h-7 px-2 text-xs gap-1"
                           onClick={() => {
-                            // We use matchCandidate data which is already formatted via IGDB
-                            // But our API expects just the fields to add.
-                            // Actually, reusing the same POST endpoint /api/games/match-and-add might be weird
-                            // if we already have the ID.
-                            // Let's call /api/games directly or use match-and-add with title (but that re-searches).
-                            // Better to call match-and-add which we updated? No we didn't update it to take ID.
-                            // Let's just use match-and-add with the *candidate* title, which is the official IGDB title.
                             if (rel.matchCandidate) {
                               addGameMutation.mutate(rel.matchCandidate.title);
                             }
@@ -240,22 +253,6 @@ export default function XrelReleasesPage() {
                           Add
                         </Button>
                       ) : null}
-                      <Badge variant="secondary" className="text-xs">
-                        {rel.source}
-                      </Badge>
-                      <Badge variant="outline" className="text-xs">
-                        {rel.group_name || "—"}
-                      </Badge>
-                      <a
-                        href={safeUrl(rel.link_href)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary hover:underline inline-flex items-center gap-0.5 text-sm"
-                        aria-label={`View ${rel.ext_info?.title ?? rel.dirname} on xREL`}
-                      >
-                        <ExternalLink className="h-3.5 w-3.5" />
-                        View
-                      </a>
                     </div>
                   </li>
                 ))}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,4 @@
 sonar.sources=client/src,server,shared
-sonar.tests=server/__tests__,client/__tests__,tests,playwright
 sonar.sourceEncoding=UTF-8
 
 sonar.typescript.tsconfigPath=tsconfig.json
@@ -9,18 +8,3 @@ sonar.coverage.exclusions=**/__tests__/**,**/*.test.ts,**/*.test.tsx,tests/**,pl
 sonar.cpd.exclusions=**/__tests__/**,**/*.test.ts,**/*.test.tsx,migrations/**,playwright/**
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-
-# Suppress all issues (including security hotspots) on test files
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6
-sonar.issue.ignore.multicriteria.e1.ruleKey=*
-sonar.issue.ignore.multicriteria.e1.resourceKey=**/__tests__/**
-sonar.issue.ignore.multicriteria.e2.ruleKey=*
-sonar.issue.ignore.multicriteria.e2.resourceKey=**/*.test.ts
-sonar.issue.ignore.multicriteria.e3.ruleKey=*
-sonar.issue.ignore.multicriteria.e3.resourceKey=**/*.test.tsx
-sonar.issue.ignore.multicriteria.e4.ruleKey=*
-sonar.issue.ignore.multicriteria.e4.resourceKey=**/*.spec.ts
-sonar.issue.ignore.multicriteria.e5.ruleKey=*
-sonar.issue.ignore.multicriteria.e5.resourceKey=**/*.spec.tsx
-sonar.issue.ignore.multicriteria.e6.ruleKey=*
-sonar.issue.ignore.multicriteria.e6.resourceKey=tests/**


### PR DESCRIPTION
This pull request introduces responsive mobile support for several modal components by adding bottom sheet (drawer) layouts for mobile devices, while retaining the existing dialog/modal layouts for desktop. It also refactors common content into reusable variables and makes minor UI adjustments for consistency.

**Mobile drawer support for modals:**

* [`AddGameModal.tsx`](diffhunk://#diff-8b8927c32ff11dca6c914ad78cbdbfdf0e5a9e48b7b2fd0d59c59ce793164498R11-R31): Adds a mobile-specific drawer layout for the Add Game modal, including a bottom sheet UI and improved empty/disabled states. Uses the new `useIsMobile` hook to switch between drawer (mobile) and dialog (desktop) layouts. [[1]](diffhunk://#diff-8b8927c32ff11dca6c914ad78cbdbfdf0e5a9e48b7b2fd0d59c59ce793164498R11-R31) [[2]](diffhunk://#diff-8b8927c32ff11dca6c914ad78cbdbfdf0e5a9e48b7b2fd0d59c59ce793164498R49) [[3]](diffhunk://#diff-8b8927c32ff11dca6c914ad78cbdbfdf0e5a9e48b7b2fd0d59c59ce793164498R155-R316) [[4]](diffhunk://#diff-8b8927c32ff11dca6c914ad78cbdbfdf0e5a9e48b7b2fd0d59c59ce793164498L154-R326)
* [`DiscoverSettingsModal.tsx`](diffhunk://#diff-b3bf5e6ee64edb04b6293674e8656e0de85fac02506b71fb4aacda8fbbda65ffR11-R24): Implements a mobile drawer layout for the Discovery Settings modal, refactoring shared content into an `innerContent` variable and using `useIsMobile` to render either a drawer or dialog. [[1]](diffhunk://#diff-b3bf5e6ee64edb04b6293674e8656e0de85fac02506b71fb4aacda8fbbda65ffR11-R24) [[2]](diffhunk://#diff-b3bf5e6ee64edb04b6293674e8656e0de85fac02506b71fb4aacda8fbbda65ffR47-L40) [[3]](diffhunk://#diff-b3bf5e6ee64edb04b6293674e8656e0de85fac02506b71fb4aacda8fbbda65ffL51-R70) [[4]](diffhunk://#diff-b3bf5e6ee64edb04b6293674e8656e0de85fac02506b71fb4aacda8fbbda65ffL98-R100) [[5]](diffhunk://#diff-b3bf5e6ee64edb04b6293674e8656e0de85fac02506b71fb4aacda8fbbda65ffR139-R165)
* [`DownloadDetailsModal.tsx`](diffhunk://#diff-d86010a14b2ffa936697a0e7d281617a8f63490f456d2d1ad8615768d53a08abR9-R15): Adds a mobile drawer version for the Download Details modal, moving shared content into an `innerContent` variable and conditionally rendering a drawer or dialog based on device type. [[1]](diffhunk://#diff-d86010a14b2ffa936697a0e7d281617a8f63490f456d2d1ad8615768d53a08abR9-R15) [[2]](diffhunk://#diff-d86010a14b2ffa936697a0e7d281617a8f63490f456d2d1ad8615768d53a08abR34) [[3]](diffhunk://#diff-d86010a14b2ffa936697a0e7d281617a8f63490f456d2d1ad8615768d53a08abR91-R92) [[4]](diffhunk://#diff-d86010a14b2ffa936697a0e7d281617a8f63490f456d2d1ad8615768d53a08abL95-R106)

**UI consistency and minor improvements:**

* [`CompactGameCard.tsx`](diffhunk://#diff-b3bb94dc8e8fb66062efc87c944f23be2eac3275afb279796636d8ef3b5914fcL205-R205): Reduces the number of displayed genres from two to one for a more compact card appearance.
* Minor code cleanup and formatting improvements, such as error toast simplification and consistent use of `h-full` for scroll areas in tab content. [[1]](diffhunk://#diff-d86010a14b2ffa936697a0e7d281617a8f63490f456d2d1ad8615768d53a08abL128-R125) [[2]](diffhunk://#diff-d86010a14b2ffa936697a0e7d281617a8f63490f456d2d1ad8615768d53a08abL152) [[3]](diffhunk://#diff-d86010a14b2ffa936697a0e7d281617a8f63490f456d2d1ad8615768d53a08abL220-R216) [[4]](diffhunk://#diff-d86010a14b2ffa936697a0e7d281617a8f63490f456d2d1ad8615768d53a08abL233) [[5]](diffhunk://#diff-d86010a14b2ffa936697a0e7d281617a8f63490f456d2d1ad8615768d53a08abL242) [[6]](diffhunk://#diff-d86010a14b2ffa936697a0e7d281617a8f63490f456d2d1ad8615768d53a08abL276-R268) [[7]](diffhunk://#diff-d86010a14b2ffa936697a0e7d281617a8f63490f456d2d1ad8615768d53a08abL330-R322) [[8]](diffhunk://#diff-b3bf5e6ee64edb04b6293674e8656e0de85fac02506b71fb4aacda8fbbda65ffL51-R70)

These changes significantly improve the user experience on mobile devices by providing native-feeling bottom sheets for key modals, while keeping the desktop experience unchanged.