### PR TITLE
⚡ Bolt: Consolidate array iterations in Discover page for O(N) performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,6 @@
 
 **Learning:** Found multiple O(n) array traversals (filter, map, reduce, flatMap) within a React useMemo hook processing game statistics. Replacing these multiple array methods with a single manual loop significantly improves performance on the hot path (re-evaluating stats) by reducing redundant iterations and object allocations.
 **Action:** Always scrutinize React useMemo hooks operating on collections for unnecessary or repeated iterations, and consider combining loops.
+## 2026-06-10 - Consolidating O(N) array loops in useMemo
+**Learning:** Chained array operations like `.filter().map()` inside `useMemo` hooks will iterate over arrays multiple times and create several unnecessary intermediate arrays, compounding overhead significantly as N grows.
+**Action:** When computing multiple derived states from a single large array (e.g. mapping IDs by multiple criteria), consolidate all calculations into a single `for...of` loop inside one `useMemo`.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -35,3 +35,6 @@
 ## 2026-06-10 - Consolidating O(N) array loops in useMemo
 **Learning:** Chained array operations like `.filter().map()` inside `useMemo` hooks will iterate over arrays multiple times and create several unnecessary intermediate arrays, compounding overhead significantly as N grows.
 **Action:** When computing multiple derived states from a single large array (e.g. mapping IDs by multiple criteria), consolidate all calculations into a single `for...of` loop inside one `useMemo`.
+## 2026-06-10 - Handling nullable properties in object-mapped Set lookups
+**Learning:** When adding elements to a `Set<number>` from an object property (like `igdbId`), failing to handle `null`/`undefined` values causes TypeScript build failures when later using `Set.has()` on objects that might legitimately have a null ID.
+**Action:** When filtering or transforming objects by properties that can be `null` in the schema, add an explicit check to early-return or fallback to avoid passing `null` into `Set.has()`.

--- a/client/src/pages/discover.tsx
+++ b/client/src/pages/discover.tsx
@@ -145,6 +145,8 @@ export default function DiscoverPage() {
   const filterGames = useCallback(
     (games: Game[]) => {
       return games.filter((g: Game) => {
+        if (g.igdbId === null) return true; // Keep games without IGDB ID as we can't reliably filter them
+
         if (hiddenIgdbIds.has(g.igdbId)) return false;
 
         if (hideOwned && ownedIgdbIds.has(g.igdbId)) return false;

--- a/client/src/pages/discover.tsx
+++ b/client/src/pages/discover.tsx
@@ -109,32 +109,37 @@ export default function DiscoverPage() {
     enabled: !!config?.igdb.configured,
   });
 
-  const hiddenIgdbIds = useMemo(() => {
-    return new Set(localGames.filter((g) => g.hidden).map((g) => g.igdbId));
-  }, [localGames]);
+  // ⚡ Bolt: Consolidated multiple array passes into a single loop to avoid unnecessary intermediate allocations and reduce iteration overhead (O(N) instead of O(4N)).
+  const { hiddenIgdbIds, ownedIgdbIds, wantedIgdbIds, igdbToLocalIdMap } = useMemo(() => {
+    const hidden = new Set<number>();
+    const owned = new Set<number>();
+    const wanted = new Set<number>();
+    const idMap = new Map<number, string>();
 
-  const ownedIgdbIds = useMemo(() => {
-    return new Set(
-      localGames
-        .filter(
-          (g) => g.status === "owned" || g.status === "completed" || g.status === "downloading"
-        )
-        .map((g) => g.igdbId)
-    );
-  }, [localGames]);
+    for (const g of localGames) {
+      if (g.igdbId) {
+        idMap.set(g.igdbId, g.id);
 
-  const wantedIgdbIds = useMemo(() => {
-    return new Set(
-      localGames.filter((g) => g.status === "wanted" && !g.hidden).map((g) => g.igdbId)
-    );
-  }, [localGames]);
+        if (g.hidden) {
+          hidden.add(g.igdbId);
+        }
 
-  const igdbToLocalIdMap = useMemo(() => {
-    const map = new Map<number, string>();
-    localGames.forEach((g) => {
-      if (g.igdbId) map.set(g.igdbId, g.id);
-    });
-    return map;
+        if (g.status === "owned" || g.status === "completed" || g.status === "downloading") {
+          owned.add(g.igdbId);
+        }
+
+        if (g.status === "wanted" && !g.hidden) {
+          wanted.add(g.igdbId);
+        }
+      }
+    }
+
+    return {
+      hiddenIgdbIds: hidden,
+      ownedIgdbIds: owned,
+      wantedIgdbIds: wanted,
+      igdbToLocalIdMap: idMap,
+    };
   }, [localGames]);
 
   const filterGames = useCallback(

--- a/client/src/pages/discover.tsx
+++ b/client/src/pages/discover.tsx
@@ -145,7 +145,7 @@ export default function DiscoverPage() {
   const filterGames = useCallback(
     (games: Game[]) => {
       return games.filter((g: Game) => {
-        if (g.igdbId === null) return true; // Keep games without IGDB ID as we can't reliably filter them
+        if (g.igdbId === null || g.igdbId === undefined) return true; // Keep games without IGDB ID as we can't reliably filter them
 
         if (hiddenIgdbIds.has(g.igdbId)) return false;
 


### PR DESCRIPTION
💡 What: Consolidated four separate `useMemo` hooks (which used chained `.filter().map()` operations) into a single `useMemo` hook with one `for...of` loop in `client/src/pages/discover.tsx`.
🎯 Why: The previous implementation required 4 distinct iterations over the `localGames` array and created numerous unnecessary intermediate arrays. This caused an O(4N) overhead which can bottleneck React renders when a user's library grows large.
📊 Impact: Reduces iteration overhead from O(4N) to O(N) and completely eliminates intermediate array allocations when computing hidden, wanted, and owned game sets.
🔬 Measurement: Verify the discovery page correctly displays, hides, and filters games depending on user preferences, with no changes in visible behavior but less memory and CPU usage during component mounting/updates.

---

*PR created automatically by Jules for task [7786018460576525198](https://jules.google.com/task/7786018460576525198) started by @Doezer*