### PR TITLE
⚡ Bolt: Optimize AddGameModal collection status lookup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 
 **Learning:** Found multiple O(n) array traversals (filter, map, reduce, flatMap) within a React useMemo hook processing game statistics. Replacing these multiple array methods with a single manual loop significantly improves performance on the hot path (re-evaluating stats) by reducing redundant iterations and object allocations.
 **Action:** Always scrutinize React useMemo hooks operating on collections for unnecessary or repeated iterations, and consider combining loops.
+## 2025-05-23 - Optimizing O(N*M) lookups in React loops
+
+**Learning:** Nesting array `.some()` or `.find()` calls inside a `.map()` loop (e.g., to check if an API search result exists in the user's local library) creates an O(N*M) time complexity that runs on every render, severely degrading performance for large collections.
+**Action:** Always optimize nested array lookups by pre-computing a `Set` or `Map` of unique identifiers from the target array inside a `useMemo` hook. This reduces the time complexity to O(N+M) and prevents redundant parsing on re-renders.

--- a/client/src/components/AddGameModal.tsx
+++ b/client/src/components/AddGameModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import {
   Dialog,
@@ -134,10 +134,13 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
   };
 
   // Mark games already in collection
-  const resultsWithCollectionStatus: SearchResult[] = searchResults.map((game: Game) => ({
-    ...game,
-    inCollection: userGames.some((userGame) => userGame.igdbId === game.igdbId),
-  }));
+  const resultsWithCollectionStatus: SearchResult[] = useMemo(() => {
+    const userGameIgdbIds = new Set(userGames.map((userGame) => userGame.igdbId));
+    return searchResults.map((game: Game) => ({
+      ...game,
+      inCollection: userGameIgdbIds.has(game.igdbId),
+    }));
+  }, [searchResults, userGames]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
💡 What: Wrapped the `resultsWithCollectionStatus` mapping in a `useMemo` hook and replaced the `userGames.some(...)` lookup with a `Set` to achieve O(1) membership checks.

🎯 Why: The original logic evaluated an $O(N \times M)$ nested array iteration (where N is search results and M is the user's library) directly in the component body. This meant it was re-calculating on every single keystroke during the search typing debounce and any other state change in `AddGameModal`, causing micro-stutters for users with large libraries.

📊 Impact: Reduces time complexity from $O(N \times M)$ to $O(N + M)$ and ensures the calculation is strictly memoized to only run when the search results or local library actually change.

🔬 Measurement: Observe the "Add Game" modal's typing responsiveness and render timings in React DevTools, especially for users with hundreds of games in their library.

---

*PR created automatically by Jules for task [7444706966073268596](https://jules.google.com/task/7444706966073268596) started by @Doezer*