### PR TITLE
Add periodic downloader and indexer version logging

### DIFF
--- a/client/__tests__/CalendarPage.test.tsx
+++ b/client/__tests__/CalendarPage.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TooltipProvider } from "../src/components/ui/tooltip";
 import CalendarPage from "../src/pages/calendar";
@@ -90,8 +90,14 @@ function mockGamesFetch(games: unknown[]) {
 
 describe("CalendarPage", () => {
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-29T12:00:00Z"));
     vi.clearAllMocks();
     mockGamesFetch([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("shows the IGDB setup prompt when configuration is missing", async () => {

--- a/server/__tests__/downloaders.test.ts
+++ b/server/__tests__/downloaders.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Downloader } from "../../shared/schema";
 import { safeFetch } from "../ssrf.js";
+import { downloadersLogger } from "../logger.js";
 import {
   TransmissionClient,
   RTorrentClient,
@@ -100,13 +101,13 @@ describe("TransmissionClient", () => {
         ok: true,
         json: async () => ({
           result: "success",
-          arguments: { "session-id": "12345" },
+          arguments: { "session-id": "12345", version: "4.0.6", "rpc-version": 17 },
         }),
       });
 
       const result = await client.testConnection();
       expect(result.success).toBe(true);
-      expect(result.message).toContain("Connected successfully");
+      expect(result.message).toBe("Connected successfully to Transmission 4.0.6");
     });
 
     it("should handle authentication failure", async () => {
@@ -120,6 +121,33 @@ describe("TransmissionClient", () => {
       const result = await client.testConnection();
       expect(result.success).toBe(false);
       expect(result.message).toContain("Authentication failed");
+    });
+
+    it("should log version info from session-get", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: "success",
+          arguments: {
+            version: "4.0.6",
+            "rpc-version": 17,
+            "rpc-version-minimum": 1,
+          },
+        }),
+      });
+
+      await client.logVersionInfo();
+
+      expect(downloadersLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          downloaderId: "trans-1",
+          downloaderType: "transmission",
+          version: "4.0.6",
+          rpcVersion: 17,
+          rpcVersionMinimum: 1,
+        }),
+        "Downloader version probe completed"
+      );
     });
   });
 

--- a/server/__tests__/downloaders_clients_regression.test.ts
+++ b/server/__tests__/downloaders_clients_regression.test.ts
@@ -1572,7 +1572,8 @@ describe("downloader client regression coverage", () => {
     } as Response);
     await expect(client.testConnection()).resolves.toEqual({
       success: false,
-      message: "HTTP 500: Boom - server error",
+      message:
+        "Failed to connect to SABnzbd at http://localhost:8080/api?apikey=api-key&mode=version&output=json: HTTP 500: Boom - server error",
     });
 
     fetchWithFallbackSpy.mockRejectedValueOnce(new Error("connect boom"));

--- a/server/__tests__/downloaders_sabnzbd_remaining.test.ts
+++ b/server/__tests__/downloaders_sabnzbd_remaining.test.ts
@@ -209,7 +209,8 @@ describe("sabnzbd remaining regression coverage", () => {
     } as Response);
     await expect(client.testConnection()).resolves.toEqual({
       success: false,
-      message: "HTTP 500: Broken - No error details",
+      message:
+        "Failed to connect to SABnzbd at http://sab.local/api?apikey=api-key&mode=version&output=json: HTTP 500: Broken - No error details",
     });
 
     safeFetchMock.mockResolvedValueOnce({

--- a/server/__tests__/newznab.test.ts
+++ b/server/__tests__/newznab.test.ts
@@ -214,7 +214,7 @@ describe("NewznabClient", () => {
   });
 
   describe("logVersionInfo", () => {
-    it("logs newznab server version from caps", async () => {
+    it("logs newznab server version from caps without duplicating api", async () => {
       (isSafeUrl as Mock).mockResolvedValue(true);
       (safeFetch as Mock).mockResolvedValue({
         ok: true,
@@ -222,6 +222,12 @@ describe("NewznabClient", () => {
       });
 
       await newznabClient.logVersionInfo(mockIndexer);
+
+      expect(isSafeUrl).toHaveBeenNthCalledWith(1, "http://example.com/api");
+      expect(isSafeUrl).toHaveBeenNthCalledWith(2, "http://example.com/api?apikey=secret&t=caps");
+      expect(safeFetch).toHaveBeenCalledWith("http://example.com/api?apikey=secret&t=caps", {
+        signal: expect.any(AbortSignal),
+      });
 
       expect(routesLogger.info).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -232,6 +238,22 @@ describe("NewznabClient", () => {
         }),
         "Indexer version probe completed"
       );
+    });
+
+    it("logs newznab server version from the api caps endpoint when the configured URL omits it", async () => {
+      (isSafeUrl as Mock).mockResolvedValue(true);
+      (safeFetch as Mock).mockResolvedValue({
+        ok: true,
+        text: async () => mockCapsWithVersionXml,
+      });
+
+      await newznabClient.logVersionInfo({ ...mockIndexer, url: "http://example.com" });
+
+      expect(isSafeUrl).toHaveBeenNthCalledWith(1, "http://example.com");
+      expect(isSafeUrl).toHaveBeenNthCalledWith(2, "http://example.com/api?apikey=secret&t=caps");
+      expect(safeFetch).toHaveBeenCalledWith("http://example.com/api?apikey=secret&t=caps", {
+        signal: expect.any(AbortSignal),
+      });
     });
   });
 

--- a/server/__tests__/newznab.test.ts
+++ b/server/__tests__/newznab.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { newznabClient } from "../newznab.js";
+import { routesLogger } from "../logger.js";
 
 vi.mock("../ssrf.js", () => ({
   isSafeUrl: vi.fn(),
@@ -66,6 +67,11 @@ const mockSearchXml = `<?xml version="1.0" encoding="UTF-8"?>
     </item>
   </channel>
 </rss>`;
+
+const mockCapsWithVersionXml = `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+  <server title="My Newznab" version="7.8.9" />
+</caps>`;
 
 describe("NewznabClient", () => {
   beforeEach(() => {
@@ -204,6 +210,28 @@ describe("NewznabClient", () => {
       const result = await newznabClient.testConnection(mockIndexer);
       expect(result.success).toBe(false);
       expect(result.message).toBe("Invalid API Key");
+    });
+  });
+
+  describe("logVersionInfo", () => {
+    it("logs newznab server version from caps", async () => {
+      (isSafeUrl as Mock).mockResolvedValue(true);
+      (safeFetch as Mock).mockResolvedValue({
+        ok: true,
+        text: async () => mockCapsWithVersionXml,
+      });
+
+      await newznabClient.logVersionInfo(mockIndexer);
+
+      expect(routesLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          indexer: "My Newznab",
+          protocol: "newznab",
+          serverTitle: "My Newznab",
+          serverVersion: "7.8.9",
+        }),
+        "Indexer version probe completed"
+      );
     });
   });
 

--- a/server/__tests__/torznab.test.ts
+++ b/server/__tests__/torznab.test.ts
@@ -8,6 +8,7 @@ vi.mock("../logger.js", () => ({
 vi.mock("../ssrf.js", () => ({ safeFetch: vi.fn() }));
 
 const { TorznabClient } = await import("../torznab.js");
+const { torznabLogger } = await import("../logger.js");
 const { safeFetch } = await import("../ssrf.js");
 
 const mockSafeFetch = vi.mocked(safeFetch);
@@ -54,6 +55,13 @@ function mockFetchResponse(xml: string) {
     statusText: "OK",
     text: async () => xml,
   } as Response);
+}
+
+function makeCapsXml(version = "1.2.3", title = "Test Torznab"): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+  <server title="${title}" version="${version}" />
+</caps>`;
 }
 
 describe("TorznabClient — download link rewriting", () => {
@@ -159,5 +167,21 @@ describe("TorznabClient — download link rewriting", () => {
     // No apiKey → falls through to standard host rewrite
     const link = result.items[0].link;
     expect(new URL(link).host).toBe("prowlarr:9696");
+  });
+
+  it("logs torznab server version from caps", async () => {
+    mockFetchResponse(makeCapsXml("2.4.0", "My Torznab"));
+
+    await client.logVersionInfo(makeIndexer());
+
+    expect(torznabLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        indexer: "Test Indexer",
+        protocol: "torznab",
+        serverTitle: "My Torznab",
+        serverVersion: "2.4.0",
+      }),
+      "Indexer version probe completed"
+    );
   });
 });

--- a/server/__tests__/torznab.test.ts
+++ b/server/__tests__/torznab.test.ts
@@ -5,12 +5,13 @@ vi.mock("../db.js", () => ({ pool: {}, db: {} }));
 vi.mock("../logger.js", () => ({
   torznabLogger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
-vi.mock("../ssrf.js", () => ({ safeFetch: vi.fn() }));
+vi.mock("../ssrf.js", () => ({ isSafeUrl: vi.fn(), safeFetch: vi.fn() }));
 
 const { TorznabClient } = await import("../torznab.js");
 const { torznabLogger } = await import("../logger.js");
-const { safeFetch } = await import("../ssrf.js");
+const { isSafeUrl, safeFetch } = await import("../ssrf.js");
 
+const mockIsSafeUrl = vi.mocked(isSafeUrl);
 const mockSafeFetch = vi.mocked(safeFetch);
 
 function makeIndexer(overrides: Partial<Indexer> = {}): Indexer {
@@ -170,9 +171,20 @@ describe("TorznabClient — download link rewriting", () => {
   });
 
   it("logs torznab server version from caps", async () => {
+    mockIsSafeUrl.mockResolvedValue(true);
     mockFetchResponse(makeCapsXml("2.4.0", "My Torznab"));
 
     await client.logVersionInfo(makeIndexer());
+
+    expect(mockIsSafeUrl).toHaveBeenCalledWith(
+      "http://indexer.example.com/api/?t=caps&apikey=testkey"
+    );
+    expect(mockSafeFetch).toHaveBeenCalledWith(
+      "http://indexer.example.com/api/?t=caps&apikey=testkey",
+      expect.objectContaining({
+        headers: { "User-Agent": "Questarr/1.0" },
+      })
+    );
 
     expect(torznabLogger.info).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -182,6 +194,23 @@ describe("TorznabClient — download link rewriting", () => {
         serverVersion: "2.4.0",
       }),
       "Indexer version probe completed"
+    );
+  });
+
+  it("logs torznab server version from the api caps endpoint when the configured URL omits it", async () => {
+    mockIsSafeUrl.mockResolvedValue(true);
+    mockFetchResponse(makeCapsXml("2.4.0", "My Torznab"));
+
+    await client.logVersionInfo(makeIndexer({ url: "http://indexer.example.com/5" }));
+
+    expect(mockIsSafeUrl).toHaveBeenCalledWith(
+      "http://indexer.example.com/5/api/?t=caps&apikey=testkey"
+    );
+    expect(mockSafeFetch).toHaveBeenCalledWith(
+      "http://indexer.example.com/5/api/?t=caps&apikey=testkey",
+      expect.objectContaining({
+        headers: { "User-Agent": "Questarr/1.0" },
+      })
     );
   });
 });

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -3,6 +3,8 @@ import { igdbClient, IGDB_EARLY_ACCESS_STATUS } from "./igdb.js";
 import { igdbLogger } from "./logger.js";
 import { notifyUser } from "./socket.js";
 import { DownloaderManager } from "./downloaders.js";
+import { torznabClient } from "./torznab.js";
+import { newznabClient } from "./newznab.js";
 import { searchAllIndexers, filterBlacklistedReleases, type SearchItem } from "./search.js";
 import { xrelClient, DEFAULT_XREL_BASE } from "./xrel.js";
 import { steamService } from "./steam.js";
@@ -35,6 +37,7 @@ const downloadMissCount = new Map<string, number>();
 const DOWNLOAD_MISS_THRESHOLD = 3;
 const AUTO_SEARCH_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const XREL_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours (xREL search rate limit: 2/5s)
+const CLIENT_VERSION_LOG_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
 const OWNED_STATUSES = new Set(["owned", "completed", "downloading"]);
 
 const GAME_UPDATE_TITLE_TO_EVENT: Record<string, NotificationEvent> = {
@@ -271,6 +274,7 @@ export function startCronJobs() {
     checkDownloadStatus().catch((err) => igdbLogger.error({ err }, "Error in checkDownloadStatus"));
     checkAutoSearch().catch((err) => igdbLogger.error({ err }, "Error in checkAutoSearch"));
     checkXrelReleases().catch((err) => igdbLogger.error({ err }, "Error in checkXrelReleases"));
+    logClientVersions().catch((err) => igdbLogger.warn({ err }, "Error in logClientVersions"));
   }, 10000);
 
   // Schedule periodic checks
@@ -289,6 +293,35 @@ export function startCronJobs() {
   setInterval(() => {
     checkXrelReleases().catch((err) => igdbLogger.error({ err }, "Error in checkXrelReleases"));
   }, XREL_CHECK_INTERVAL_MS);
+
+  setInterval(() => {
+    logClientVersions().catch((err) => igdbLogger.warn({ err }, "Error in logClientVersions"));
+  }, CLIENT_VERSION_LOG_INTERVAL_MS);
+}
+
+async function logClientVersions(): Promise<void> {
+  const [downloaders, indexers] = await Promise.all([
+    storage.getEnabledDownloaders(),
+    storage.getEnabledIndexers(),
+  ]);
+
+  if (downloaders.length === 0 && indexers.length === 0) {
+    return;
+  }
+
+  igdbLogger.debug(
+    { downloaderCount: downloaders.length, indexerCount: indexers.length },
+    "Running periodic client version probes"
+  );
+
+  await Promise.allSettled([
+    ...downloaders.map((downloader) => DownloaderManager.logVersionInfo(downloader)),
+    ...indexers.map((indexer) =>
+      indexer.protocol === "newznab"
+        ? newznabClient.logVersionInfo(indexer)
+        : torznabClient.logVersionInfo(indexer)
+    ),
+  ]);
 }
 
 export async function checkGameUpdates() {

--- a/server/downloaders/manager.ts
+++ b/server/downloaders/manager.ts
@@ -51,6 +51,19 @@ export class DownloaderManager {
     }
   }
 
+  static async logVersionInfo(downloader: Downloader): Promise<void> {
+    try {
+      const client = this.createClient(downloader);
+      await client.logVersionInfo();
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      downloadersLogger.warn(
+        { downloaderId: downloader.id, downloaderType: downloader.type, error: errorMessage },
+        "Downloader version probe failed"
+      );
+    }
+  }
+
   static async addDownload(
     downloader: Downloader,
     request: DownloadRequest

--- a/server/downloaders/nzbget.ts
+++ b/server/downloaders/nzbget.ts
@@ -258,6 +258,18 @@ export class NZBGetClient implements DownloaderClient {
     }
   }
 
+  async logVersionInfo(): Promise<void> {
+    const version = await this.makeXMLRPCRequest("version");
+    downloadersLogger.info(
+      {
+        downloaderId: this.downloader.id,
+        downloaderType: this.downloader.type,
+        version,
+      },
+      "Downloader version probe completed"
+    );
+  }
+
   async addDownload(
     request: DownloadRequest
   ): Promise<{ success: boolean; id?: string; message: string }> {

--- a/server/downloaders/qbittorrent.ts
+++ b/server/downloaders/qbittorrent.ts
@@ -56,14 +56,25 @@ export class QBittorrentClient implements DownloaderClient {
   async testConnection(): Promise<{ success: boolean; message: string }> {
     try {
       await this.authenticate();
-      // Test by getting app version
-      const response = await this.makeRequest("GET", "/api/v2/app/version");
-      const version = await response.text();
+      const version = await this.getAppVersion();
       return { success: true, message: `Connected successfully to qBittorrent ${version}` };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
       return { success: false, message: `Failed to connect to qBittorrent: ${errorMessage}` };
     }
+  }
+
+  async logVersionInfo(): Promise<void> {
+    await this.authenticate();
+    const version = await this.getAppVersion();
+    downloadersLogger.info(
+      {
+        downloaderId: this.downloader.id,
+        downloaderType: this.downloader.type,
+        version,
+      },
+      "Downloader version probe completed"
+    );
   }
 
   async addDownload(
@@ -991,6 +1002,11 @@ export class QBittorrentClient implements DownloaderClient {
       .trim();
 
     return cleaned.length > 0 ? cleaned : "torrent.torrent";
+  }
+
+  private async getAppVersion(): Promise<string> {
+    const response = await this.makeRequest("GET", "/api/v2/app/version");
+    return (await response.text()).trim();
   }
 
   private async authenticate(force = false): Promise<void> {

--- a/server/downloaders/rtorrent.ts
+++ b/server/downloaders/rtorrent.ts
@@ -66,6 +66,18 @@ export class RTorrentClient implements DownloaderClient {
     }
   }
 
+  async logVersionInfo(): Promise<void> {
+    const version = await this.makeXMLRPCRequest("system.client_version", []);
+    downloadersLogger.info(
+      {
+        downloaderId: this.downloader.id,
+        downloaderType: this.downloader.type,
+        version,
+      },
+      "Downloader version probe completed"
+    );
+  }
+
   async addDownload(
     request: DownloadRequest
   ): Promise<{ success: boolean; id?: string; message: string }> {

--- a/server/downloaders/sabnzbd.ts
+++ b/server/downloaders/sabnzbd.ts
@@ -176,20 +176,8 @@ export class SABnzbdClient implements DownloaderClient {
   }
 
   async testConnection(): Promise<{ success: boolean; message: string }> {
-    const url = this.getApiUrl("version");
     try {
-      downloadersLogger.debug({ url }, "Testing SABnzbd connection");
-      const response = await this.fetchWithFallback(url, { signal: AbortSignal.timeout(10000) });
-
-      if (!response.ok) {
-        const errorText = await response.text().catch(() => "No error details");
-        return {
-          success: false,
-          message: `HTTP ${response.status}: ${response.statusText} - ${errorText}`,
-        };
-      }
-
-      const data = await response.json();
+      const data = await this.getVersionInfo();
       if (data.version) {
         return { success: true, message: `Connected to SABnzbd v${data.version}` };
       }
@@ -197,12 +185,45 @@ export class SABnzbdClient implements DownloaderClient {
       return { success: false, message: "Invalid SABnzbd response - missing version field" };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
-      downloadersLogger.error({ error, url }, "SABnzbd connection test failed");
+      downloadersLogger.error({ error, url: this.getApiUrl("version") }, "SABnzbd connection test failed");
       return {
         success: false,
-        message: `Failed to connect to SABnzbd at ${url}: ${errorMessage}`,
+        message: `Failed to connect to SABnzbd at ${this.getApiUrl("version")}: ${errorMessage}`,
       };
     }
+  }
+
+  async logVersionInfo(): Promise<void> {
+    const data = await this.getVersionInfo();
+    if (!data.version) {
+      downloadersLogger.debug(
+        { downloaderId: this.downloader.id, downloaderType: this.downloader.type },
+        "SABnzbd version endpoint did not expose version info"
+      );
+      return;
+    }
+
+    downloadersLogger.info(
+      {
+        downloaderId: this.downloader.id,
+        downloaderType: this.downloader.type,
+        version: data.version,
+      },
+      "Downloader version probe completed"
+    );
+  }
+
+  private async getVersionInfo(): Promise<Record<string, unknown>> {
+    const url = this.getApiUrl("version");
+    downloadersLogger.debug({ url }, "Testing SABnzbd connection");
+    const response = await this.fetchWithFallback(url, { signal: AbortSignal.timeout(10000) });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "No error details");
+      throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
+    }
+
+    return (await response.json()) as Record<string, unknown>;
   }
 
   async addDownload(

--- a/server/downloaders/synology.ts
+++ b/server/downloaders/synology.ts
@@ -645,6 +645,27 @@ export class SynologyDownloadStationClient implements DownloaderClient {
     }
   }
 
+  async logVersionInfo(): Promise<void> {
+    await this.ensureApiInfo();
+
+    const authDescriptor = this.apiInfo?.["SYNO.API.Auth"];
+    const taskDescriptor = this.apiInfo?.["SYNO.DownloadStation2.Task"];
+    const legacyTaskDescriptor = this.apiInfo?.["SYNO.DownloadStation.Task"];
+    const fileStationDescriptor = this.apiInfo?.["SYNO.FileStation.Info"];
+
+    downloadersLogger.info(
+      {
+        downloaderId: this.downloader.id,
+        downloaderType: this.downloader.type,
+        authApiVersion: authDescriptor?.maxVersion,
+        downloadStationTaskApiVersion: taskDescriptor?.maxVersion,
+        legacyDownloadStationTaskApiVersion: legacyTaskDescriptor?.maxVersion,
+        fileStationApiVersion: fileStationDescriptor?.maxVersion,
+      },
+      "Downloader version probe completed"
+    );
+  }
+
   async addDownload(
     request: DownloadRequest
   ): Promise<{ success: boolean; id?: string; message: string }> {

--- a/server/downloaders/transmission.ts
+++ b/server/downloaders/transmission.ts
@@ -102,12 +102,19 @@ export class TransmissionClient implements DownloaderClient {
 
   async testConnection(): Promise<{ success: boolean; message: string }> {
     try {
-      const _response = await this.makeRequest("session-get", {});
+      const response = await this.makeRequest("session-get", {});
+      const version = response.arguments?.version;
       downloadersLogger.info(
         { url: this.downloader.url },
         "Transmission connection test successful"
       );
-      return { success: true, message: "Connected successfully to Transmission" };
+      return {
+        success: true,
+        message:
+          typeof version === "string"
+            ? `Connected successfully to Transmission ${version}`
+            : "Connected successfully to Transmission",
+      };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
       downloadersLogger.error(
@@ -124,6 +131,32 @@ export class TransmissionClient implements DownloaderClient {
       }
       return { success: false, message: `Failed to connect to Transmission: ${errorMessage}` };
     }
+  }
+
+  async logVersionInfo(): Promise<void> {
+    const response = await this.makeRequest("session-get", {});
+    const version = response.arguments?.version;
+    const rpcVersion = response.arguments?.["rpc-version"];
+    const rpcVersionMinimum = response.arguments?.["rpc-version-minimum"];
+
+    if (typeof version !== "string" && typeof rpcVersion !== "number") {
+      downloadersLogger.debug(
+        { downloaderId: this.downloader.id, downloaderType: this.downloader.type },
+        "Transmission session-get did not expose version info"
+      );
+      return;
+    }
+
+    downloadersLogger.info(
+      {
+        downloaderId: this.downloader.id,
+        downloaderType: this.downloader.type,
+        version,
+        rpcVersion,
+        rpcVersionMinimum,
+      },
+      "Downloader version probe completed"
+    );
   }
 
   async addDownload(

--- a/server/downloaders/types.ts
+++ b/server/downloaders/types.ts
@@ -23,6 +23,7 @@ export interface DownloadResult extends DownloaderActionResult {
 
 export interface DownloaderClient {
   testConnection(): Promise<DownloaderActionResult>;
+  logVersionInfo(): Promise<void>;
   addDownload(request: DownloadRequest): Promise<DownloadResult>;
   getDownloadStatus(id: string): Promise<DownloadStatus | null>;
   getDownloadDetails(id: string): Promise<DownloadDetails | null>;

--- a/server/newznab.ts
+++ b/server/newznab.ts
@@ -43,6 +43,11 @@ export interface NewznabCategory {
   name: string;
 }
 
+interface NewznabServerInfo {
+  title?: string;
+  version?: string;
+}
+
 class NewznabClient {
   /**
    * Search a single Newznab indexer
@@ -418,6 +423,64 @@ class NewznabClient {
         message: error instanceof Error ? error.message : "Unknown error",
       };
     }
+  }
+
+  async logVersionInfo(indexer: Indexer): Promise<void> {
+    try {
+      const serverInfo = await this.fetchServerInfo(indexer);
+      if (!serverInfo.title && !serverInfo.version) {
+        routesLogger.debug(
+          { indexerId: indexer.id, indexer: indexer.name },
+          "Newznab caps response did not expose version info"
+        );
+        return;
+      }
+
+      routesLogger.info(
+        {
+          indexerId: indexer.id,
+          indexer: indexer.name,
+          protocol: indexer.protocol,
+          serverTitle: serverInfo.title,
+          serverVersion: serverInfo.version,
+        },
+        "Indexer version probe completed"
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      routesLogger.warn(
+        { indexerId: indexer.id, indexer: indexer.name, error: errorMessage },
+        "Indexer version probe failed"
+      );
+    }
+  }
+
+  private async fetchServerInfo(indexer: Indexer): Promise<NewznabServerInfo> {
+    if (!(await isSafeUrl(indexer.url))) {
+      throw new Error(`Unsafe URL detected: ${indexer.url}`);
+    }
+
+    const url = new URL(indexer.url);
+    url.pathname = url.pathname.endsWith("/") ? `${url.pathname}api` : `${url.pathname}/api`;
+    url.searchParams.set("apikey", indexer.apiKey);
+    url.searchParams.set("t", "caps");
+
+    const response = await safeFetch(url.toString(), {
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const xmlText = await response.text();
+    const data = parser.parse(xmlText);
+    const server = data.caps?.server;
+
+    return {
+      title: typeof server?.["@_title"] === "string" ? server["@_title"] : undefined,
+      version: typeof server?.["@_version"] === "string" ? server["@_version"] : undefined,
+    };
   }
 }
 

--- a/server/newznab.ts
+++ b/server/newznab.ts
@@ -49,6 +49,15 @@ interface NewznabServerInfo {
 }
 
 class NewznabClient {
+  private buildApiUrl(indexerUrl: string): URL {
+    const url = new URL(indexerUrl);
+    if (!url.pathname.includes("/api")) {
+      url.pathname = url.pathname.endsWith("/") ? `${url.pathname}api` : `${url.pathname}/api`;
+    }
+
+    return url;
+  }
+
   /**
    * Search a single Newznab indexer
    */
@@ -59,11 +68,7 @@ class NewznabClient {
         throw new Error(`Unsafe URL detected: ${indexer.url}`);
       }
 
-      const url = new URL(indexer.url);
-      // Don't modify pathname if it already contains 'api'
-      if (!url.pathname.includes("/api")) {
-        url.pathname = url.pathname.endsWith("/") ? `${url.pathname}api` : `${url.pathname}/api`;
-      }
+      const url = this.buildApiUrl(indexer.url);
 
       // Build Newznab search parameters
       url.searchParams.set("apikey", indexer.apiKey);
@@ -460,10 +465,13 @@ class NewznabClient {
       throw new Error(`Unsafe URL detected: ${indexer.url}`);
     }
 
-    const url = new URL(indexer.url);
-    url.pathname = url.pathname.endsWith("/") ? `${url.pathname}api` : `${url.pathname}/api`;
+    const url = this.buildApiUrl(indexer.url);
     url.searchParams.set("apikey", indexer.apiKey);
     url.searchParams.set("t", "caps");
+
+    if (!(await isSafeUrl(url.toString()))) {
+      throw new Error(`Unsafe URL detected: ${url.toString()}`);
+    }
 
     const response = await safeFetch(url.toString(), {
       signal: AbortSignal.timeout(10000),

--- a/server/torznab.ts
+++ b/server/torznab.ts
@@ -1,6 +1,6 @@
 import { type Indexer } from "@shared/schema";
 import { torznabLogger } from "./logger.js";
-import { safeFetch } from "./ssrf.js";
+import { isSafeUrl, safeFetch } from "./ssrf.js";
 import { XMLParser } from "fast-xml-parser";
 
 interface TorznabItem {
@@ -53,6 +53,19 @@ export class TorznabClient {
       textNodeName: "#text",
       isArray: (name: string) => ["item", "category"].includes(name),
     });
+  }
+
+  private buildApiUrl(indexerUrl: string): URL {
+    const url = new URL(indexerUrl);
+
+    if (!url.pathname.endsWith("/")) {
+      url.pathname += "/";
+    }
+    if (!url.pathname.includes("/api")) {
+      url.pathname += "api/";
+    }
+
+    return url;
   }
 
   /**
@@ -224,15 +237,7 @@ export class TorznabClient {
    * Build the search URL for a Torznab indexer
    */
   private buildSearchUrl(indexer: Indexer, params: TorznabSearchParams): string {
-    const url = new URL(indexer.url);
-
-    // Ensure the URL ends with a slash and has the correct path
-    if (!url.pathname.endsWith("/")) {
-      url.pathname += "/";
-    }
-    if (!url.pathname.includes("/api")) {
-      url.pathname += "api/";
-    }
+    const url = this.buildApiUrl(indexer.url);
 
     // Set common Torznab parameters
     url.searchParams.set("t", "search");
@@ -280,9 +285,13 @@ export class TorznabClient {
   }
 
   private async fetchServerInfo(indexer: Indexer): Promise<TorznabServerInfo> {
-    const url = new URL(indexer.url);
+    const url = this.buildApiUrl(indexer.url);
     url.searchParams.set("t", "caps");
     url.searchParams.set("apikey", indexer.apiKey);
+
+    if (!(await isSafeUrl(url.toString()))) {
+      throw new Error(`Unsafe URL detected: ${url.toString()}`);
+    }
 
     const response = await safeFetch(url.toString(), {
       headers: { "User-Agent": "Questarr/1.0" },

--- a/server/torznab.ts
+++ b/server/torznab.ts
@@ -38,6 +38,11 @@ interface TorznabResponse {
   offset?: number;
 }
 
+interface TorznabServerInfo {
+  title?: string;
+  version?: string;
+}
+
 export class TorznabClient {
   private parser: XMLParser;
 
@@ -185,6 +190,36 @@ export class TorznabClient {
     };
   }
 
+  async logVersionInfo(indexer: Indexer): Promise<void> {
+    try {
+      const serverInfo = await this.fetchServerInfo(indexer);
+      if (!serverInfo.title && !serverInfo.version) {
+        torznabLogger.debug(
+          { indexerId: indexer.id, indexer: indexer.name },
+          "Torznab caps response did not expose version info"
+        );
+        return;
+      }
+
+      torznabLogger.info(
+        {
+          indexerId: indexer.id,
+          indexer: indexer.name,
+          protocol: indexer.protocol,
+          serverTitle: serverInfo.title,
+          serverVersion: serverInfo.version,
+        },
+        "Indexer version probe completed"
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      torznabLogger.warn(
+        { indexerId: indexer.id, indexer: indexer.name, error: errorMessage },
+        "Indexer version probe failed"
+      );
+    }
+  }
+
   /**
    * Build the search URL for a Torznab indexer
    */
@@ -242,6 +277,31 @@ export class TorznabClient {
     }
 
     return url.toString();
+  }
+
+  private async fetchServerInfo(indexer: Indexer): Promise<TorznabServerInfo> {
+    const url = new URL(indexer.url);
+    url.searchParams.set("t", "caps");
+    url.searchParams.set("apikey", indexer.apiKey);
+
+    const response = await safeFetch(url.toString(), {
+      headers: { "User-Agent": "Questarr/1.0" },
+      signal: AbortSignal.timeout(30000),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "No error details available");
+      throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
+    }
+
+    const xmlData = await response.text();
+    const parsed = this.parser.parse(xmlData);
+    const server = parsed.caps?.server;
+
+    return {
+      title: typeof server?.["@_title"] === "string" ? server["@_title"] : undefined,
+      version: typeof server?.["@_version"] === "string" ? server["@_version"] : undefined,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

- add periodic version probes for enabled downloaders and indexers after startup and every 12 hours
- log documented client and caps version details for all supported downloaders and Torznab/Newznab indexers
- add regression coverage for Transmission, Torznab, and Newznab version logging

## Notes

- Synology logs API descriptor versions because the documented APIs expose capability versions rather than a single product version string