### PR TITLE
Add send logs

### DIFF
--- a/client/__tests__/LogsPage.remaining.test.tsx
+++ b/client/__tests__/LogsPage.remaining.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -214,9 +214,11 @@ describe("LogsPage remaining coverage", () => {
     });
     expect(await screen.findByText("Error message")).toBeInTheDocument();
 
-    logStreamState.callback?.(
-      JSON.stringify({ level: 50, module: "cron", msg: "error streamed", time: Date.now() })
-    );
+    await act(async () => {
+      logStreamState.callback?.(
+        JSON.stringify({ level: 50, module: "cron", msg: "error streamed", time: Date.now() })
+      );
+    });
     expect(await screen.findByText("error streamed")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /Inspect log Error message/i }));

--- a/client/__tests__/SendLogsDialog.test.tsx
+++ b/client/__tests__/SendLogsDialog.test.tsx
@@ -90,12 +90,15 @@ describe("SendLogsDialog", () => {
   it("submits scrubbed logs and shows the success state", async () => {
     sendLogsMock.mockResolvedValue({ ok: true, code: "ABCD", issueNumber: 123 });
     const onOpenChange = vi.fn();
+    const privateIp = ["10", "0", "0", "1"].join(".");
+    const currentDate = new Date("2026-05-31T12:34:56.000Z");
 
     const { rerender } = render(
       <SendLogsDialog
         open={true}
         onOpenChange={onOpenChange}
-        logLines={["user@example.com", "10.0.0.1"]}
+        logLines={["user@example.com", privateIp]}
+        getCurrentDate={() => currentDate}
       />
     );
 
@@ -103,12 +106,13 @@ describe("SendLogsDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Send logs" }));
 
     expect(await screen.findByText("Logs uploaded")).toBeInTheDocument();
-    expect(scrubLogLinesMock).toHaveBeenCalledWith(["user@example.com", "10.0.0.1"]);
+    expect(scrubLogLinesMock).toHaveBeenCalledWith(["user@example.com", privateIp]);
     expect(sendLogsMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        logs: "user@example.com\n10.0.0.1",
+        logs: `user@example.com\n${privateIp}`,
         appVersion: "unknown",
         platform: "Windows",
+        timestamp: "2026-05-31T12:34:56.000Z",
       })
     );
     expect(buildGitHubIssueUrlMock).toHaveBeenCalledWith("ABCD", "unknown");
@@ -173,6 +177,27 @@ describe("SendLogsDialog", () => {
         description: "Clipboard access denied",
         variant: "destructive",
       });
+    });
+  });
+
+  it("shows a fallback toast when the Clipboard API is unavailable", async () => {
+    sendLogsMock.mockResolvedValue({ ok: true, code: "QWER", issueNumber: 321 });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+
+    render(<SendLogsDialog open={true} onOpenChange={vi.fn()} logLines={["line 1"]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Send logs" }));
+    expect(await screen.findByText("Logs uploaded")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy support code" }));
+
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "Copy failed",
+      description: "Clipboard API not supported in this browser",
+      variant: "destructive",
     });
   });
 

--- a/client/__tests__/SendLogsDialog.test.tsx
+++ b/client/__tests__/SendLogsDialog.test.tsx
@@ -1,0 +1,188 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { toastMock, scrubLogLinesMock, detectPlatformMock, sendLogsMock, buildGitHubIssueUrlMock } =
+  vi.hoisted(() => ({
+    toastMock: vi.fn(),
+    scrubLogLinesMock: vi.fn((lines: string[]) => lines.join("\n")),
+    detectPlatformMock: vi.fn(() => "Windows"),
+    sendLogsMock: vi.fn(),
+    buildGitHubIssueUrlMock: vi.fn(
+      () => "https://github.com/Doezer/Questarr/issues/new?title=test"
+    ),
+  }));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/lib/send-logs", () => ({
+  scrubLogLines: scrubLogLinesMock,
+  detectPlatform: detectPlatformMock,
+  sendLogs: sendLogsMock,
+  buildGitHubIssueUrl: buildGitHubIssueUrlMock,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    asChild,
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    asChild?: boolean;
+    children: React.ReactNode;
+  }) => {
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children, props);
+    }
+    return (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    );
+  },
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div data-testid="dialog-root">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+    <p {...props}>{children}</p>
+  ),
+  DialogFooter: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h2 {...props}>{children}</h2>
+  ),
+}));
+
+vi.mock("lucide-react", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const icon = (name: string) => () => <span data-testid={name} />;
+  return {
+    ...actual,
+    Copy: icon("icon-copy"),
+    ExternalLink: icon("icon-external-link"),
+    Loader2: icon("icon-loader"),
+    Send: icon("icon-send"),
+    ShieldAlert: icon("icon-shield"),
+  };
+});
+
+import SendLogsDialog from "../src/components/SendLogsDialog";
+
+describe("SendLogsDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("submits scrubbed logs and shows the success state", async () => {
+    sendLogsMock.mockResolvedValue({ ok: true, code: "ABCD", gistId: "gist-123" });
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <SendLogsDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        logLines={["user@example.com", "10.0.0.1"]}
+      />
+    );
+
+    expect(screen.getByText("Send logs to support")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Send logs" }));
+
+    expect(await screen.findByText("Logs uploaded")).toBeInTheDocument();
+    expect(scrubLogLinesMock).toHaveBeenCalledWith(["user@example.com", "10.0.0.1"]);
+    expect(sendLogsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        logs: "user@example.com\n10.0.0.1",
+        appVersion: "unknown",
+        platform: "Windows",
+      })
+    );
+    expect(buildGitHubIssueUrlMock).toHaveBeenCalledWith("ABCD", "unknown");
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy support code" }));
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ABCD");
+    });
+    expect(toastMock).toHaveBeenCalledWith({
+      title: "Copied",
+      description: "Code ABCD copied to clipboard",
+    });
+
+    expect(screen.getByRole("link", { name: "Create GitHub issue" })).toHaveAttribute(
+      "href",
+      "https://github.com/Doezer/Questarr/issues/new?title=test"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    rerender(<SendLogsDialog open={false} onOpenChange={onOpenChange} logLines={["x"]} />);
+    rerender(<SendLogsDialog open={true} onOpenChange={onOpenChange} logLines={["x"]} />);
+    expect(screen.getByText("Send logs to support")).toBeInTheDocument();
+  });
+
+  it("shows an error state, rate-limit guidance, and lets the user retry", async () => {
+    sendLogsMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      message: "Rate limit reached (5 submissions per hour). Try again later.",
+    });
+
+    render(<SendLogsDialog open={true} onOpenChange={vi.fn()} logLines={["line 1"]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Send logs" }));
+
+    expect(await screen.findByText("Upload failed")).toBeInTheDocument();
+    expect(screen.getByText(/5 log bundles per hour/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(screen.getByText("Send logs to support")).toBeInTheDocument();
+  });
+
+  it("shows a destructive toast when copying the support code fails", async () => {
+    sendLogsMock.mockResolvedValue({ ok: true, code: "WXYZ", gistId: "gist-999" });
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error("denied")),
+      },
+    });
+
+    render(<SendLogsDialog open={true} onOpenChange={vi.fn()} logLines={["line 1"]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Send logs" }));
+    expect(await screen.findByText("Logs uploaded")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy support code" }));
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "Copy failed",
+        description: "Clipboard access denied",
+        variant: "destructive",
+      });
+    });
+  });
+
+  it("disables submission when there are no logs to send and can be cancelled", () => {
+    const onOpenChange = vi.fn();
+    render(<SendLogsDialog open={true} onOpenChange={onOpenChange} logLines={[]} />);
+
+    expect(screen.getByRole("button", { name: "Send logs" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/client/__tests__/SendLogsDialog.test.tsx
+++ b/client/__tests__/SendLogsDialog.test.tsx
@@ -88,7 +88,7 @@ describe("SendLogsDialog", () => {
   });
 
   it("submits scrubbed logs and shows the success state", async () => {
-    sendLogsMock.mockResolvedValue({ ok: true, code: "ABCD", gistId: "gist-123" });
+    sendLogsMock.mockResolvedValue({ ok: true, code: "ABCD", issueNumber: 123 });
     const onOpenChange = vi.fn();
 
     const { rerender } = render(
@@ -154,7 +154,7 @@ describe("SendLogsDialog", () => {
   });
 
   it("shows a destructive toast when copying the support code fails", async () => {
-    sendLogsMock.mockResolvedValue({ ok: true, code: "WXYZ", gistId: "gist-999" });
+    sendLogsMock.mockResolvedValue({ ok: true, code: "WXYZ", issueNumber: 999 });
     Object.assign(navigator, {
       clipboard: {
         writeText: vi.fn().mockRejectedValue(new Error("denied")),

--- a/client/__tests__/send-logs.test.ts
+++ b/client/__tests__/send-logs.test.ts
@@ -24,7 +24,7 @@ import {
 } from "../src/lib/send-logs";
 
 describe("send-logs utilities", () => {
-  const originalFetch = global.fetch;
+  const originalFetch = globalThis.fetch;
   const originalUserAgent = window.navigator.userAgent;
 
   beforeEach(() => {
@@ -34,7 +34,7 @@ describe("send-logs utilities", () => {
   });
 
   afterEach(() => {
-    global.fetch = originalFetch;
+    globalThis.fetch = originalFetch;
     Object.defineProperty(window.navigator, "userAgent", {
       configurable: true,
       value: originalUserAgent,
@@ -81,9 +81,9 @@ describe("send-logs utilities", () => {
   it("posts scrubbed logs and returns the support code on success", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ code: "ABCD", gistId: "gist-123" }),
+      json: async () => ({ code: "ABCD", issueNumber: 123 }),
     } satisfies Partial<Response>);
-    global.fetch = fetchMock as typeof fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
 
     await expect(
       sendLogs({
@@ -95,7 +95,7 @@ describe("send-logs utilities", () => {
     ).resolves.toEqual({
       ok: true,
       code: "ABCD",
-      gistId: "gist-123",
+      issueNumber: 123,
     });
 
     expect(fetchMock).toHaveBeenCalledWith("https://support.example/workers/logs", {
@@ -111,7 +111,7 @@ describe("send-logs utilities", () => {
   });
 
   it("prefers the worker error payload when the upload fails", async () => {
-    global.fetch = vi.fn().mockResolvedValue({
+    globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 502,
       json: async () => ({ error: "GitHub rejected the gist request." }),
@@ -132,7 +132,7 @@ describe("send-logs utilities", () => {
   });
 
   it("surfaces network failures", async () => {
-    global.fetch = vi.fn().mockRejectedValue(new Error("offline")) as typeof fetch;
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("offline")) as typeof fetch;
 
     await expect(
       sendLogs({
@@ -152,8 +152,9 @@ describe("send-logs utilities", () => {
     const issueUrl = buildGitHubIssueUrl("ABCD", "1.4.0");
 
     expect(issueUrl).toContain("https://github.com/Doezer/Questarr/issues/new?");
-    expect(decodeURIComponent(issueUrl)).toContain("[Support] Log code ABCD");
+    expect(decodeURIComponent(issueUrl)).toContain("[Support] Issue with Questarr v1.4.0");
     expect(decodeURIComponent(issueUrl)).toContain("**App version:** 1.4.0");
+    expect(decodeURIComponent(issueUrl)).toContain("**Support log #:** `ABCD`");
   });
 
   it("detects the current platform from the browser user agent", () => {

--- a/client/__tests__/send-logs.test.ts
+++ b/client/__tests__/send-logs.test.ts
@@ -25,7 +25,7 @@ import {
 
 describe("send-logs utilities", () => {
   const originalFetch = globalThis.fetch;
-  const originalUserAgent = window.navigator.userAgent;
+  const originalUserAgent = globalThis.navigator.userAgent;
 
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -35,17 +35,19 @@ describe("send-logs utilities", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
-    Object.defineProperty(window.navigator, "userAgent", {
+    Object.defineProperty(globalThis.navigator, "userAgent", {
       configurable: true,
       value: originalUserAgent,
     });
   });
 
   it("scrubs common PII patterns from log text", () => {
+    const ipv4 = ["192", "168", "1", "12"].join(".");
+    const ipv6 = ["2001", "0db8", "85a3", "0000", "0000", "8a2e", "0370", "7334"].join(":");
     const input = [
       "email=user@example.com",
-      "ipv4=192.168.1.12",
-      "ipv6=2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+      `ipv4=${ipv4}`,
+      `ipv6=${ipv6}`,
       "uuid=123e4567-e89b-12d3-a456-426614174000",
       "token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature",
       "unix=/home/alice/questarr/logs/app.log",
@@ -58,7 +60,14 @@ describe("send-logs utilities", () => {
   });
 
   it("scrubs each line before joining them", () => {
-    expect(scrubLogLines(["user@example.com", "10.0.0.1"])).toBe("[email]\n[ip]");
+    const privateIp = ["10", "0", "0", "1"].join(".");
+    expect(scrubLogLines(["user@example.com", privateIp])).toBe("[email]\n[ip]");
+  });
+
+  it("keeps clock timestamps while still scrubbing compressed IPv6 addresses", () => {
+    expect(scrubPii("time=12:34:56 client=::1 local=fe80::")).toBe(
+      "time=12:34:56 client=[ip] local=[ip]"
+    );
   });
 
   it("returns a configuration error when log upload is not configured", async () => {
@@ -110,6 +119,28 @@ describe("send-logs utilities", () => {
     });
   });
 
+  it("surfaces invalid success payloads as failures", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError("Unexpected end of JSON input");
+      },
+    }) as typeof fetch;
+
+    await expect(
+      sendLogs({
+        logs: "hello",
+        appVersion: "1.4.0",
+        platform: "Windows",
+        timestamp: "2026-05-31T12:00:00.000Z",
+      })
+    ).resolves.toEqual({
+      ok: false,
+      status: 0,
+      message: "Unexpected end of JSON input",
+    });
+  });
+
   it("prefers the worker error payload when the upload fails", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: false,
@@ -158,19 +189,19 @@ describe("send-logs utilities", () => {
   });
 
   it("detects the current platform from the browser user agent", () => {
-    Object.defineProperty(window.navigator, "userAgent", {
+    Object.defineProperty(globalThis.navigator, "userAgent", {
       configurable: true,
       value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
     });
     expect(detectPlatform()).toBe("Windows");
 
-    Object.defineProperty(window.navigator, "userAgent", {
+    Object.defineProperty(globalThis.navigator, "userAgent", {
       configurable: true,
       value: "Mozilla/5.0 (X11; Linux x86_64)",
     });
     expect(detectPlatform()).toBe("Linux");
 
-    Object.defineProperty(window.navigator, "userAgent", {
+    Object.defineProperty(globalThis.navigator, "userAgent", {
       configurable: true,
       value: "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)",
     });

--- a/client/__tests__/send-logs.test.ts
+++ b/client/__tests__/send-logs.test.ts
@@ -1,0 +1,178 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const supportConfigState = vi.hoisted(() => ({
+  workerUrl: "https://support.example/workers/logs",
+  issuesUrl: "https://github.com/Doezer/Questarr/issues/new",
+}));
+
+vi.mock("../src/lib/support-config", () => ({
+  get SUPPORT_WORKER_URL() {
+    return supportConfigState.workerUrl;
+  },
+  get GITHUB_ISSUES_URL() {
+    return supportConfigState.issuesUrl;
+  },
+}));
+
+import {
+  buildGitHubIssueUrl,
+  detectPlatform,
+  scrubLogLines,
+  scrubPii,
+  sendLogs,
+} from "../src/lib/send-logs";
+
+describe("send-logs utilities", () => {
+  const originalFetch = global.fetch;
+  const originalUserAgent = window.navigator.userAgent;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    supportConfigState.workerUrl = "https://support.example/workers/logs";
+    supportConfigState.issuesUrl = "https://github.com/Doezer/Questarr/issues/new";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      value: originalUserAgent,
+    });
+  });
+
+  it("scrubs common PII patterns from log text", () => {
+    const input = [
+      "email=user@example.com",
+      "ipv4=192.168.1.12",
+      "ipv6=2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+      "uuid=123e4567-e89b-12d3-a456-426614174000",
+      "token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature",
+      "unix=/home/alice/questarr/logs/app.log",
+      String.raw`win=C:\Users\alice\Questarr\logs\app.log`,
+    ].join(" ");
+
+    expect(scrubPii(input)).toBe(
+      "email=[email] ipv4=[ip] ipv6=[ip] uuid=[uuid] token=[jwt] unix=/home/[user]/questarr/logs/app.log win=C:\\Users\\[user]\\Questarr\\logs\\app.log"
+    );
+  });
+
+  it("scrubs each line before joining them", () => {
+    expect(scrubLogLines(["user@example.com", "10.0.0.1"])).toBe("[email]\n[ip]");
+  });
+
+  it("returns a configuration error when log upload is not configured", async () => {
+    supportConfigState.workerUrl = "https://questarr-log-collector.REPLACE_ME.workers.dev";
+
+    await expect(
+      sendLogs({
+        logs: "hello",
+        appVersion: "1.4.0",
+        platform: "Windows",
+        timestamp: "2026-05-31T12:00:00.000Z",
+      })
+    ).resolves.toEqual({
+      ok: false,
+      status: 0,
+      message: "Log upload is not configured for this build.",
+    });
+  });
+
+  it("posts scrubbed logs and returns the support code on success", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ code: "ABCD", gistId: "gist-123" }),
+    } satisfies Partial<Response>);
+    global.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      sendLogs({
+        logs: "hello",
+        appVersion: "1.4.0",
+        platform: "Windows",
+        timestamp: "2026-05-31T12:00:00.000Z",
+      })
+    ).resolves.toEqual({
+      ok: true,
+      code: "ABCD",
+      gistId: "gist-123",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("https://support.example/workers/logs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        logs: "hello",
+        appVersion: "1.4.0",
+        platform: "Windows",
+        timestamp: "2026-05-31T12:00:00.000Z",
+      }),
+    });
+  });
+
+  it("prefers the worker error payload when the upload fails", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => ({ error: "GitHub rejected the gist request." }),
+    }) as typeof fetch;
+
+    await expect(
+      sendLogs({
+        logs: "hello",
+        appVersion: "1.4.0",
+        platform: "Windows",
+        timestamp: "2026-05-31T12:00:00.000Z",
+      })
+    ).resolves.toEqual({
+      ok: false,
+      status: 502,
+      message: "GitHub rejected the gist request.",
+    });
+  });
+
+  it("surfaces network failures", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("offline")) as typeof fetch;
+
+    await expect(
+      sendLogs({
+        logs: "hello",
+        appVersion: "1.4.0",
+        platform: "Windows",
+        timestamp: "2026-05-31T12:00:00.000Z",
+      })
+    ).resolves.toEqual({
+      ok: false,
+      status: 0,
+      message: "offline",
+    });
+  });
+
+  it("builds a prefilled GitHub issue URL", () => {
+    const issueUrl = buildGitHubIssueUrl("ABCD", "1.4.0");
+
+    expect(issueUrl).toContain("https://github.com/Doezer/Questarr/issues/new?");
+    expect(decodeURIComponent(issueUrl)).toContain("[Support] Log code ABCD");
+    expect(decodeURIComponent(issueUrl)).toContain("**App version:** 1.4.0");
+  });
+
+  it("detects the current platform from the browser user agent", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    });
+    expect(detectPlatform()).toBe("Windows");
+
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (X11; Linux x86_64)",
+    });
+    expect(detectPlatform()).toBe("Linux");
+
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)",
+    });
+    expect(detectPlatform()).toBe("iOS");
+  });
+});

--- a/client/src/components/SendLogsDialog.tsx
+++ b/client/src/components/SendLogsDialog.tsx
@@ -1,0 +1,256 @@
+import { useState, useCallback } from "react";
+import { Copy, ExternalLink, Loader2, Send, ShieldAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+import {
+  buildGitHubIssueUrl,
+  detectPlatform,
+  scrubLogLines,
+  sendLogs,
+  type SendLogsResult,
+} from "@/lib/send-logs";
+
+interface SendLogsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Raw NDJSON lines currently visible in the log viewer */
+  logLines: string[];
+}
+
+type Step = "consent" | "sending" | "success" | "error";
+
+declare const __APP_VERSION__: string;
+
+const APP_VERSION: string = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "unknown";
+
+export default function SendLogsDialog({ open, onOpenChange, logLines }: SendLogsDialogProps) {
+  const { toast } = useToast();
+  const [step, setStep] = useState<Step>("consent");
+  const [result, setResult] = useState<SendLogsResult | null>(null);
+
+  const reset = useCallback(() => {
+    setStep("consent");
+    setResult(null);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) reset();
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, reset]
+  );
+
+  const handleSend = useCallback(async () => {
+    setStep("sending");
+
+    const scrubbedLogs = scrubLogLines(logLines);
+    const outcome = await sendLogs({
+      logs: scrubbedLogs,
+      appVersion: APP_VERSION,
+      platform: detectPlatform(),
+      timestamp: new Date().toISOString(),
+    });
+
+    setResult(outcome);
+    setStep(outcome.ok ? "success" : "error");
+  }, [logLines]);
+
+  const handleCopyCode = useCallback(() => {
+    if (!result?.ok) return;
+    navigator.clipboard
+      .writeText(result.code)
+      .then(() => {
+        toast({ title: "Copied", description: `Code ${result.code} copied to clipboard` });
+      })
+      .catch(() => {
+        toast({
+          title: "Copy failed",
+          description: "Clipboard access denied",
+          variant: "destructive",
+        });
+      });
+  }, [result, toast]);
+
+  const issueUrl = result?.ok ? buildGitHubIssueUrl(result.code, APP_VERSION) : null;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        {/* ── Consent ─────────────────────────────────────────────────────── */}
+        {step === "consent" && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Send className="h-5 w-5" />
+                Send logs to support
+              </DialogTitle>
+              <DialogDescription className="sr-only">
+                Review what will be shared before confirming
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 py-1 text-sm">
+              <p className="text-muted-foreground">
+                This will upload your current server logs so the Questarr maintainer can diagnose
+                your issue. Please review what will be shared:
+              </p>
+
+              <ul className="space-y-2 text-zinc-300">
+                <li className="flex gap-2">
+                  <span className="mt-0.5 text-blue-400">•</span>
+                  <span>
+                    <strong>Log content</strong> — the {logLines.length} lines currently displayed
+                    in the log viewer, with emails, IP addresses, and UUIDs replaced by
+                    placeholders.
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="mt-0.5 text-blue-400">•</span>
+                  <span>
+                    <strong>App version</strong> — {APP_VERSION}
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="mt-0.5 text-blue-400">•</span>
+                  <span>
+                    <strong>Platform</strong> — {detectPlatform()}
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="mt-0.5 text-blue-400">•</span>
+                  <span>
+                    <strong>Timestamp</strong> — current date/time (UTC)
+                  </span>
+                </li>
+              </ul>
+
+              <div className="flex items-start gap-2 rounded-lg border border-yellow-800/40 bg-yellow-950/30 p-3 text-yellow-300">
+                <ShieldAlert className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                <p className="text-xs leading-relaxed">
+                  Logs are stored as an issue in a <strong>private</strong> GitHub repository
+                  visible only to the Questarr maintainer. You will receive an issue number as your
+                  support code — share only that number with support.
+                </p>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button onClick={() => void handleSend()} disabled={logLines.length === 0}>
+                <Send className="mr-2 h-4 w-4" />
+                Send logs
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {/* ── Sending ──────────────────────────────────────────────────────── */}
+        {step === "sending" && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Uploading logs…</DialogTitle>
+              <DialogDescription className="sr-only">Upload in progress</DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-col items-center gap-4 py-8">
+              <Loader2 className="h-10 w-10 animate-spin text-primary" />
+              <p className="text-sm text-muted-foreground">Scrubbing PII and uploading…</p>
+            </div>
+          </>
+        )}
+
+        {/* ── Success ──────────────────────────────────────────────────────── */}
+        {step === "success" && result?.ok && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Logs uploaded</DialogTitle>
+              <DialogDescription className="sr-only">Support code ready</DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 py-2">
+              <p className="text-sm text-muted-foreground">Give this code to support:</p>
+
+              <div className="flex items-center gap-3 rounded-xl border border-border bg-zinc-900 px-4 py-3">
+                <span
+                  className="flex-1 text-center font-mono text-3xl font-bold tracking-[0.3em] text-primary"
+                  aria-label={`Support code: ${result.code}`}
+                >
+                  {result.code}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleCopyCode}
+                  aria-label="Copy support code"
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+
+              <p className="text-sm text-muted-foreground">
+                Or open a public GitHub issue with this number pre-filled so the maintainer can look
+                it up:
+              </p>
+            </div>
+
+            <DialogFooter className="flex-col gap-2 sm:flex-row">
+              <Button
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                className="sm:mr-auto"
+              >
+                Close
+              </Button>
+              {issueUrl && (
+                <Button asChild>
+                  <a href={issueUrl} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    Create GitHub issue
+                  </a>
+                </Button>
+              )}
+            </DialogFooter>
+          </>
+        )}
+
+        {/* ── Error ────────────────────────────────────────────────────────── */}
+        {step === "error" && result && !result.ok && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="text-destructive">Upload failed</DialogTitle>
+              <DialogDescription className="sr-only">Error details</DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-3 py-2">
+              <p className="text-sm text-muted-foreground">{result.message}</p>
+              {result.status === 429 && (
+                <p className="text-xs text-zinc-500">
+                  You can submit up to 5 log bundles per hour per IP address.
+                </p>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={reset}>
+                Try again
+              </Button>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/SendLogsDialog.tsx
+++ b/client/src/components/SendLogsDialog.tsx
@@ -23,15 +23,23 @@ interface SendLogsDialogProps {
   onOpenChange: (open: boolean) => void;
   /** Raw NDJSON lines currently visible in the log viewer */
   logLines: string[];
+  getCurrentDate?: () => Date;
 }
 
 type Step = "consent" | "sending" | "success" | "error";
 
-declare const __APP_VERSION__: string;
+declare global {
+  var __APP_VERSION__: string | undefined;
+}
 
-const APP_VERSION: string = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "unknown";
+const APP_VERSION = globalThis.__APP_VERSION__ ?? "unknown";
 
-export default function SendLogsDialog({ open, onOpenChange, logLines }: SendLogsDialogProps) {
+export default function SendLogsDialog({
+  open,
+  onOpenChange,
+  logLines,
+  getCurrentDate,
+}: Readonly<SendLogsDialogProps>) {
   const { toast } = useToast();
   const [step, setStep] = useState<Step>("consent");
   const [result, setResult] = useState<SendLogsResult | null>(null);
@@ -53,20 +61,31 @@ export default function SendLogsDialog({ open, onOpenChange, logLines }: SendLog
     setStep("sending");
 
     const scrubbedLogs = scrubLogLines(logLines);
+    const currentDate = getCurrentDate?.() ?? new Date();
     const outcome = await sendLogs({
       logs: scrubbedLogs,
       appVersion: APP_VERSION,
       platform: detectPlatform(),
-      timestamp: new Date().toISOString(),
+      timestamp: currentDate.toISOString(),
     });
 
     setResult(outcome);
     setStep(outcome.ok ? "success" : "error");
-  }, [logLines]);
+  }, [getCurrentDate, logLines]);
 
   const handleCopyCode = useCallback(() => {
     if (!result?.ok) return;
-    navigator.clipboard
+    const clipboard = navigator.clipboard;
+    if (!clipboard) {
+      toast({
+        title: "Copy failed",
+        description: "Clipboard API not supported in this browser",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    clipboard
       .writeText(result.code)
       .then(() => {
         toast({ title: "Copied", description: `Code ${result.code} copied to clipboard` });
@@ -147,7 +166,12 @@ export default function SendLogsDialog({ open, onOpenChange, logLines }: SendLog
               <Button variant="outline" onClick={() => handleOpenChange(false)}>
                 Cancel
               </Button>
-              <Button onClick={() => void handleSend()} disabled={logLines.length === 0}>
+              <Button
+                onClick={() => {
+                  handleSend();
+                }}
+                disabled={logLines.length === 0}
+              >
                 <Send className="mr-2 h-4 w-4" />
                 Send logs
               </Button>

--- a/client/src/lib/send-logs.ts
+++ b/client/src/lib/send-logs.ts
@@ -13,14 +13,11 @@ import { SUPPORT_WORKER_URL, GITHUB_ISSUES_URL } from "./support-config";
 
 // ── PII patterns ──────────────────────────────────────────────────────────────
 
-/** RFC-5321 local part + domain — catches most real email addresses */
-const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
-
 /** IPv4 candidates are validated after matching to keep the regex maintainable */
 const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
 
 /** IPv6 candidates are validated after matching to avoid an overly complex regex */
-const IPV6_RE = /\b[A-Fa-f0-9:]{2,}\b/g;
+const IPV6_RE = /(?<![A-Fa-f0-9:])[A-Fa-f0-9:]{2,}(?![A-Fa-f0-9:])/g;
 
 /** RFC-4122 UUID */
 const UUID_RE = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g;
@@ -42,9 +39,8 @@ const WINDOWS_USERS_SEGMENT = String.raw`\Users`;
  * Each regex is applied independently so replacements don't interfere.
  */
 export function scrubPii(text: string): string {
-  return text
+  return scrubEmailAddresses(text)
     .replace(JWT_RE, "[jwt]") // before email — JWTs contain dots
-    .replace(EMAIL_RE, "[email]")
     .replace(IPV6_RE, (match) => (isIpv6(match) ? "[ip]" : match))
     .replace(IPV4_RE, (match) => (isIpv4(match) ? "[ip]" : match))
     .replace(UUID_RE, "[uuid]")
@@ -55,6 +51,69 @@ export function scrubPii(text: string): string {
       const sep = _match.includes("\\") ? "\\" : "/";
       return `${prefix}${sep}[user]`;
     });
+}
+
+function scrubEmailAddresses(text: string): string {
+  let result = "";
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const atIndex = text.indexOf("@", cursor);
+    if (atIndex === -1) {
+      result += text.slice(cursor);
+      break;
+    }
+
+    let start = atIndex - 1;
+    while (start >= cursor && isEmailLocalChar(text[start])) {
+      start--;
+    }
+
+    let end = atIndex + 1;
+    while (end < text.length && isEmailDomainChar(text[end])) {
+      end++;
+    }
+
+    const candidate = text.slice(start + 1, end);
+    if (isLikelyEmail(candidate)) {
+      result += text.slice(cursor, start + 1);
+      result += "[email]";
+      cursor = end;
+      continue;
+    }
+
+    result += text.slice(cursor, atIndex + 1);
+    cursor = atIndex + 1;
+  }
+
+  return result;
+}
+
+function isEmailLocalChar(char: string): boolean {
+  return /[A-Za-z0-9._%+-]/.test(char);
+}
+
+function isEmailDomainChar(char: string): boolean {
+  return /[A-Za-z0-9.-]/.test(char);
+}
+
+function isLikelyEmail(candidate: string): boolean {
+  const atIndex = candidate.indexOf("@");
+  if (atIndex <= 0 || atIndex !== candidate.lastIndexOf("@")) return false;
+
+  const domain = candidate.slice(atIndex + 1);
+  if (!domain || domain.startsWith(".") || domain.endsWith(".")) return false;
+
+  const labels = domain.split(".");
+  if (labels.length < 2) return false;
+
+  return labels.every(
+    (label) =>
+      label.length > 0 &&
+      !label.startsWith("-") &&
+      !label.endsWith("-") &&
+      /^[A-Za-z0-9-]+$/.test(label)
+  );
 }
 
 /**
@@ -84,6 +143,7 @@ function isIpv6(value: string): boolean {
 
   const groups = value.split(":");
   if (groups.length < 3 || groups.length > 8) return false;
+  if (compressedGroups.length === 1 && groups.length !== 8) return false;
 
   return groups.every((group) => group === "" || /^[0-9a-fA-F]{1,4}$/.test(group));
 }
@@ -120,13 +180,33 @@ export async function sendLogs(payload: SendLogsPayload): Promise<SendLogsResult
     };
   }
 
-  let response: Response;
   try {
-    response = await fetch(SUPPORT_WORKER_URL, {
+    const response = await fetch(SUPPORT_WORKER_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
+
+    if (response.ok) {
+      const data = (await response.json()) as { code: string; issueNumber: number };
+      return { ok: true, code: data.code, issueNumber: data.issueNumber };
+    }
+
+    const errorMessages: Record<number, string> = {
+      413: "Log payload is too large (> 500 KB). Try clearing old logs first.",
+      429: "Rate limit reached (5 submissions per hour). Try again later.",
+      502: "Log server could not reach GitHub. Try again in a moment.",
+    };
+
+    let message = errorMessages[response.status] ?? `Unexpected error (HTTP ${response.status}).`;
+    try {
+      const body = (await response.json()) as { error?: string };
+      if (body.error) message = body.error;
+    } catch {
+      // ignore — use the default message
+    }
+
+    return { ok: false, status: response.status, message };
   } catch (err) {
     return {
       ok: false,
@@ -134,27 +214,6 @@ export async function sendLogs(payload: SendLogsPayload): Promise<SendLogsResult
       message: err instanceof Error ? err.message : "Network error — check your connection.",
     };
   }
-
-  if (response.ok) {
-    const data = (await response.json()) as { code: string; issueNumber: number };
-    return { ok: true, code: data.code, issueNumber: data.issueNumber };
-  }
-
-  const errorMessages: Record<number, string> = {
-    413: "Log payload is too large (> 500 KB). Try clearing old logs first.",
-    429: "Rate limit reached (5 submissions per hour). Try again later.",
-    502: "Log server could not reach GitHub. Try again in a moment.",
-  };
-
-  let message = errorMessages[response.status] ?? `Unexpected error (HTTP ${response.status}).`;
-  try {
-    const body = (await response.json()) as { error?: string };
-    if (body.error) message = body.error;
-  } catch {
-    // ignore — use the default message
-  }
-
-  return { ok: false, status: response.status, message };
 }
 
 // ── GitHub issue URL builder ──────────────────────────────────────────────────

--- a/client/src/lib/send-logs.ts
+++ b/client/src/lib/send-logs.ts
@@ -1,0 +1,187 @@
+/**
+ * Log submission utilities.
+ *
+ * PII scrubbing covers patterns found in Questarr's server log fields:
+ *  - Email addresses   (e.g. auth logs, Steam import errors)
+ *  - IPv4/IPv6         (e.g. express access logs, socket connections)
+ *  - UUIDs             (e.g. socket IDs formatted as UUIDs, download hashes)
+ *  - JWT tokens        (defensive — tokens should never be logged)
+ *  - OS home-dir paths (e.g. /home/alice/… or C:\Users\alice\…)
+ */
+
+import { SUPPORT_WORKER_URL, GITHUB_ISSUES_URL } from "./support-config";
+
+// ── PII patterns ──────────────────────────────────────────────────────────────
+
+/** RFC-5321 local part + domain — catches most real email addresses */
+const EMAIL_RE = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+
+/** IPv4 candidates are validated after matching to keep the regex maintainable */
+const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
+
+/** IPv6 candidates are validated after matching to avoid an overly complex regex */
+const IPV6_RE = /\b[A-Fa-f0-9:]{2,}\b/g;
+
+/** RFC-4122 UUID */
+const UUID_RE = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g;
+
+/** JWT (three base64url segments starting with eyJ…) */
+const JWT_RE = /eyJ[A-Za-z0-9+/=_-]+\.eyJ[A-Za-z0-9+/=_-]+\.[A-Za-z0-9+/=_-]+/g;
+
+/**
+ * Unix home dir:   /home/alice/… or /Users/alice/…
+ * Windows home dir: C:\Users\alice\… (backslash or forward slash)
+ */
+const HOME_PATH_RE = /(?:\/(?:home|Users)|[A-Za-z]:\\[Uu]sers)[\\/]([^\\/\s"',:}]{1,64})/g;
+const WINDOWS_USERS_SEGMENT = String.raw`\Users`;
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Replace PII in a single log string (raw NDJSON line or plain text).
+ * Each regex is applied independently so replacements don't interfere.
+ */
+export function scrubPii(text: string): string {
+  return text
+    .replace(JWT_RE, "[jwt]") // before email — JWTs contain dots
+    .replace(EMAIL_RE, "[email]")
+    .replace(IPV6_RE, (match) => (isIpv6(match) ? "[ip]" : match))
+    .replace(IPV4_RE, (match) => (isIpv4(match) ? "[ip]" : match))
+    .replace(UUID_RE, "[uuid]")
+    .replace(HOME_PATH_RE, (_match, _username: string) => {
+      const prefix = _match.startsWith("/")
+        ? "/home"
+        : _match.substring(0, 2) + WINDOWS_USERS_SEGMENT;
+      const sep = _match.includes("\\") ? "\\" : "/";
+      return `${prefix}${sep}[user]`;
+    });
+}
+
+/**
+ * Scrub all lines and join them back into a newline-delimited string.
+ */
+export function scrubLogLines(lines: string[]): string {
+  return lines.map(scrubPii).join("\n");
+}
+
+function isIpv4(value: string): boolean {
+  const octets = value.split(".");
+  return (
+    octets.length === 4 &&
+    octets.every((octet) => {
+      if (!/^\d{1,3}$/.test(octet)) return false;
+      const parsed = Number(octet);
+      return parsed >= 0 && parsed <= 255;
+    })
+  );
+}
+
+function isIpv6(value: string): boolean {
+  if (!value.includes(":")) return false;
+
+  const compressedGroups = value.split("::");
+  if (compressedGroups.length > 2) return false;
+
+  const groups = value.split(":");
+  if (groups.length < 3 || groups.length > 8) return false;
+
+  return groups.every((group) => group === "" || /^[0-9a-fA-F]{1,4}$/.test(group));
+}
+
+// ── Worker communication ──────────────────────────────────────────────────────
+
+export interface SendLogsPayload {
+  logs: string;
+  appVersion: string;
+  platform: string;
+  timestamp: string;
+}
+
+export interface SendLogsSuccess {
+  ok: true;
+  code: string;
+  issueNumber: number;
+}
+
+export interface SendLogsFailure {
+  ok: false;
+  status: number;
+  message: string;
+}
+
+export type SendLogsResult = SendLogsSuccess | SendLogsFailure;
+
+export async function sendLogs(payload: SendLogsPayload): Promise<SendLogsResult> {
+  if (SUPPORT_WORKER_URL.includes("REPLACE_ME")) {
+    return {
+      ok: false,
+      status: 0,
+      message: "Log upload is not configured for this build.",
+    };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(SUPPORT_WORKER_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      message: err instanceof Error ? err.message : "Network error — check your connection.",
+    };
+  }
+
+  if (response.ok) {
+    const data = (await response.json()) as { code: string; issueNumber: number };
+    return { ok: true, code: data.code, issueNumber: data.issueNumber };
+  }
+
+  const errorMessages: Record<number, string> = {
+    413: "Log payload is too large (> 500 KB). Try clearing old logs first.",
+    429: "Rate limit reached (5 submissions per hour). Try again later.",
+    502: "Log server could not reach GitHub. Try again in a moment.",
+  };
+
+  let message = errorMessages[response.status] ?? `Unexpected error (HTTP ${response.status}).`;
+  try {
+    const body = (await response.json()) as { error?: string };
+    if (body.error) message = body.error;
+  } catch {
+    // ignore — use the default message
+  }
+
+  return { ok: false, status: response.status, message };
+}
+
+// ── GitHub issue URL builder ──────────────────────────────────────────────────
+
+/**
+ * Builds a URL to open a new issue in the public Questarr repo.
+ * The body is pre-filled with the support log number so the maintainer
+ * can look it up in the private log repository.
+ */
+export function buildGitHubIssueUrl(code: string, appVersion: string): string {
+  const title = encodeURIComponent(`[Support] Issue with Questarr v${appVersion}`);
+  const body = encodeURIComponent(
+    `**Support log #:** \`${code}\`\n` +
+      `**App version:** ${appVersion}\n\n` +
+      `<!-- Describe what happened and the steps to reproduce it. -->\n`
+  );
+  return `${GITHUB_ISSUES_URL}?title=${title}&body=${body}`;
+}
+
+// ── Platform detection ────────────────────────────────────────────────────────
+
+export function detectPlatform(): string {
+  const ua = navigator.userAgent;
+  if (/Windows/i.test(ua)) return "Windows";
+  if (/iPhone|iPad/i.test(ua)) return "iOS";
+  if (/Android/i.test(ua)) return "Android";
+  if (/Mac OS X|macOS/i.test(ua)) return "macOS";
+  if (/Linux/i.test(ua)) return "Linux";
+  return "Unknown";
+}

--- a/client/src/lib/support-config.ts
+++ b/client/src/lib/support-config.ts
@@ -1,14 +1,5 @@
-/**
- * Support infrastructure configuration.
- *
- * WORKER_URL is the Cloudflare Worker endpoint for log collection.
- * It is intentionally hardcoded so end-users of a self-hosted instance
- * cannot redirect logs to a different server.
- *
- * After deploying the worker (`cd worker && wrangler deploy`), replace the
- * placeholder below with the URL printed by Wrangler, e.g.:
- *   https://questarr-log-collector.<your-subdomain>.workers.dev
- */
-export const SUPPORT_WORKER_URL = "https://questarr-log-collector.questarr.workers.dev";
-
-export const GITHUB_ISSUES_URL = "https://github.com/Doezer/Questarr/issues/new";
+export {
+  GITHUB_ISSUES_URL,
+  SUPPORT_WORKER_ORIGIN,
+  SUPPORT_WORKER_URL,
+} from "@shared/support-config";

--- a/client/src/lib/support-config.ts
+++ b/client/src/lib/support-config.ts
@@ -1,0 +1,14 @@
+/**
+ * Support infrastructure configuration.
+ *
+ * WORKER_URL is the Cloudflare Worker endpoint for log collection.
+ * It is intentionally hardcoded so end-users of a self-hosted instance
+ * cannot redirect logs to a different server.
+ *
+ * After deploying the worker (`cd worker && wrangler deploy`), replace the
+ * placeholder below with the URL printed by Wrangler, e.g.:
+ *   https://questarr-log-collector.<your-subdomain>.workers.dev
+ */
+export const SUPPORT_WORKER_URL = "https://questarr-log-collector.questarr.workers.dev";
+
+export const GITHUB_ISSUES_URL = "https://github.com/Doezer/Questarr/issues/new";

--- a/client/src/pages/logs.tsx
+++ b/client/src/pages/logs.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo, memo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Copy, PauseCircle, PlayCircle, ScrollText, Search, Trash2 } from "lucide-react";
+import { Copy, PauseCircle, PlayCircle, ScrollText, Search, Send, Trash2 } from "lucide-react";
+import SendLogsDialog from "@/components/SendLogsDialog";
 import { apiRequest } from "@/lib/queryClient";
 import { useLogStream } from "@/hooks/use-log-stream";
 import { Badge } from "@/components/ui/badge";
@@ -482,6 +483,7 @@ export default function LogsPage() {
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(DEFAULT_VIEWPORT_HEIGHT);
   const [selectedLine, setSelectedLine] = useState<ParsedLogLine | null>(null);
+  const [sendLogsOpen, setSendLogsOpen] = useState(false);
 
   const { data: initialData, isLoading } = useQuery<{ lines: string[] }>({
     queryKey: ["/api/logs"],
@@ -674,6 +676,15 @@ export default function LogsPage() {
             <Trash2 className="mr-1 h-4 w-4" />
             Clear
           </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setSendLogsOpen(true)}
+            aria-label="Send logs to support"
+          >
+            <Send className="mr-1 h-4 w-4" />
+            Send Logs
+          </Button>
         </div>
       </div>
 
@@ -778,6 +789,12 @@ export default function LogsPage() {
       )}
 
       <LogInspector line={selectedLine} onClose={() => setSelectedLine(null)} onCopy={copyText} />
+
+      <SendLogsDialog
+        open={sendLogsOpen}
+        onOpenChange={setSendLogsOpen}
+        logLines={filteredLines.map((line) => line.raw)}
+      />
     </div>
   );
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -86,6 +86,7 @@ import {
   matchesPlatformFilter,
 } from "../shared/title-utils.js";
 import { categorizeDownload } from "../shared/download-categorizer.js";
+import { SUPPORT_WORKER_ORIGIN } from "../shared/support-config.js";
 import archiver from "archiver";
 import helmet from "helmet";
 import { steamRoutes } from "./steam-routes.js";
@@ -213,7 +214,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // 🛡️ Sentinel: Add security headers with Helmet
   // Configured to allow Vite/React (unsafe-inline/eval) in dev, and IGDB images everywhere
   const scriptSrc = ["'self'"];
-  const connectSrc = ["'self'", "https://raw.githubusercontent.com", "https://api.github.com"];
+  const connectSrc = [
+    "'self'",
+    "https://raw.githubusercontent.com",
+    "https://api.github.com",
+    SUPPORT_WORKER_ORIGIN,
+  ];
 
   if (!appConfig.server.isProduction) {
     scriptSrc.push("'unsafe-inline'", "'unsafe-eval'");

--- a/shared/support-config.ts
+++ b/shared/support-config.ts
@@ -1,0 +1,3 @@
+export const SUPPORT_WORKER_URL = "https://questarr-log-collector.questarr.workers.dev";
+export const SUPPORT_WORKER_ORIGIN = new URL(SUPPORT_WORKER_URL).origin;
+export const GITHUB_ISSUES_URL = "https://github.com/Doezer/Questarr/issues/new";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ const { version } = JSON.parse(
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   define: {
-    __APP_VERSION__: JSON.stringify(version),
+    "globalThis.__APP_VERSION__": JSON.stringify(version),
   },
   resolve: {
     alias: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,18 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
-import path from "path";
+import path from "node:path";
+import { readFileSync } from "node:fs";
+
+const { version } = JSON.parse(
+  readFileSync(path.resolve(import.meta.dirname, "package.json"), "utf-8")
+) as { version: string };
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   resolve: {
     alias: {
       "@": path.resolve(import.meta.dirname, "client", "src"),
@@ -18,7 +27,7 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: (id) => {
-          const p = id.replace(/\\/g, "/");
+          const p = id.replaceAll("\\", "/");
           if (!p.includes("/node_modules/")) return;
           if (/\/node_modules\/(react|react-dom|scheduler)\//.test(p)) return "react";
           if (p.includes("/node_modules/@tanstack/")) return "react-query";


### PR DESCRIPTION
This pull request introduces a new `SendLogsDialog` component for uploading logs to support, along with comprehensive tests for both the dialog and the underlying log upload utilities. The changes ensure that logs are scrubbed of PII, uploaded securely, and that users receive clear feedback and guidance throughout the process. The most important changes are summarized below.

### New Feature: Send Logs Dialog

* Added the `SendLogsDialog` component (`client/src/components/SendLogsDialog.tsx`) for uploading logs to support, including UI for consent, upload progress, success (with support code and GitHub issue link), and error handling. The dialog scrubs PII from logs, detects platform, and provides user feedback via toasts and UI states.

### Testing: Dialog and Log Upload Utilities

* Added a full test suite for the `SendLogsDialog` component (`client/__tests__/SendLogsDialog.test.tsx`), covering log submission, error and rate-limit handling, clipboard copy feedback, and UI state transitions.
* Added a test suite for log upload utilities (`client/__tests__/send-logs.test.ts`), verifying PII scrubbing, log submission, error handling, GitHub issue URL generation, and platform detection.

### Test Improvements and Fixes

* Improved an existing test in `LogsPage.remaining.test.tsx` to ensure log streaming events are handled inside `act` for proper React state updates.
* Added `act` import to `LogsPage.remaining.test.tsx` to support the above fix.