### PR TITLE
🎨 Palette: Add ARIA label to download options button

### DIFF
--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -717,7 +717,7 @@ export default function Downloads() {
                         <Button
                           variant="outline"
                           size="icon"
-                          aria-label={`Options for ${download.gameTitle || "download"}`}
+                          aria-label={`Options for ${download.name || 'download'}`}
                           data-testid={`button-menu-${download.id}`}
                         >
                           <MoreHorizontal className="h-4 w-4" />

--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -717,6 +717,7 @@ export default function Downloads() {
                         <Button
                           variant="outline"
                           size="icon"
+                          aria-label={`Options for ${download.gameTitle || "download"}`}
                           data-testid={`button-menu-${download.id}`}
                         >
                           <MoreHorizontal className="h-4 w-4" />

--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -717,7 +717,7 @@ export default function Downloads() {
                         <Button
                           variant="outline"
                           size="icon"
-                          aria-label={`Options for ${download.name || 'download'}`}
+                          aria-label={`Options for ${download.name || "download"}`}
                           data-testid={`button-menu-${download.id}`}
                         >
                           <MoreHorizontal className="h-4 w-4" />

--- a/test-report.junit.xml
+++ b/test-report.junit.xml
@@ -1,0 +1,2357 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites name="vitest tests" tests="1022" failures="0" errors="0" time="39.880405632">
+    <testsuite name="client/__tests__/Accessibility.test.tsx" timestamp="2026-06-10T11:57:55.814Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="0.183854568">
+        <testcase classname="client/__tests__/Accessibility.test.tsx" name="Accessibility Improvements &gt; CompactGameCard &gt; should have descriptive aria-labels for Discovery mode" time="0.108862824">
+        </testcase>
+        <testcase classname="client/__tests__/Accessibility.test.tsx" name="Accessibility Improvements &gt; CompactGameCard &gt; should have descriptive aria-labels for Library mode" time="0.018936712">
+        </testcase>
+        <testcase classname="client/__tests__/Accessibility.test.tsx" name="Accessibility Improvements &gt; GameCard &gt; should have descriptive aria-labels for Discovery mode" time="0.025386866">
+        </testcase>
+        <testcase classname="client/__tests__/Accessibility.test.tsx" name="Accessibility Improvements &gt; GameCard &gt; should have descriptive aria-labels for Library mode" time="0.022432562">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/AddGameModal.test.tsx" timestamp="2026-06-10T11:57:55.818Z" hostname="devbox" tests="5" failures="0" errors="0" skipped="0" time="1.020549998">
+        <testcase classname="client/__tests__/AddGameModal.test.tsx" name="AddGameModal &gt; pre-fills search input from initialQuery prop when modal opens" time="0.461569845">
+            <system-err>
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+
+            </system-err>
+        </testcase>
+        <testcase classname="client/__tests__/AddGameModal.test.tsx" name="AddGameModal &gt; pre-fills search from add-game-store when modal opens without initialQuery" time="0.119659157">
+            <system-err>
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+
+            </system-err>
+        </testcase>
+        <testcase classname="client/__tests__/AddGameModal.test.tsx" name="AddGameModal &gt; clears search state when modal closes" time="0.137199083">
+            <system-err>
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+
+            </system-err>
+        </testcase>
+        <testcase classname="client/__tests__/AddGameModal.test.tsx" name="AddGameModal &gt; shows Calendar icon for search results with a release date" time="0.157587126">
+            <system-err>
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+
+            </system-err>
+        </testcase>
+        <testcase classname="client/__tests__/AddGameModal.test.tsx" name="AddGameModal &gt; shows release year only for year-end release dates (Dec 31)" time="0.139208343">
+            <system-err>
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+
+            </system-err>
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/CompactGameCard.test.tsx" timestamp="2026-06-10T11:57:55.825Z" hostname="devbox" tests="10" failures="0" errors="0" skipped="0" time="0.832881863">
+        <testcase classname="client/__tests__/CompactGameCard.test.tsx" name="CompactGameCard &gt; renders game title and metadata correctly" time="0.101753748">
+        </testcase>
+        <testcase classname="client/__tests__/CompactGameCard.test.tsx" name="CompactGameCard &gt; renders &apos;No genres&apos; when genres is empty or undefined" time="0.015918423">
+        </testcase>
+        <testcase classname="client/__tests__/CompactGameCard.test.tsx" name="CompactGameCard &gt; calls onStatusChange when status button is clicked" time="0.027755045">
+        </testcase>
+        <testcase classname="client/__tests__/CompactGameCard.test.tsx" name="CompactGameCard &gt; calls onViewDetails when info button is clicked" time="0.440464934">
+        </testcase>
+        <testcase classname="client/__tests__/CompactGameCard.test.tsx" name="CompactGameCard &gt; dynamic aria-labels for status button &gt; shows aria-label &apos;Mark undefined as &apos;Owned&apos;&apos; when status is &apos;wanted&apos;" time="0.023236676">
+        </testcase>
+        <testcase classname="client/__tests__/CompactGameCard.test.tsx" name="CompactGameCard &gt; dynamic aria-labels for status button &gt; shows aria-label &apos;Mark undefined as &apos;Completed&apos;&apos; when status is &apos;owned&apos;" time="0.037544861">
+        </testcase>
+        <testcase classname="client/__tests__/CompactGameCard.test.tsx" name="CompactGameCard &gt; dynamic aria-labels for status button &gt; shows aria-label &apos;Mark undefined as &apos;Wanted&apos;&apos; when status is &apos;completed&apos;" time="0.014571486">
+        </testcase>
+        <testcase classname="client/__tests__/CompactGameCard.test.tsx" name="CompactGameCard &gt; shows a loading fallback when opening details" time="0.130390308">
+        </testcase>
+        <testcase classname="client/__tests__/CompactGameCard.test.tsx" name="CompactGameCard &gt; shows Early Access badge when earlyAccess is true" time="0.019054825">
+        </testcase>
+        <testcase classname="client/__tests__/CompactGameCard.test.tsx" name="CompactGameCard &gt; does not show Early Access badge when earlyAccess is false" time="0.01592726">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/DashboardConfig.test.tsx" timestamp="2026-06-10T11:57:55.830Z" hostname="devbox" tests="2" failures="0" errors="0" skipped="0" time="0.763611481">
+        <testcase classname="client/__tests__/DashboardConfig.test.tsx" name="Dashboard Configuration &gt; should persist grid column preference to local storage" time="0.677914091">
+            <system-err>
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+
+            </system-err>
+        </testcase>
+        <testcase classname="client/__tests__/DashboardConfig.test.tsx" name="Dashboard Configuration &gt; should load grid column preference from local storage on mount" time="0.073384468">
+            <system-err>
+[[&quot;/api/games&quot;]]: No queryFn was passed as an option, and no default queryFn was found. The queryFn parameter is only optional when using a default queryFn. More info here: https://tanstack.com/query/latest/docs/framework/react/guides/default-query-function
+
+            </system-err>
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/DashboardStats.test.tsx" timestamp="2026-06-10T11:57:55.833Z" hostname="devbox" tests="1" failures="0" errors="0" skipped="0" time="0.263835436">
+        <testcase classname="client/__tests__/DashboardStats.test.tsx" name="Dashboard Stats Calculation &gt; renders correctly and calculates stats without throwing" time="0.2587995">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/DownloadIndicator.test.tsx" timestamp="2026-06-10T11:57:55.834Z" hostname="devbox" tests="8" failures="0" errors="0" skipped="0" time="0.531902365">
+        <testcase classname="client/__tests__/DownloadIndicator.test.tsx" name="DownloadIndicator &gt; renders nothing when summary is undefined" time="0.02314914">
+        </testcase>
+        <testcase classname="client/__tests__/DownloadIndicator.test.tsx" name="DownloadIndicator &gt; renders blue dot for downloading status" time="0.323273757">
+        </testcase>
+        <testcase classname="client/__tests__/DownloadIndicator.test.tsx" name="DownloadIndicator &gt; renders emerald dot for completed status" time="0.025893356">
+        </testcase>
+        <testcase classname="client/__tests__/DownloadIndicator.test.tsx" name="DownloadIndicator &gt; tooltip shows count and types" time="0.023257063">
+        </testcase>
+        <testcase classname="client/__tests__/DownloadIndicator.test.tsx" name="DownloadIndicator &gt; uses singular &apos;download&apos; when count is 1" time="0.021925686">
+        </testcase>
+        <testcase classname="client/__tests__/DownloadIndicator.test.tsx" name="DownloadIndicator &gt; animate-pulse is applied only for downloading" time="0.052206202">
+        </testcase>
+        <testcase classname="client/__tests__/DownloadIndicator.test.tsx" name="DownloadIndicator &gt; overlay variant has absolute class" time="0.034032233">
+        </testcase>
+        <testcase classname="client/__tests__/DownloadIndicator.test.tsx" name="DownloadIndicator &gt; inline variant does not have absolute class" time="0.021913874">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/GameCard.test.tsx" timestamp="2026-06-10T11:57:55.838Z" hostname="devbox" tests="10" failures="0" errors="0" skipped="0" time="0.887034481">
+        <testcase classname="client/__tests__/GameCard.test.tsx" name="GameCard &gt; renders game details correctly" time="0.106379547">
+        </testcase>
+        <testcase classname="client/__tests__/GameCard.test.tsx" name="GameCard &gt; displays a rating of 0 as &apos;N/A&apos; since 0 is unrated" time="0.324380303">
+        </testcase>
+        <testcase classname="client/__tests__/GameCard.test.tsx" name="GameCard &gt; shows &apos;N/A&apos; and &apos;Not rated&apos; aria-label when rating is null" time="0.081194656">
+        </testcase>
+        <testcase classname="client/__tests__/GameCard.test.tsx" name="GameCard &gt; calls onViewDetails when clicking the card" time="0.165013986">
+            <system-err>
+View details triggered for game: Test Game
+
+            </system-err>
+        </testcase>
+        <testcase classname="client/__tests__/GameCard.test.tsx" name="GameCard &gt; shows &apos;No genres&apos; when genres array is empty" time="0.04220808">
+        </testcase>
+        <testcase classname="client/__tests__/GameCard.test.tsx" name="GameCard &gt; shows Early Access badge when earlyAccess is true" time="0.023236149">
+        </testcase>
+        <testcase classname="client/__tests__/GameCard.test.tsx" name="GameCard &gt; does not show Early Access badge when earlyAccess is false" time="0.025197678">
+        </testcase>
+        <testcase classname="client/__tests__/GameCard.test.tsx" name="GameCard &gt; shows user rating when userRating is set" time="0.022382579">
+        </testcase>
+        <testcase classname="client/__tests__/GameCard.test.tsx" name="GameCard &gt; does not show user rating section when userRating is null" time="0.018758286">
+        </testcase>
+        <testcase classname="client/__tests__/GameCard.test.tsx" name="GameCard &gt; status button has aria-label with next status name" time="0.071213902">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/GameDetailsModal.test.tsx" timestamp="2026-06-10T11:57:55.844Z" hostname="devbox" tests="35" failures="0" errors="0" skipped="0" time="9.236108197">
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; renders game details correctly" time="0.956963017">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; renders genres and platforms" time="0.453211145">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; renders screenshots in Media tab" time="0.177754591">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; opens download dialog when download button is clicked" time="0.293869338">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; handles remove game action" time="0.236402163">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; handles hide game action" time="0.210983323">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; handles unhide game action when game starts hidden" time="0.202105593">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; truncates long summary and expands it" time="0.193245709">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; renders the Your rating section" time="0.146430678">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; shows &quot;Not rated&quot; when userRating is null" time="0.146007598">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; shows numeric rating when userRating is set" time="0.138483121">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; calls the user-rating API when a star is clicked" time="0.438171234">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; uses &apos;IGDB score&apos; label instead of &apos;Rating&apos; in the metadata section" time="0.128934644">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; HowLongToBeat integration &gt; does not show HLTB section when data is null" time="0.122886566">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; HowLongToBeat integration &gt; shows HLTB section with completion times when data is present" time="0.188370996">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; HowLongToBeat integration &gt; shows HowLongToBeat link with direct URL in Overview when data is present" time="0.341127799">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; HowLongToBeat integration &gt; shows fallback search link in Links tab when HLTB returns null" time="0.271563893">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; HowLongToBeat integration &gt; hides HLTB section when all completion times are zero" time="0.122971203">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; NexusMods integration &gt; shows fallback search link when Nexus Mods is not configured" time="0.474639992">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; NexusMods integration &gt; shows direct mod link when domain is found" time="0.48637099">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; NexusMods integration &gt; hides NexusMods link when configured but no domain found" time="0.278893343">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; NexusMods integration &gt; shows Mods tab when domain is found" time="0.256024439">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; NexusMods integration &gt; does not show Mods tab when not configured" time="0.153968856">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; null game handling &gt; renders a placeholder Dialog instead of null when game is null" time="0.00460098">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; scoreColor branches &gt; renders without error for amber-range rating (6.0–7.4)" time="0.135077251">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; scoreColor branches &gt; renders without error for red-range rating (&lt; 6.0)" time="0.123904432">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; SourceBadge variants &gt; shows &apos;Steam Wishlist&apos; badge when source is steam" time="0.134141553">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; SourceBadge variants &gt; shows &apos;Via API&apos; badge when source is api" time="0.152815742">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; SourceBadge variants &gt; shows &apos;Added Manually&apos; badge when source is manual" time="0.134663844">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; ProtonDB link in Links tab &gt; shows ProtonDB link when game has steamAppId" time="0.339490917">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; ProtonDB link in Links tab &gt; does not show ProtonDB link when game has no steamAppId" time="0.272097711">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; PCGamingWiki URL from API &gt; uses API-provided URL when steamAppId is set and API returns a URL" time="0.547595973">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; Downloads tab &gt; shows empty state when no downloads exist" time="0.121431838">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; Downloads tab &gt; shows download entry with DownloadStatusIcon when downloads exist" time="0.165709947">
+        </testcase>
+        <testcase classname="client/__tests__/GameDetailsModal.test.tsx" name="GameDetailsModal &gt; modal state reset &gt; resets summary expansion when modal closes" time="0.678388916">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/GameDownloadDialog.test.tsx" timestamp="2026-06-10T11:57:55.860Z" hostname="devbox" tests="23" failures="0" errors="0" skipped="1" time="11.985624136">
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; renders search results correctly" time="0.974439289">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; identifies Usenet vs Torrent items" time="0.50924737">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; filters search results by indexer" time="0.646564286">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; sorts results" time="0.479671981">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; blacklists a release when clicking &apos;Blacklist release&apos;" time="0.464700033">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; keeps dialog open and shows toast after successful download" time="0.507121225">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; shows destructive toast when download API returns success:false" time="0.497548161">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; displays indexer errors returned by the search API" time="0.402207639">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; shows bundle dialog when clicking a main item that has updates available" time="0.566612457">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; filters displayed results to preferred groups when filterByPreferredGroups is enabled" time="0.421062687">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; shows all results when filterByPreferredGroups is false even if groups are configured" time="0.434847588">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; shows platform filter section when results contain platform metadata" time="0.582840811">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; filters results by selected platform" time="0.892857145">
+            <system-err>
+Warning: validateDOMNesting(...): &lt;button&gt; cannot appear as a descendant of &lt;button&gt;.
+    at button
+    at div
+    at /app/client/src/components/ui/badge.tsx:25:51
+    at div
+    at button
+    at /app/client/src/components/ui/button.tsx:40:52
+    at file:///app/node_modules/@radix-ui/react-slot/dist/index.mjs:7:11
+    at file:///app/node_modules/@radix-ui/react-primitive/dist/index.mjs:28:13
+    at file:///app/node_modules/@radix-ui/react-slot/dist/index.mjs:7:11
+    at file:///app/node_modules/@radix-ui/react-primitive/dist/index.mjs:28:13
+    at file:///app/node_modules/@radix-ui/react-popper/dist/index.mjs:49:13
+    at file:///app/node_modules/@radix-ui/react-popover/dist/index.mjs:82:13
+    at Provider (file:///app/node_modules/@radix-ui/react-context/dist/index.mjs:29:15)
+    at Provider (file:///app/node_modules/@radix-ui/react-context/dist/index.mjs:29:15)
+    at Popper (file:///app/node_modules/@radix-ui/react-popper/dist/index.mjs:30:11)
+    at Popover (file:///app/node_modules/@radix-ui/react-popover/dist/index.mjs:30:5)
+    at MultiSelect (/app/client/src/components/ui/multi-select.tsx:19:24)
+    at div
+    at div
+    at div
+    at div
+    at file:///app/node_modules/@radix-ui/react-primitive/dist/index.mjs:28:13
+    at file:///app/node_modules/@radix-ui/react-dismissable-layer/dist/index.mjs:24:7
+    at file:///app/node_modules/@radix-ui/react-slot/dist/index.mjs:7:11
+    at file:///app/node_modules/@radix-ui/react-primitive/dist/index.mjs:28:13
+    at file:///app/node_modules/@radix-ui/react-focus-scope/dist/index.mjs:15:5
+    at file:///app/node_modules/@radix-ui/react-dialog/dist/index.mjs:206:13
+    at file:///app/node_modules/@radix-ui/react-dialog/dist/index.mjs:132:58
+    at Presence (file:///app/node_modules/@radix-ui/react-presence/dist/index.mjs:18:11)
+    at file:///app/node_modules/@radix-ui/react-dialog/dist/index.mjs:123:64
+    at file:///app/node_modules/@radix-ui/react-slot/dist/index.mjs:7:11
+    at file:///app/node_modules/@radix-ui/react-primitive/dist/index.mjs:28:13
+    at file:///app/node_modules/@radix-ui/react-portal/dist/index.mjs:11:22
+    at Presence (file:///app/node_modules/@radix-ui/react-presence/dist/index.mjs:18:11)
+    at Provider (file:///app/node_modules/@radix-ui/react-context/dist/index.mjs:29:15)
+    at DialogPortal (file:///app/node_modules/@radix-ui/react-dialog/dist/index.mjs:85:11)
+    at /app/client/src/components/ui/dialog.tsx:37:59
+    at Provider (file:///app/node_modules/@radix-ui/react-context/dist/index.mjs:29:15)
+    at Dialog (file:///app/node_modules/@radix-ui/react-dialog/dist/index.mjs:25:5)
+    at GameDownloadDialog (/app/client/src/components/GameDownloadDialog.tsx:60:31)
+    at Provider (file:///app/node_modules/@radix-ui/react-context/dist/index.mjs:29:15)
+    at TooltipProvider (file:///app/node_modules/@radix-ui/react-tooltip/dist/index.mjs:29:5)
+    at QueryClientProvider (file:///app/node_modules/@tanstack/react-query/build/modern/QueryClientProvider.js:20:3)
+
+            </system-err>
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; clears stale platform selections when search results no longer include that platform" time="1.179692277">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; displays Freeleech badge for torrents with downloadVolumeFactor of 0" time="0.417885432">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; does not display Freeleech badge when downloadVolumeFactor is absent" time="0.421908027">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; displays leechers count for torrent results" time="0.410977291">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; displays file count for usenet results" time="0">
+            <skipped/>
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; Preferred Platform preselection &gt; preselects the preferred platform and shows only matching items" time="0.427440734">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; Preferred Platform preselection &gt; PC preselection includes releases with no detected platform" time="0.45711515">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; Preferred Platform preselection &gt; PC preselection includes explicit PC releases" time="0.431035631">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; Preferred Platform preselection &gt; does not preselect platform when none is configured" time="0.422067112">
+        </testcase>
+        <testcase classname="client/__tests__/GameDownloadDialog.test.tsx" name="GameDownloadDialog &gt; displays poster name for usenet results" time="0.408013997">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/LazyModalFallback.test.tsx" timestamp="2026-06-10T11:57:55.870Z" hostname="devbox" tests="2" failures="0" errors="0" skipped="0" time="0.538432697">
+        <testcase classname="client/__tests__/LazyModalFallback.test.tsx" name="LazyModalFallback &gt; renders a loading status with default message" time="0.439947729">
+        </testcase>
+        <testcase classname="client/__tests__/LazyModalFallback.test.tsx" name="LazyModalFallback &gt; renders a custom loading message" time="0.091714421">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/PageToolbar.test.tsx" timestamp="2026-06-10T11:57:55.872Z" hostname="devbox" tests="9" failures="0" errors="0" skipped="0" time="0.407330602">
+        <testcase classname="client/__tests__/PageToolbar.test.tsx" name="PageToolbar &gt; renders search input when onSearchChange is provided" time="0.349817214">
+        </testcase>
+        <testcase classname="client/__tests__/PageToolbar.test.tsx" name="PageToolbar &gt; does not render search input when onSearchChange is not provided" time="0.003712247">
+        </testcase>
+        <testcase classname="client/__tests__/PageToolbar.test.tsx" name="PageToolbar &gt; renders clear button when search is non-empty" time="0.00941687">
+        </testcase>
+        <testcase classname="client/__tests__/PageToolbar.test.tsx" name="PageToolbar &gt; calls onSearchChange with empty string when clear button is clicked" time="0.013721499">
+        </testcase>
+        <testcase classname="client/__tests__/PageToolbar.test.tsx" name="PageToolbar &gt; does not render clear button when search is empty" time="0.004541806">
+        </testcase>
+        <testcase classname="client/__tests__/PageToolbar.test.tsx" name="PageToolbar &gt; renders sort section when sortOptions and onSortChange are provided" time="0.010371349">
+        </testcase>
+        <testcase classname="client/__tests__/PageToolbar.test.tsx" name="PageToolbar &gt; does not render sort section when sortOptions is empty" time="0.003143292">
+        </testcase>
+        <testcase classname="client/__tests__/PageToolbar.test.tsx" name="PageToolbar &gt; renders ViewControlsToolbar when viewControls prop is provided" time="0.003612871">
+        </testcase>
+        <testcase classname="client/__tests__/PageToolbar.test.tsx" name="PageToolbar &gt; renders filterPills and actions slots" time="0.003930324">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/PagesHiddenWiring.test.tsx" timestamp="2026-06-10T11:57:55.876Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="0.866678002">
+        <testcase classname="client/__tests__/PagesHiddenWiring.test.tsx" name="Page hidden wiring &gt; wires onToggleHidden in WishlistPage" time="0.56430985">
+        </testcase>
+        <testcase classname="client/__tests__/PagesHiddenWiring.test.tsx" name="Page hidden wiring &gt; wires onToggleHidden in LibraryPage" time="0.04175652">
+        </testcase>
+        <testcase classname="client/__tests__/PagesHiddenWiring.test.tsx" name="LibraryPage filter buttons &gt; filters to games with downloads when hasDownloads button toggled" time="0.147617373">
+        </testcase>
+        <testcase classname="client/__tests__/PagesHiddenWiring.test.tsx" name="LibraryPage filter buttons &gt; filters to games with search results when search results button toggled" time="0.107579146">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/SearchResultsBadge.test.tsx" timestamp="2026-06-10T11:57:55.878Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="0.381126659">
+        <testcase classname="client/__tests__/SearchResultsBadge.test.tsx" name="SearchResultsBadge &gt; renders nothing when visible=false" time="0.023234864">
+        </testcase>
+        <testcase classname="client/__tests__/SearchResultsBadge.test.tsx" name="SearchResultsBadge &gt; renders badge with Search icon when visible=true" time="0.287994833">
+        </testcase>
+        <testcase classname="client/__tests__/SearchResultsBadge.test.tsx" name="SearchResultsBadge &gt; overlay variant has absolute class" time="0.040210174">
+        </testcase>
+        <testcase classname="client/__tests__/SearchResultsBadge.test.tsx" name="SearchResultsBadge &gt; inline variant does not have absolute class" time="0.02380518">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/ViewControlsToolbar.test.tsx" timestamp="2026-06-10T11:57:55.880Z" hostname="devbox" tests="8" failures="0" errors="0" skipped="0" time="0.542274872">
+        <testcase classname="client/__tests__/ViewControlsToolbar.test.tsx" name="ViewControlsToolbar &gt; renders grid and list toggle buttons" time="0.081359722">
+        </testcase>
+        <testcase classname="client/__tests__/ViewControlsToolbar.test.tsx" name="ViewControlsToolbar &gt; does not show density dropdown in grid mode" time="0.009279888">
+        </testcase>
+        <testcase classname="client/__tests__/ViewControlsToolbar.test.tsx" name="ViewControlsToolbar &gt; shows density options in list mode" time="0.26214292">
+        </testcase>
+        <testcase classname="client/__tests__/ViewControlsToolbar.test.tsx" name="ViewControlsToolbar &gt; calls onViewModeChange when list toggle clicked" time="0.022478744">
+        </testcase>
+        <testcase classname="client/__tests__/ViewControlsToolbar.test.tsx" name="ViewControlsToolbar &gt; shows current density label in list mode trigger button" time="0.01343334">
+        </testcase>
+        <testcase classname="client/__tests__/ViewControlsToolbar.test.tsx" name="ViewControlsToolbar &gt; calls onListDensityChange with compact when Compact item clicked" time="0.042820487">
+        </testcase>
+        <testcase classname="client/__tests__/ViewControlsToolbar.test.tsx" name="ViewControlsToolbar &gt; calls onListDensityChange with ultra-compact when Ultra-compact item clicked" time="0.042187373">
+        </testcase>
+        <testcase classname="client/__tests__/ViewControlsToolbar.test.tsx" name="ViewControlsToolbar &gt; calls onListDensityChange with comfortable when Comfortable item clicked" time="0.062629533">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/discover-hidden-mutation.test.ts" timestamp="2026-06-10T11:57:55.885Z" hostname="devbox" tests="3" failures="0" errors="0" skipped="0" time="0.014332266">
+        <testcase classname="client/__tests__/discover-hidden-mutation.test.ts" name="hideDiscoveryGame &gt; returns hidden true for PATCH without reading response body" time="0.008194048">
+        </testcase>
+        <testcase classname="client/__tests__/discover-hidden-mutation.test.ts" name="hideDiscoveryGame &gt; returns hidden true for POST without reading response body" time="0.002211137">
+        </testcase>
+        <testcase classname="client/__tests__/discover-hidden-mutation.test.ts" name="hideDiscoveryGame &gt; falls back to PATCH hidden when POST returns 409 with existing game" time="0.001085369">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/downloads-utils.test.ts" timestamp="2026-06-10T11:57:55.887Z" hostname="devbox" tests="77" failures="0" errors="0" skipped="0" time="0.028914477">
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="formatBytes &gt; should return &quot;0 B&quot; for 0 bytes" time="0.003147797">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="formatBytes &gt; should format bytes correctly" time="0.00035367">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="formatBytes &gt; should format kilobytes correctly" time="0.000240406">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="formatBytes &gt; should format megabytes correctly" time="0.000206743">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="formatBytes &gt; should format gigabytes correctly" time="0.000208415">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="formatBytes &gt; should format terabytes correctly" time="0.000235851">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="formatSpeed &gt; should format speed as bytes per second with /s suffix" time="0.000320178">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="formatETA &gt; should return &quot;∞&quot; for 0 or negative seconds" time="0.000387664">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="formatETA &gt; should format minutes correctly" time="0.000476275">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="formatETA &gt; should format hours and minutes correctly" time="0.000449447">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="getStatusBadgeVariant &gt; should return &quot;default&quot; for downloading status" time="0.000322825">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="getStatusBadgeVariant &gt; should return &quot;default&quot; for seeding status" time="0.000174817">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="getStatusBadgeVariant &gt; should return &quot;outline&quot; for completed status" time="0.000162209">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="getStatusBadgeVariant &gt; should return &quot;secondary&quot; for paused status" time="0.000227103">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="getStatusBadgeVariant &gt; should return &quot;destructive&quot; for error status" time="0.000146571">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="getStatusBadgeVariant &gt; should return &quot;outline&quot; for unknown status" time="0.000140757">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="filterDownloadsByStatus &gt; should return all downloads when filter is &quot;all&quot;" time="0.002206918">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="filterDownloadsByStatus &gt; should filter downloads by &quot;downloading&quot; status" time="0.000543877">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="filterDownloadsByStatus &gt; should filter downloads by &quot;seeding&quot; status" time="0.000354297">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="filterDownloadsByStatus &gt; should filter downloads by &quot;completed&quot; status" time="0.000368544">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="filterDownloadsByStatus &gt; should filter downloads by &quot;paused&quot; status" time="0.000349422">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="filterDownloadsByStatus &gt; should filter downloads by &quot;error&quot; status" time="0.000310964">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="filterDownloadsByStatus &gt; should return empty array when no downloads match the filter" time="0.000340579">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="filterDownloadsByStatus &gt; should handle empty downloads array" time="0.000273375">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowSpeedBadge &gt; should return true when speed is defined and greater than 0" time="0.000284648">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowSpeedBadge &gt; should return false when speed is 0" time="0.000154591">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowSpeedBadge &gt; should return false when speed is undefined" time="0.00022934">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowSpeedBadge &gt; should return false when speed is negative" time="0.000186966">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowETABadge &gt; should return true when ETA is defined and greater than 0" time="0.000245766">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowETABadge &gt; should return false when ETA is 0" time="0.000150167">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowETABadge &gt; should return false when ETA is undefined" time="0.000259181">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowETABadge &gt; should return false when ETA is negative (infinity case)" time="0.000180529">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowRatioBadge &gt; should return true when ratio is defined and &gt;= 0" time="0.000312241">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowRatioBadge &gt; should return false when ratio is undefined" time="0.000152529">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowRatioBadge &gt; should return false when ratio is negative" time="0.000233155">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowSizeBadge &gt; should return true when size is defined and greater than 0" time="0.000263481">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowSizeBadge &gt; should return false when size is 0" time="0.000144953">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowSizeBadge &gt; should return false when size is undefined" time="0.000137912">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowSizeBadge &gt; should return false when size is negative" time="0.000135856">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowPeersBadge &gt; should return true when seeders is defined (even if 0)" time="0.000327456">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="shouldShowPeersBadge &gt; should return false when seeders is undefined" time="0.000156149">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Badge visibility edge cases &gt; should handle download with all data present" time="0.000373257">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Badge visibility edge cases &gt; should handle download with minimal data (no optional fields)" time="0.000418419">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Badge visibility edge cases &gt; should handle completed download with ratio but no speeds" time="0.000262806">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; getDownloadTypeColor &gt; should return correct color for usenet" time="0.000505674">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; getDownloadTypeColor &gt; should return correct color for torrent" time="0.000203655">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; getDownloadTypeColor &gt; should return default color (torrent) when undefined" time="0.00016324">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; formatDownloadType &gt; should return Usenet for usenet type" time="0.000196864">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; formatDownloadType &gt; should return Torrent for torrent type" time="0.000153308">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; formatDownloadType &gt; should return Torrent when undefined" time="0.000233527">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; shouldShowTorrentMetrics &gt; should return true for torrent type" time="0.000246854">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; shouldShowTorrentMetrics &gt; should return true when type is undefined (backward compatibility)" time="0.000161473">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; shouldShowTorrentMetrics &gt; should return false for usenet type" time="0.000167776">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; shouldShowUsenetMetrics &gt; should return true for usenet type" time="0.000242473">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; shouldShowUsenetMetrics &gt; should return false for torrent type" time="0.000183099">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; shouldShowRepairStatus &gt; should return true for usenet with repair status" time="0.000211962">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; shouldShowRepairStatus &gt; should return false if not usenet" time="0.000159197">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; shouldShowRepairStatus &gt; should return false if repair status is undefined" time="0.000154298">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; shouldShowUnpackStatus &gt; should return true for usenet with unpack status" time="0.000283459">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; shouldShowUnpackStatus &gt; should return false if not usenet" time="0.000207002">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; shouldShowUnpackStatus &gt; should return false if unpack status is undefined" time="0.000159948">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; getRepairStatusBadgeVariant &gt; should return correct variants" time="0.000442745">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; getUnpackStatusBadgeVariant &gt; should return correct variants" time="0.000339156">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; formatRepairStatus &gt; should format correctly" time="0.000297659">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; formatUnpackStatus &gt; should format correctly" time="0.00036314">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; formatAge &gt; should handle undefined" time="0.000227849">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; formatAge &gt; should handle 0 days" time="0.000153552">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; formatAge &gt; should handle partial days" time="0.000167429">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; formatAge &gt; should handle 1 day" time="0.00014315">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; formatAge &gt; should handle multiple days" time="0.000225147">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; isUsenetItem &gt; should identify usenet item by grabs" time="0.000225398">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; isUsenetItem &gt; should identify usenet item by age" time="0.000166844">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; isUsenetItem &gt; should return false if seeders are present (torrent)" time="0.00026513">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; isUsenetItem &gt; should return false if no identifying fields" time="0.000236348">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; isUsenetItem &gt; returns true when downloadType is &apos;usenet&apos;" time="0.000179564">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; isUsenetItem &gt; returns false when downloadType is &apos;torrent&apos;" time="0.000179811">
+        </testcase>
+        <testcase classname="client/__tests__/downloads-utils.test.ts" name="Usenet Utility Functions &gt; isUsenetItem &gt; downloadType takes precedence over grabs/age heuristic" time="0.000176176">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/game-utils.test.ts" timestamp="2026-06-10T11:57:55.916Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="0.012702083">
+        <testcase classname="client/__tests__/game-utils.test.ts" name="getReleaseStatus &gt; returns Delayed when releaseStatus is delayed" time="0.007600706">
+        </testcase>
+        <testcase classname="client/__tests__/game-utils.test.ts" name="getReleaseStatus &gt; returns TBA when no releaseDate" time="0.000804351">
+        </testcase>
+        <testcase classname="client/__tests__/game-utils.test.ts" name="getReleaseStatus &gt; returns Upcoming for a future release date" time="0.000799931">
+        </testcase>
+        <testcase classname="client/__tests__/game-utils.test.ts" name="getReleaseStatus &gt; returns Released with green styling for a past release date" time="0.000728127">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/indexers-cache.test.ts" timestamp="2026-06-10T11:57:55.918Z" hostname="devbox" tests="2" failures="0" errors="0" skipped="0" time="0.010589369">
+        <testcase classname="client/__tests__/indexers-cache.test.ts" name="refreshIndexerQueries &gt; invalidates both indexer query caches" time="0.004926908">
+        </testcase>
+        <testcase classname="client/__tests__/indexers-cache.test.ts" name="refreshIndexerQueries &gt; propagates invalidation failures" time="0.00294268">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/use-background-notifications.test.ts" timestamp="2026-06-10T11:57:55.920Z" hostname="devbox" tests="10" failures="0" errors="0" skipped="0" time="0.05864115">
+        <testcase classname="client/__tests__/use-background-notifications.test.ts" name="useBackgroundNotifications &gt; returns null" time="0.026293881">
+        </testcase>
+        <testcase classname="client/__tests__/use-background-notifications.test.ts" name="useBackgroundNotifications &gt; does not toast when there are no downloads" time="0.002857727">
+        </testcase>
+        <testcase classname="client/__tests__/use-background-notifications.test.ts" name="useBackgroundNotifications &gt; does not toast when a new download first appears (no previous state)" time="0.002334973">
+        </testcase>
+        <testcase classname="client/__tests__/use-background-notifications.test.ts" name="useBackgroundNotifications &gt; toasts on completion when status transitions from downloading to completed" time="0.007434627">
+        </testcase>
+        <testcase classname="client/__tests__/use-background-notifications.test.ts" name="useBackgroundNotifications &gt; toasts on error when status transitions to error" time="0.002763174">
+        </testcase>
+        <testcase classname="client/__tests__/use-background-notifications.test.ts" name="useBackgroundNotifications &gt; uses download name as error description when no error message provided" time="0.002449035">
+        </testcase>
+        <testcase classname="client/__tests__/use-background-notifications.test.ts" name="useBackgroundNotifications &gt; does not toast for already-completed downloads (no status change)" time="0.002361543">
+        </testcase>
+        <testcase classname="client/__tests__/use-background-notifications.test.ts" name="useBackgroundNotifications &gt; does not toast when status stays at downloading" time="0.002109811">
+        </testcase>
+        <testcase classname="client/__tests__/use-background-notifications.test.ts" name="useBackgroundNotifications &gt; handles multiple downloads completing independently" time="0.002344089">
+        </testcase>
+        <testcase classname="client/__tests__/use-background-notifications.test.ts" name="useBackgroundNotifications &gt; cleans up tracking when a download disappears from a non-empty list" time="0.002483282">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/use-debounce.test.ts" timestamp="2026-06-10T11:57:55.924Z" hostname="devbox" tests="8" failures="0" errors="0" skipped="0" time="0.064256322">
+        <testcase classname="client/__tests__/use-debounce.test.ts" name="useDebounce &gt; returns the initial value immediately" time="0.031154392">
+        </testcase>
+        <testcase classname="client/__tests__/use-debounce.test.ts" name="useDebounce &gt; does not update immediately on value change" time="0.004596772">
+        </testcase>
+        <testcase classname="client/__tests__/use-debounce.test.ts" name="useDebounce &gt; updates value after the delay has passed" time="0.00519037">
+        </testcase>
+        <testcase classname="client/__tests__/use-debounce.test.ts" name="useDebounce &gt; only uses the latest value when changed multiple times before delay" time="0.003940894">
+        </testcase>
+        <testcase classname="client/__tests__/use-debounce.test.ts" name="useDebounce &gt; clears the previous timer on rapid re-renders" time="0.003513898">
+        </testcase>
+        <testcase classname="client/__tests__/use-debounce.test.ts" name="useDebounce &gt; works with zero delay" time="0.002678968">
+        </testcase>
+        <testcase classname="client/__tests__/use-debounce.test.ts" name="useDebounce &gt; cancels pending update on unmount" time="0.003561386">
+        </testcase>
+        <testcase classname="client/__tests__/use-debounce.test.ts" name="useDebounce &gt; works with non-string types (numbers)" time="0.002865188">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/use-download-summary.test.ts" timestamp="2026-06-10T11:57:55.928Z" hostname="devbox" tests="3" failures="0" errors="0" skipped="0" time="0.111729378">
+        <testcase classname="client/__tests__/use-download-summary.test.ts" name="useDownloadSummary &gt; returns empty object by default before data loads" time="0.039119392">
+            <system-err>
+Query data cannot be undefined. Please make sure to return a value other than undefined from your query function. Affected query key: [&quot;/api/downloads/summary&quot;]
+
+            </system-err>
+        </testcase>
+        <testcase classname="client/__tests__/use-download-summary.test.ts" name="useDownloadSummary &gt; returns the summary data after query resolves" time="0.059350408">
+        </testcase>
+        <testcase classname="client/__tests__/use-download-summary.test.ts" name="useDownloadSummary &gt; calls getQueryFn with on401: returnNull" time="0.00466086">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/use-hidden-mutation.test.tsx" timestamp="2026-06-10T11:57:55.930Z" hostname="devbox" tests="3" failures="0" errors="0" skipped="0" time="0.290067815">
+        <testcase classname="client/__tests__/use-hidden-mutation.test.tsx" name="useHiddenMutation &gt; uses default mode, calls API, and shows hidden/unhidden success messages" time="0.170249055">
+        </testcase>
+        <testcase classname="client/__tests__/use-hidden-mutation.test.tsx" name="useHiddenMutation &gt; returns custom mutationFn path without calling apiRequest" time="0.056976087">
+        </testcase>
+        <testcase classname="client/__tests__/use-hidden-mutation.test.tsx" name="useHiddenMutation &gt; shows error toast for invalid payload in default mode" time="0.057510114">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/use-local-storage-state.test.ts" timestamp="2026-06-10T11:57:55.932Z" hostname="devbox" tests="12" failures="0" errors="0" skipped="0" time="0.064378698">
+        <testcase classname="client/__tests__/use-local-storage-state.test.ts" name="useLocalStorageState &gt; initialization &gt; returns the default string value when key is not set" time="0.02981549">
+        </testcase>
+        <testcase classname="client/__tests__/use-local-storage-state.test.ts" name="useLocalStorageState &gt; initialization &gt; returns the default number value when key is not set" time="0.003182399">
+        </testcase>
+        <testcase classname="client/__tests__/use-local-storage-state.test.ts" name="useLocalStorageState &gt; initialization &gt; returns the default boolean value when key is not set" time="0.002722976">
+        </testcase>
+        <testcase classname="client/__tests__/use-local-storage-state.test.ts" name="useLocalStorageState &gt; initialization &gt; reads an existing string from localStorage on mount" time="0.002477768">
+        </testcase>
+        <testcase classname="client/__tests__/use-local-storage-state.test.ts" name="useLocalStorageState &gt; initialization &gt; reads and deserializes an existing number from localStorage" time="0.003590387">
+        </testcase>
+        <testcase classname="client/__tests__/use-local-storage-state.test.ts" name="useLocalStorageState &gt; initialization &gt; reads and deserializes &apos;true&apos; boolean from localStorage" time="0.002149834">
+        </testcase>
+        <testcase classname="client/__tests__/use-local-storage-state.test.ts" name="useLocalStorageState &gt; initialization &gt; reads and deserializes &apos;false&apos; boolean from localStorage" time="0.002031013">
+        </testcase>
+        <testcase classname="client/__tests__/use-local-storage-state.test.ts" name="useLocalStorageState &gt; initialization &gt; falls back to default when stored number is NaN" time="0.002144895">
+        </testcase>
+        <testcase classname="client/__tests__/use-local-storage-state.test.ts" name="useLocalStorageState &gt; persistence &gt; writes value to localStorage when state is set" time="0.004014095">
+        </testcase>
+        <testcase classname="client/__tests__/use-local-storage-state.test.ts" name="useLocalStorageState &gt; persistence &gt; writes number value as string to localStorage" time="0.002126669">
+        </testcase>
+        <testcase classname="client/__tests__/use-local-storage-state.test.ts" name="useLocalStorageState &gt; persistence &gt; writes boolean value as string to localStorage" time="0.002146344">
+        </testcase>
+        <testcase classname="client/__tests__/use-local-storage-state.test.ts" name="useLocalStorageState &gt; persistence &gt; reflects the updated state after calling setter" time="0.002168825">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/use-view-controls.test.ts" timestamp="2026-06-10T11:57:55.937Z" hostname="devbox" tests="5" failures="0" errors="0" skipped="0" time="0.042854924">
+        <testcase classname="client/__tests__/use-view-controls.test.ts" name="useViewControls &gt; uses libraryViewMode and libraryListDensity keys for pageKey=library" time="0.028572592">
+        </testcase>
+        <testcase classname="client/__tests__/use-view-controls.test.ts" name="useViewControls &gt; defaults to grid and comfortable" time="0.002404422">
+        </testcase>
+        <testcase classname="client/__tests__/use-view-controls.test.ts" name="useViewControls &gt; uses wishlistViewMode and wishlistListDensity keys for pageKey=wishlist" time="0.002558238">
+        </testcase>
+        <testcase classname="client/__tests__/use-view-controls.test.ts" name="useViewControls &gt; falls back to grid when stored viewMode is invalid" time="0.002079845">
+        </testcase>
+        <testcase classname="client/__tests__/use-view-controls.test.ts" name="useViewControls &gt; falls back to comfortable when stored listDensity is invalid" time="0.001879138">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/usenet-utils.test.ts" timestamp="2026-06-10T11:57:55.940Z" hostname="devbox" tests="3" failures="0" errors="0" skipped="0" time="0.0063327">
+        <testcase classname="client/__tests__/usenet-utils.test.ts" name="isUsenetItem &gt; should return true for items with grabs or age" time="0.003169537">
+        </testcase>
+        <testcase classname="client/__tests__/usenet-utils.test.ts" name="isUsenetItem &gt; should return false for items with seeders" time="0.000383789">
+        </testcase>
+        <testcase classname="client/__tests__/usenet-utils.test.ts" name="isUsenetItem &gt; should return false for empty items (default to torrent)" time="0.000205781">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/utils.test.ts" timestamp="2026-06-10T11:57:55.942Z" hostname="devbox" tests="11" failures="0" errors="0" skipped="0" time="0.01367336">
+        <testcase classname="client/__tests__/utils.test.ts" name="safeUrl &gt; should return the original URL if it uses http protocol" time="0.005101854">
+        </testcase>
+        <testcase classname="client/__tests__/utils.test.ts" name="safeUrl &gt; should return the original URL if it uses https protocol" time="0.000484379">
+        </testcase>
+        <testcase classname="client/__tests__/utils.test.ts" name="safeUrl &gt; should resolve missing protocol URLs against the window location if they don&apos;t have a protocol" time="0.000320111">
+        </testcase>
+        <testcase classname="client/__tests__/utils.test.ts" name="safeUrl &gt; should return the fallback URL if it uses javascript protocol" time="0.000199858">
+        </testcase>
+        <testcase classname="client/__tests__/utils.test.ts" name="safeUrl &gt; should return the fallback URL if it uses data protocol" time="0.000359033">
+        </testcase>
+        <testcase classname="client/__tests__/utils.test.ts" name="safeUrl &gt; should return the fallback URL if it uses vbscript protocol" time="0.000277849">
+        </testcase>
+        <testcase classname="client/__tests__/utils.test.ts" name="safeUrl &gt; should return a custom fallback URL if provided" time="0.000188599">
+        </testcase>
+        <testcase classname="client/__tests__/utils.test.ts" name="safeUrl &gt; should block javascript pseudo-protocol with spaces" time="0.000180593">
+        </testcase>
+        <testcase classname="client/__tests__/utils.test.ts" name="getNextStatusLabel &gt; returns Owned when current status is wanted" time="0.000377673">
+        </testcase>
+        <testcase classname="client/__tests__/utils.test.ts" name="getNextStatusLabel &gt; returns Completed when current status is owned" time="0.00027102">
+        </testcase>
+        <testcase classname="client/__tests__/utils.test.ts" name="getNextStatusLabel &gt; returns Wanted when current status is completed" time="0.000180876">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/versionService.test.ts" timestamp="2026-06-10T11:57:55.946Z" hostname="devbox" tests="8" failures="0" errors="0" skipped="0" time="0.01563476">
+        <testcase classname="client/__tests__/versionService.test.ts" name="Version Service &gt; fetchLatestQuestarrVersion &gt; should fetch and return the latest version from GitHub releases" time="0.007223606">
+        </testcase>
+        <testcase classname="client/__tests__/versionService.test.ts" name="Version Service &gt; fetchLatestQuestarrVersion &gt; should handle tag_name without v prefix" time="0.000550376">
+        </testcase>
+        <testcase classname="client/__tests__/versionService.test.ts" name="Version Service &gt; fetchLatestQuestarrVersion &gt; should return null and log rate-limit context on 403 response" time="0.001727575">
+        </testcase>
+        <testcase classname="client/__tests__/versionService.test.ts" name="Version Service &gt; fetchLatestQuestarrVersion &gt; should return null and log 404 response" time="0.000645837">
+        </testcase>
+        <testcase classname="client/__tests__/versionService.test.ts" name="Version Service &gt; fetchLatestQuestarrVersion &gt; should return null and log generic non-ok response" time="0.000626119">
+        </testcase>
+        <testcase classname="client/__tests__/versionService.test.ts" name="Version Service &gt; fetchLatestQuestarrVersion &gt; should return null when tag_name is missing from response" time="0.000465726">
+        </testcase>
+        <testcase classname="client/__tests__/versionService.test.ts" name="Version Service &gt; fetchLatestQuestarrVersion &gt; should return null and log error when fetch throws" time="0.000896629">
+        </testcase>
+        <testcase classname="client/__tests__/versionService.test.ts" name="Version Service &gt; fetchLatestQuestarrVersion &gt; should return null when JSON parsing fails" time="0.000771077">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/__tests__/wishlist-sort.test.ts" timestamp="2026-06-10T11:57:55.950Z" hostname="devbox" tests="9" failures="0" errors="0" skipped="0" time="0.027592495">
+        <testcase classname="client/__tests__/wishlist-sort.test.ts" name="sortGames &gt; release-asc &gt; sorts by release date ascending" time="0.008111598">
+        </testcase>
+        <testcase classname="client/__tests__/wishlist-sort.test.ts" name="sortGames &gt; release-asc &gt; pushes games with no release date to the end" time="0.000467303">
+        </testcase>
+        <testcase classname="client/__tests__/wishlist-sort.test.ts" name="sortGames &gt; release-asc &gt; is stable when both games have no release date (returns 0)" time="0.000556508">
+        </testcase>
+        <testcase classname="client/__tests__/wishlist-sort.test.ts" name="sortGames &gt; release-desc &gt; sorts by release date descending" time="0.000381448">
+        </testcase>
+        <testcase classname="client/__tests__/wishlist-sort.test.ts" name="sortGames &gt; release-desc &gt; is stable when both games have no release date (returns 0)" time="0.000279992">
+        </testcase>
+        <testcase classname="client/__tests__/wishlist-sort.test.ts" name="sortGames &gt; added-desc &gt; sorts by addedAt descending" time="0.000286226">
+        </testcase>
+        <testcase classname="client/__tests__/wishlist-sort.test.ts" name="sortGames &gt; added-desc &gt; is stable when both games have no addedAt (returns 0)" time="0.000322183">
+        </testcase>
+        <testcase classname="client/__tests__/wishlist-sort.test.ts" name="sortGames &gt; title-asc &gt; sorts by title alphabetically" time="0.013390732">
+        </testcase>
+        <testcase classname="client/__tests__/wishlist-sort.test.ts" name="sortGames &gt; does not mutate the original array" time="0.000474498">
+        </testcase>
+    </testsuite>
+    <testsuite name="shared/__tests__/download-categorizer.test.ts" timestamp="2026-06-10T11:57:55.955Z" hostname="devbox" tests="24" failures="0" errors="0" skipped="0" time="0.020547982">
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects main game with default confidence" time="0.005203426">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects main game with higher confidence when Repack keyword is present" time="0.000861262">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects main game with higher confidence when full keyword is present" time="0.000299729">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects update via &apos;update&apos; keyword" time="0.000342676">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects update via &apos;patch&apos; keyword" time="0.000320872">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects update via &apos;hotfix&apos; keyword" time="0.000228346">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; classifies version-number-only releases as main (version alone is ambiguous)" time="0.00023173">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects update via crackfix keyword" time="0.000254099">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects DLC via &apos;DLC&apos; keyword" time="0.000383272">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects DLC via &apos;expansion&apos; keyword" time="0.000794415">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects DLC via &apos;season pass&apos; keyword" time="0.000260417">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects DLC via &apos;deluxe&apos; keyword" time="0.000390119">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects DLC via &apos;goty&apos; keyword" time="0.000250233">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects extra via &apos;OST&apos; keyword" time="0.000201545">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects extra via &apos;soundtrack&apos; keyword" time="0.000193404">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects extra via &apos;artbook&apos; keyword" time="0.000264199">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; detects extra via &apos;bonus&apos; keyword" time="0.000217104">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; extras take priority over DLC when both keywords present" time="0.001185934">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; categorizeDownload &gt; is case-insensitive for keyword matching" time="0.000276129">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; groupDownloadsByCategory &gt; groups downloads into correct categories" time="0.001922599">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; groupDownloadsByCategory &gt; returns all empty arrays for empty input" time="0.001390244">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; groupDownloadsByCategory &gt; preserves original download objects in groups" time="0.000285203">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; groupDownloadsByCategory &gt; puts multiple downloads of the same category in the same group" time="0.000335376">
+        </testcase>
+        <testcase classname="shared/__tests__/download-categorizer.test.ts" name="download-categorizer &gt; getCategoryLabel &gt; returns correct label for each category" time="0.000322818">
+        </testcase>
+    </testsuite>
+    <testsuite name="shared/__tests__/schema.test.ts" timestamp="2026-06-10T11:57:55.965Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="0.01811153">
+        <testcase classname="shared/__tests__/schema.test.ts" name="insertIndexerSchema &gt; requires non-empty name, url, and apiKey" time="0.009825174">
+        </testcase>
+        <testcase classname="shared/__tests__/schema.test.ts" name="insertDownloaderSchema &gt; requires non-empty name and host" time="0.00356929">
+        </testcase>
+        <testcase classname="shared/__tests__/schema.test.ts" name="insertDownloaderSchema &gt; requires an API key for SABnzbd" time="0.001028919">
+        </testcase>
+        <testcase classname="shared/__tests__/schema.test.ts" name="insertDownloaderSchema &gt; allows other downloaders without authentication details" time="0.000461549">
+        </testcase>
+    </testsuite>
+    <testsuite name="shared/__tests__/title_utils.test.ts" timestamp="2026-06-10T11:57:55.967Z" hostname="devbox" tests="33" failures="0" errors="0" skipped="0" time="0.028328196">
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; normalizeTitle &gt; should normalize titles correctly" time="0.003970783">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; normalizeTitle &gt; should handle empty strings" time="0.000362369">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; cleanReleaseName &gt; should clean release names by removing tags" time="0.003062936">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; cleanReleaseName &gt; should remove common version patterns" time="0.000291967">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; cleanReleaseName &gt; should handle bracketed content correctly" time="0.000643403">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; cleanReleaseName &gt; should replace &apos;and&apos; with &apos;&amp;&apos; for better matching" time="0.000213679">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; cleanReleaseName &gt; should remove years in range 1975-2040" time="0.000227435">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; titleMatches &gt; should match identical and case-insensitive titles" time="0.000407725">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; titleMatches &gt; should match partial titles within word boundaries" time="0.000636845">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; titleMatches &gt; should not match unrelated titles" time="0.000443314">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; titleMatches &gt; should require exact match for short titles" time="0.000303696">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; releaseMatchesGame &gt; should match release name against game title" time="0.000688995">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; releaseMatchesGame &gt; should handle stopwords and numbers in fallback matching" time="0.000543733">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; releaseMatchesGame &gt; should not match if meaningful words are missing" time="0.000667622">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseReleaseMetadata &gt; should extract metadata from release name" time="0.004240574">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseReleaseMetadata &gt; should detect scene status" time="0.002036739">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseReleaseMetadata &gt; should handle bracketed groups" time="0.000304335">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseReleaseMetadata &gt; should detect various platforms" time="0.000431682">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseReleaseMetadata &gt; should parse Mac platform and DRM-Free tags" time="0.000356221">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseJsonStringArray &gt; parses a valid JSON string array" time="0.001303437">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseJsonStringArray &gt; returns empty array for null" time="0.000228002">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseJsonStringArray &gt; returns empty array for undefined" time="0.000265837">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseJsonStringArray &gt; returns empty array for empty string" time="0.000181982">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseJsonStringArray &gt; returns empty array for invalid JSON" time="0.000297947">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseJsonStringArray &gt; returns empty array when JSON is not an array" time="0.000280838">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseJsonStringArray &gt; returns empty array for JSON null literal" time="0.000215892">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; parseJsonStringArray &gt; handles an empty JSON array" time="0.000168001">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; matchesPlatformFilter &gt; PC platform &gt; matches releases explicitly detected as PC" time="0.000260051">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; matchesPlatformFilter &gt; PC platform &gt; matches releases with no detected platform" time="0.000318266">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; matchesPlatformFilter &gt; PC platform &gt; does not match non-PC platforms when PC is preferred" time="0.000266896">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; matchesPlatformFilter &gt; non-PC platforms &gt; matches when detected platform equals preferred" time="0.000413938">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; matchesPlatformFilter &gt; non-PC platforms &gt; does not match different explicit platforms" time="0.000295299">
+        </testcase>
+        <testcase classname="shared/__tests__/title_utils.test.ts" name="title-utils &gt; matchesPlatformFilter &gt; non-PC platforms &gt; does not match releases with no detected platform for non-PC preferred" time="0.000223132">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/api_routes.test.ts" timestamp="2026-06-10T11:57:55.981Z" hostname="devbox" tests="189" failures="0" errors="0" skipped="0" time="1.200694557">
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; parseCategories &gt; should return undefined for falsy input" time="0.016527512">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; parseCategories &gt; should parse comma-separated string" time="0.004569185">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; parseCategories &gt; should parse array input" time="0.002810483">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; parseCategories &gt; should filter empty strings" time="0.002549719">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; parseCategories &gt; should return undefined for non-string/non-array input" time="0.002579543">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; GET /api/auth/status &gt; should return hasUsers true when users exist" time="0.03613904">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; GET /api/auth/status &gt; should return hasUsers false when no users" time="0.015398909">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; GET /api/auth/status &gt; should return 500 on error" time="0.005958534">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/setup &gt; should return 403 when users already exist" time="0.017839732">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/setup &gt; should create first user and return token" time="0.006656739">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/setup &gt; should return 400 for missing username" time="0.005486507">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/setup &gt; should return 400 for short username" time="0.005494292">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/setup &gt; should return 400 for short password" time="0.005430153">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/setup &gt; should return 400 for too-long username" time="0.005637697">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/setup &gt; should return 400 for non-string types" time="0.004917185">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/setup &gt; should save IGDB credentials if provided" time="0.006913066">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/setup &gt; should handle duplicative setup race condition" time="0.005011966">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/login &gt; should return 401 for invalid credentials" time="0.014037824">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/login &gt; should return 400 when username is missing" time="0.006047127">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/login &gt; should return 400 when password is missing" time="0.005470742">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/login &gt; should return 400 for non-string username" time="0.012721042">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; POST /api/auth/login &gt; should trim username and password before authentication" time="0.006184061">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; GET /api/auth/me &gt; should return current user info" time="0.00585301">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; PATCH /api/auth/password &gt; should update password successfully" time="0.008637035">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; PATCH /api/auth/password &gt; should return 404 when user not found" time="0.006027471">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; PATCH /api/auth/password &gt; should return 401 for incorrect current password" time="0.005104406">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; PATCH /api/auth/password &gt; should return 400 for new password too short" time="0.006504904">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; PATCH /api/auth/password &gt; should return 400 when passwords do not match" time="0.005518342">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; PATCH /api/auth/password &gt; should trim whitespace from passwords before validation" time="0.006022165">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Auth routes &gt; PATCH /api/auth/password &gt; should return 500 on unexpected error" time="0.005543865">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/health &gt; should return ok" time="0.00471049">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/ready &gt; should return 200 when db and igdb are healthy" time="0.004857636">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/ready &gt; should return 503 when db check fails" time="0.0061555">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/ready &gt; should return 503 when igdb check fails" time="0.005005969">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/games &gt; should return user games" time="0.00780493">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/games &gt; should handle search query" time="0.007496096">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/games &gt; should handle status filter" time="0.005388155">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/games &gt; should handle includeHidden flag" time="0.020598768">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/games &gt; should return 500 on error" time="0.005630293">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/games/status/:status &gt; should return games by status" time="0.005861242">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; POST /api/games &gt; should add a new game" time="0.019596938">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; POST /api/games &gt; should prevent duplicate games" time="0.008047912">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; PATCH /api/games/:id/status &gt; should update game status" time="0.009261702">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; PATCH /api/games/:id/status &gt; should return 404 for non-existent game" time="0.006970081">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; PATCH /api/games/:id/hidden &gt; should update hidden status" time="0.006113481">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; PATCH /api/games/:id/user-rating &gt; should set a valid rating scoped to the authenticated user" time="0.006008008">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; PATCH /api/games/:id/user-rating &gt; should accept a half-step rating (0.5 increment)" time="0.00550848">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; PATCH /api/games/:id/user-rating &gt; should clear the rating with null" time="0.005203092">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; PATCH /api/games/:id/user-rating &gt; should return 400 for rating above 10" time="0.006642472">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; PATCH /api/games/:id/user-rating &gt; should return 400 for rating below 0" time="0.005608066">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; PATCH /api/games/:id/user-rating &gt; should return 400 for rating of 0 (minimum is 0.5)" time="0.005504914">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; PATCH /api/games/:id/user-rating &gt; should return 400 for non-0.5-increment rating" time="0.005508783">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; PATCH /api/games/:id/user-rating &gt; should return 404 if game not found (including cross-user access)" time="0.015698499">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; DELETE /api/games/:id &gt; should remove game" time="0.005367162">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; DELETE /api/games/:id &gt; should return 404 if game not found" time="0.005874627">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB routes &gt; GET /api/igdb/search &gt; should return search results" time="0.006127067">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB routes &gt; GET /api/igdb/search &gt; should require query parameter" time="0.009186994">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB routes &gt; GET /api/igdb/popular &gt; should return popular games" time="0.005445038">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB routes &gt; GET /api/igdb/recent &gt; should return recent releases" time="0.005150573">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB routes &gt; GET /api/igdb/upcoming &gt; should return upcoming releases" time="0.005025396">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB routes &gt; GET /api/igdb/genre/:genre &gt; should return games by genre" time="0.005159902">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB routes &gt; GET /api/igdb/platform/:platform &gt; should return games by platform" time="0.005146723">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB routes &gt; GET /api/igdb/genres &gt; should return genres" time="0.004903895">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB routes &gt; GET /api/igdb/platforms &gt; should return platforms" time="0.005071749">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB routes &gt; GET /api/igdb/game/:id &gt; should return game details" time="0.005453929">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB routes &gt; GET /api/igdb/game/:id &gt; should return 404 for missing game" time="0.005128841">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; GET /api/indexers &gt; should return all indexers" time="0.005114951">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; GET /api/indexers &gt; should return 500 on error" time="0.004823063">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; GET /api/indexers/enabled &gt; should return enabled indexers" time="0.004918045">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; GET /api/indexers/:id &gt; should return single indexer" time="0.013127616">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; GET /api/indexers/:id &gt; should return 404 for missing indexer" time="0.004973788">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; DELETE /api/indexers/:id &gt; should delete indexer" time="0.00475823">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; DELETE /api/indexers/:id &gt; should return 404 for missing indexer" time="0.004766849">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; POST /api/indexers/:id/test &gt; should test existing indexer" time="0.006731581">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; POST /api/indexers/:id/test &gt; should return 404 for missing indexer" time="0.005458905">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; GET /api/indexers/:id/categories &gt; should return categories" time="0.005513302">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; GET /api/indexers/:id/categories &gt; should return 404 for missing indexer" time="0.006320856">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; GET /api/indexers/:id/search &gt; should search specific indexer" time="0.005283998">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; GET /api/indexers/:id/search &gt; should require query parameter" time="0.004441479">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Indexer routes &gt; GET /api/indexers/:id/search &gt; should return 404 for missing indexer" time="0.004491119">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; GET /api/downloaders &gt; should return all downloaders" time="0.004520113">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; GET /api/downloaders/enabled &gt; should return enabled downloaders" time="0.004490472">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; GET /api/downloaders/storage &gt; should return storage info" time="0.004965131">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; GET /api/downloaders/:id &gt; should return single downloader" time="0.004686441">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; GET /api/downloaders/:id &gt; should return 404 for missing downloader" time="0.004233978">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; DELETE /api/downloaders/:id &gt; should delete downloader" time="0.004548547">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; DELETE /api/downloaders/:id &gt; should return 404 for missing downloader" time="0.015368148">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; POST /api/downloaders/:id/test &gt; should test existing downloader" time="0.005553331">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; POST /api/downloaders/:id/test &gt; should return 404 for missing downloader" time="0.006321684">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; GET /api/downloaders/:id/downloads &gt; should return downloads" time="0.004939499">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; GET /api/downloaders/:id/downloads &gt; should return 404 for missing downloader" time="0.004284163">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; GET /api/downloaders/:id/downloads/:downloadId &gt; should return download status" time="0.004709387">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; GET /api/downloaders/:id/downloads/:downloadId &gt; should return 404 for missing download" time="0.004676297">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; POST /api/downloaders/:id/downloads/:downloadId/pause &gt; should pause download" time="0.004643126">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; POST /api/downloaders/:id/downloads/:downloadId/pause &gt; should return 404 for missing downloader" time="0.004619712">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; POST /api/downloaders/:id/downloads/:downloadId/resume &gt; should resume download" time="0.00426248">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; POST /api/downloaders/:id/downloads/:downloadId/resume &gt; should return 404 for missing downloader" time="0.004245179">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; DELETE /api/downloaders/:id/downloads/:downloadId &gt; should remove download" time="0.004214951">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Downloader routes &gt; DELETE /api/downloaders/:id/downloads/:downloadId &gt; should return 404 for missing downloader" time="0.004034337">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/downloads &gt; should return aggregated downloads" time="0.009476366">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/downloads &gt; should handle downloader errors gracefully" time="0.005718621">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/downloads &gt; should sanitize downloader error details in production" time="0.005663924">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/downloads &gt; should mark downloads as trackedByQuestarr when hash matches with case-insensitive comparison" time="0.00434262">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/downloads &gt; should mark downloads as trackedByQuestarr when hash matches a game download" time="0.012526474">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/downloads &gt; should include downloaderCategory from the downloader settings" time="0.004485361">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/downloads &gt; should omit downloaderCategory when the downloader has no category configured" time="0.004881029">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Notification routes &gt; GET /api/notifications &gt; should return notifications" time="0.004906075">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Notification routes &gt; GET /api/notifications &gt; should return 500 on error" time="0.00461306">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Notification routes &gt; GET /api/notifications/unread-count &gt; should return unread count" time="0.004758397">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Notification routes &gt; PUT /api/notifications/:id/read &gt; should mark notification as read" time="0.004712033">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Notification routes &gt; PUT /api/notifications/:id/read &gt; should return 404 for missing notification" time="0.004337695">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Notification routes &gt; PUT /api/notifications/read-all &gt; should mark all as read" time="0.005482876">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Notification routes &gt; DELETE /api/notifications &gt; should clear all notifications" time="0.004130223">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/config &gt; should return config with DB credentials" time="0.004780971">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/config &gt; should fallback to env credentials" time="0.004123947">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB settings &gt; GET /api/settings/igdb &gt; should return IGDB settings from DB" time="0.004235754">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB settings &gt; POST /api/settings/igdb &gt; should update IGDB credentials" time="0.004631142">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB settings &gt; POST /api/settings/igdb &gt; should return 400 when clientId is missing" time="0.004234613">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; IGDB settings &gt; POST /api/settings/igdb &gt; should handle masked secret update" time="0.004721666">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; User settings &gt; GET /api/settings &gt; should return user settings" time="0.00449237">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; User settings &gt; GET /api/settings &gt; should create default settings if they don&apos;t exist" time="0.011031403">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; User settings &gt; PATCH /api/settings &gt; should update user settings" time="0.006686969">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; RSS routes &gt; GET /api/rss/feeds &gt; should return RSS feeds" time="0.004516286">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; RSS routes &gt; GET /api/rss/feeds &gt; should return 500 on error" time="0.004723274">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; RSS routes &gt; PUT /api/rss/feeds/:id &gt; should update RSS feed" time="0.005984374">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; RSS routes &gt; PUT /api/rss/feeds/:id &gt; should return 404 for missing feed" time="0.008930457">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; RSS routes &gt; DELETE /api/rss/feeds/:id &gt; should delete RSS feed" time="0.004912616">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; RSS routes &gt; DELETE /api/rss/feeds/:id &gt; should return 404 for missing feed" time="0.0044794">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; RSS routes &gt; GET /api/rss/items &gt; should return RSS items" time="0.004451537">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; RSS routes &gt; POST /api/rss/refresh &gt; should refresh all feeds" time="0.004451561">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; RSS routes &gt; POST /api/rss/refresh &gt; should return 500 on error" time="0.004963211">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; POST /api/indexers/test &gt; should return 400 for missing url/apiKey" time="0.004868128">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; POST /api/downloaders/test &gt; should return 400 for missing type/url" time="0.00456207">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/downloaders/:id/downloads/:downloadId/details &gt; should return download details" time="0.004346476">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/downloaders/:id/downloads/:downloadId/details &gt; should return 404 for missing downloader" time="0.004098947">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/downloaders/:id/downloads/:downloadId/details &gt; should return 404 for missing download details" time="0.004334137">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; POST /api/indexers/prowlarr/sync &gt; should return 400 for missing url/apiKey" time="0.004995818">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; POST /api/games/:gameId/blacklist &gt; should add a release to the blacklist" time="0.015348032">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; POST /api/games/:gameId/blacklist &gt; should return 400 for missing releaseTitle" time="0.014000731">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; POST /api/games/:gameId/blacklist &gt; should return 403 when game belongs to another user" time="0.005056791">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; POST /api/games/:gameId/blacklist &gt; should return 404 when game not found" time="0.00458466">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; POST /api/games/:gameId/blacklist &gt; should return 400 when releaseTitle exceeds 500 characters" time="0.004897369">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; POST /api/games/:gameId/blacklist &gt; should return 500 on storage error" time="0.004585333">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; GET /api/games/:gameId/blacklist &gt; should return blacklist entries for a game" time="0.004502315">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; GET /api/games/:gameId/blacklist &gt; should return 403 when game belongs to another user" time="0.003974095">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; GET /api/games/:gameId/blacklist &gt; should return 404 when game not found" time="0.004208958">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; GET /api/games/:gameId/blacklist &gt; should return 500 on storage error" time="0.003945113">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; DELETE /api/games/:gameId/blacklist/:id &gt; should remove a blacklist entry" time="0.003731612">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; DELETE /api/games/:gameId/blacklist/:id &gt; should return 404 when entry not found" time="0.004131442">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; DELETE /api/games/:gameId/blacklist/:id &gt; should return 403 when game belongs to another user" time="0.003924184">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; DELETE /api/games/:gameId/blacklist/:id &gt; should return 404 when game not found" time="0.003969332">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; DELETE /api/games/:gameId/blacklist/:id &gt; should return 500 on storage error" time="0.00444654">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; GET /api/blacklist &gt; should return all blacklist entries for the user" time="0.004646384">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; GET /api/blacklist &gt; should return empty array when no entries" time="0.004345799">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; GET /api/blacklist &gt; should return 500 on storage error" time="0.012168751">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/search - blacklist filtering &gt; should filter blacklisted releases when gameId belongs to user" time="0.00671132">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/search - blacklist filtering &gt; should include blacklistedCount in response when items are blacklisted" time="0.005736616">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/search - blacklist filtering &gt; should not filter when game belongs to another user" time="0.006592576">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Discord settings &gt; GET /api/settings/discord &gt; should return configured: true when webhook URL is set" time="0.004559667">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Discord settings &gt; GET /api/settings/discord &gt; should return configured: false when webhook URL is empty" time="0.005349818">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Discord settings &gt; GET /api/settings/discord &gt; should return configured: false when webhook URL is null" time="0.004478666">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Discord settings &gt; GET /api/settings/discord &gt; should return 500 on storage error" time="0.006836693">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Discord settings &gt; POST /api/settings/discord &gt; should save a valid discord.com webhook URL" time="0.006772903">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Discord settings &gt; POST /api/settings/discord &gt; should save a valid discordapp.com webhook URL" time="0.005110487">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Discord settings &gt; POST /api/settings/discord &gt; should return 400 for an invalid webhook URL" time="0.004732303">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Discord settings &gt; POST /api/settings/discord &gt; should clear the webhook URL when empty string is sent" time="0.004434756">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Discord settings &gt; POST /api/settings/discord &gt; should return 500 on storage error" time="0.004907115">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; POST /api/stats/discord-share &gt; should return 400 when no webhook is configured" time="0.005114583">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; POST /api/stats/discord-share &gt; should return 400 when webhook URL is invalid in DB" time="0.005160032">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; POST /api/stats/discord-share &gt; should return 400 when no image is provided" time="0.004469638">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; POST /api/stats/discord-share &gt; should return 400 for malformed image data" time="0.004709661">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; POST /api/stats/discord-share &gt; should post to Discord and return success" time="0.021128923">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; POST /api/stats/discord-share &gt; should return 502 when Discord rejects the request" time="0.005841733">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; POST /api/stats/discord-share &gt; should return 500 on unexpected error" time="0.004686554">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; POST /api/games/:gameId/blacklist &gt; should add a release to the blacklist" time="0.006999418">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; POST /api/games/:gameId/blacklist &gt; should return 400 for missing releaseTitle" time="0.005252603">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; POST /api/games/:gameId/blacklist &gt; should return 403 when game belongs to another user" time="0.004578585">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; POST /api/games/:gameId/blacklist &gt; should return 404 when game not found" time="0.005334265">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; GET /api/games/:gameId/blacklist &gt; should return blacklist entries for a game" time="0.00442191">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; GET /api/games/:gameId/blacklist &gt; should return 403 when game belongs to another user" time="0.004200249">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; DELETE /api/games/:gameId/blacklist/:id &gt; should remove a blacklist entry" time="0.004106453">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; DELETE /api/games/:gameId/blacklist/:id &gt; should return 404 when entry not found" time="0.004244136">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; DELETE /api/games/:gameId/blacklist/:id &gt; should return 403 when game belongs to another user" time="0.004089157">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; GET /api/blacklist &gt; should return all blacklist entries for the user" time="0.004253301">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; Release Blacklist routes &gt; GET /api/blacklist &gt; should return empty array when no entries" time="0.004302813">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/games/:id/downloads &gt; should return downloads for a game" time="0.004967387">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/games/:id/downloads &gt; should return empty array when game has no downloads" time="0.004478631">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/games/:id/downloads &gt; should return 400 for an invalid (non-UUID) game id" time="0.004845363">
+        </testcase>
+        <testcase classname="server/__tests__/api_routes.test.ts" name="API Routes - Extended Coverage &gt; GET /api/games/:id/downloads &gt; should return 500 when storage throws" time="0.016561818">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/auth.test.ts" timestamp="2026-06-10T11:57:56.062Z" hostname="devbox" tests="6" failures="0" errors="0" skipped="0" time="0.526571487">
+        <testcase classname="server/__tests__/auth.test.ts" name="auth Module &gt; hashPassword &amp; comparePassword &gt; should hash a password and be able to compare it" time="0.509861361">
+        </testcase>
+        <testcase classname="server/__tests__/auth.test.ts" name="auth Module &gt; generateToken &gt; should generate a valid JWT token" time="0.006294726">
+        </testcase>
+        <testcase classname="server/__tests__/auth.test.ts" name="auth Module &gt; authenticateToken &gt; should return 401 if no token provided" time="0.003111626">
+        </testcase>
+        <testcase classname="server/__tests__/auth.test.ts" name="auth Module &gt; authenticateToken &gt; should return 401 if user not found" time="0.001659927">
+        </testcase>
+        <testcase classname="server/__tests__/auth.test.ts" name="auth Module &gt; authenticateToken &gt; should call next() if token and user are valid" time="0.001058976">
+        </testcase>
+        <testcase classname="server/__tests__/auth.test.ts" name="auth Module &gt; authenticateToken &gt; should return 403 on invalid signature" time="0.001113742">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/config-loader.test.ts" timestamp="2026-06-10T11:57:56.065Z" hostname="devbox" tests="5" failures="0" errors="0" skipped="0" time="0.012520906">
+        <testcase classname="server/__tests__/config-loader.test.ts" name="ConfigLoader &gt; Constructor Path Logic &gt; should prioritize data/config.yaml if it exists" time="0.0045748">
+        </testcase>
+        <testcase classname="server/__tests__/config-loader.test.ts" name="ConfigLoader &gt; Constructor Path Logic &gt; should fallback to config.yaml if data/config.yaml missing but root exists" time="0.000867205">
+        </testcase>
+        <testcase classname="server/__tests__/config-loader.test.ts" name="ConfigLoader &gt; Constructor Path Logic &gt; should default to data/config.yaml for new instances if neither exists" time="0.00085605">
+        </testcase>
+        <testcase classname="server/__tests__/config-loader.test.ts" name="ConfigLoader &gt; Environment Variable Overrides &gt; should override SSL port from env var" time="0.000906652">
+        </testcase>
+        <testcase classname="server/__tests__/config-loader.test.ts" name="ConfigLoader &gt; Environment Variable Overrides &gt; should use env var SSL port for default config if file broken" time="0.002094711">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/config.test.ts" timestamp="2026-06-10T11:57:56.067Z" hostname="devbox" tests="8" failures="0" errors="0" skipped="0" time="0.071990716">
+        <testcase classname="server/__tests__/config.test.ts" name="Config Module &gt; when configuration is missing &gt; should use default fallback sqlite DB if paths are missing" time="0.044262782">
+        </testcase>
+        <testcase classname="server/__tests__/config.test.ts" name="Config Module &gt; when PORT is invalid &gt; should call process.exit(1) for non-numeric PORT" time="0.010727142">
+        </testcase>
+        <testcase classname="server/__tests__/config.test.ts" name="Config Module &gt; when SQLITE_DB_PATH is set &gt; should export valid config with defaults" time="0.002569381">
+        </testcase>
+        <testcase classname="server/__tests__/config.test.ts" name="Config Module &gt; when SQLITE_DB_PATH is set &gt; should respect custom PORT and HOST" time="0.002506261">
+        </testcase>
+        <testcase classname="server/__tests__/config.test.ts" name="Config Module &gt; when SQLITE_DB_PATH is set &gt; should detect IGDB as configured when both credentials are set" time="0.002035841">
+        </testcase>
+        <testcase classname="server/__tests__/config.test.ts" name="Config Module &gt; when SQLITE_DB_PATH is set &gt; should detect IGDB as not configured when only one credential is set" time="0.002238348">
+        </testcase>
+        <testcase classname="server/__tests__/config.test.ts" name="Config Module &gt; when SQLITE_DB_PATH is set &gt; should set NODE_ENV correctly" time="0.002133729">
+        </testcase>
+        <testcase classname="server/__tests__/config.test.ts" name="Config Module &gt; when SQLITE_DB_PATH is set &gt; should set test environment flags correctly" time="0.00215342">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/cron_autosearch.test.ts" timestamp="2026-06-10T11:57:56.071Z" hostname="devbox" tests="36" failures="0" errors="0" skipped="0" time="0.0661178">
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should search for released games when autoSearchUnreleased is false (default)" time="0.012068782">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should NOT search for unreleased games when autoSearchUnreleased is false" time="0.001170331">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should search for released games when autoSearchUnreleased is true" time="0.000971136">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should search for unreleased games when autoSearchUnreleased is true" time="0.001125424">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should search for delayed games when autoSearchUnreleased is true" time="0.000877667">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should NOT search for delayed games when autoSearchUnreleased is false" time="0.000759541">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should respect search interval" time="0.000670985">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should search if interval has passed" time="0.000705471">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should not notify updates for wanted games" time="0.004616874">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should notify updates for owned games" time="0.002333265">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should still notify game availability for wanted games when main results exist" time="0.001658998">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should mark search results available when single main result found and auto-download disabled" time="0.001348758">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should mark search results available when multiple main results found with notifyMultipleDownloads" time="0.000979046">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Release Groups Filtering &gt; should filter to preferred group when matching items exist (multiple→single triggers availability)" time="0.001551015">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Release Groups Filtering &gt; should fall back to all items when no items match preferred groups" time="0.001064428">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Release Groups Filtering &gt; should not filter when preferredReleaseGroups is an empty array" time="0.000951378">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Release Groups Filtering &gt; should handle malformed JSON in preferredReleaseGroups gracefully" time="0.002690521">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Release Groups Filtering &gt; should treat non-array JSON as no filter (use all items)" time="0.001019486">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Release Groups Filtering &gt; should include group name in Download Started notification" time="0.001106978">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Release Groups Filtering &gt; should not include group suffix in Download Started notification when item has no group" time="0.001252336">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Release Groups Filtering &gt; should filter owned-game update items by preferred groups" time="0.001056165">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Platform Filtering &gt; should include explicit PC releases when PC is the preferred platform" time="0.004378968">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Platform Filtering &gt; should include no-platform releases when PC is the preferred platform" time="0.002149274">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Platform Filtering &gt; should exclude no-platform releases when a non-PC platform is preferred" time="0.001124697">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Platform Filtering &gt; should apply platform filter before preferred groups (platform is strict)" time="0.001121156">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Platform Filtering &gt; should fall back to platform-filtered set when no group matches after platform filter" time="0.001101615">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Preferred Platform Filtering &gt; should not apply platform filter when preferredPlatform is null" time="0.001036128">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should not notify when all matched items are blacklisted" time="0.000958959">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; should clear search results badge when indexer returns zero items" time="0.000717045">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Strict preferred-group filtering (filterByPreferredGroups=true) &gt; should trigger auto-download when strict filter narrows 3 results to 1 preferred-group match" time="0.002259137">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Strict preferred-group filtering (filterByPreferredGroups=true) &gt; should clear availability flag and not auto-download when strict filter matches nothing" time="0.001025675">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; Strict preferred-group filtering (filterByPreferredGroups=true) &gt; should fall back to all items when filterByPreferredGroups is false and no group matches" time="0.001039386">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; De-duplication of releases across indexers &gt; should de-duplicate identical releases from multiple indexers and trigger auto-download" time="0.001643304">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; De-duplication of releases across indexers &gt; should prefer the item from the higher-priority indexer when de-duplicating" time="0.001215012">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; De-duplication of releases across indexers &gt; should not de-duplicate releases with different titles" time="0.001026885">
+        </testcase>
+        <testcase classname="server/__tests__/cron_autosearch.test.ts" name="Cron - checkAutoSearch &gt; De-duplication of releases across indexers &gt; should treat titles as duplicates despite punctuation or casing differences" time="0.001014859">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/cron_download_status.test.ts" timestamp="2026-06-10T11:57:56.083Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="0.013390867">
+        <testcase classname="server/__tests__/cron_download_status.test.ts" name="Cron - checkDownloadStatus &gt; should find a download via the bulk map when it is in the queue" time="0.006565804">
+        </testcase>
+        <testcase classname="server/__tests__/cron_download_status.test.ts" name="Cron - checkDownloadStatus &gt; should fall back to getDownloadStatus when a download is absent from getAllDownloads" time="0.002501044">
+        </testcase>
+        <testcase classname="server/__tests__/cron_download_status.test.ts" name="Cron - checkDownloadStatus &gt; should mark as completed via error path when both bulk and individual checks return null" time="0.001040806">
+        </testcase>
+        <testcase classname="server/__tests__/cron_download_status.test.ts" name="Cron - checkDownloadStatus &gt; should not call getDownloadStatus when the bulk map already contains the download" time="0.000523646">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/cron_updates.test.ts" timestamp="2026-06-10T11:57:56.085Z" hostname="devbox" tests="5" failures="0" errors="0" skipped="0" time="0.020168872">
+        <testcase classname="server/__tests__/cron_updates.test.ts" name="checkGameUpdates &gt; should batch updates and notifications for multiple games" time="0.010033376">
+        </testcase>
+        <testcase classname="server/__tests__/cron_updates.test.ts" name="checkGameUpdates &gt; should initialize originalReleaseDate if missing" time="0.001375447">
+        </testcase>
+        <testcase classname="server/__tests__/cron_updates.test.ts" name="checkGameUpdates &gt; should update earlyAccess flag for games without a release date" time="0.001010029">
+        </testcase>
+        <testcase classname="server/__tests__/cron_updates.test.ts" name="checkGameUpdates &gt; should handle network errors from IGDB gracefully" time="0.00281177">
+        </testcase>
+        <testcase classname="server/__tests__/cron_updates.test.ts" name="checkGameUpdates &gt; should handle notification batch failure gracefully" time="0.001222937">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/cron_xrel.test.ts" timestamp="2026-06-10T11:57:56.087Z" hostname="devbox" tests="3" failures="0" errors="0" skipped="0" time="0.017922493">
+        <testcase classname="server/__tests__/cron_xrel.test.ts" name="checkXrelReleases &gt; should find and notify matching xREL releases using optimized matching" time="0.01314336">
+        </testcase>
+        <testcase classname="server/__tests__/cron_xrel.test.ts" name="checkXrelReleases &gt; should respect user preferences for scene/p2p releases" time="0.001020562">
+        </testcase>
+        <testcase classname="server/__tests__/cron_xrel.test.ts" name="checkXrelReleases &gt; should not notify if already notified" time="0.000784022">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/database_storage_integration.test.ts" timestamp="2026-06-10T11:57:56.088Z" hostname="devbox" tests="3" failures="0" errors="0" skipped="0" time="0.35283408">
+        <testcase classname="server/__tests__/database_storage_integration.test.ts" name="DatabaseStorage Integration &gt; getUserGames should filter by status correctly" time="0.16734848">
+        </testcase>
+        <testcase classname="server/__tests__/database_storage_integration.test.ts" name="DatabaseStorage Integration &gt; getDownloadSummaryByGame should aggregate downloads in the database layer" time="0.070462402">
+        </testcase>
+        <testcase classname="server/__tests__/database_storage_integration.test.ts" name="DatabaseStorage Integration &gt; getTrackedDownloadKeys returns downloaderId:downloadHash keys for all game downloads" time="0.112092875">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/db.test.ts" timestamp="2026-06-10T11:57:56.089Z" hostname="devbox" tests="6" failures="0" errors="0" skipped="6" time="0">
+        <testcase classname="server/__tests__/db.test.ts" name="Database Initialization &gt; should initialize with :memory: database in test environment" time="0">
+            <skipped/>
+        </testcase>
+        <testcase classname="server/__tests__/db.test.ts" name="Database Initialization &gt; should create database directory if it doesn&apos;t exist" time="0">
+            <skipped/>
+        </testcase>
+        <testcase classname="server/__tests__/db.test.ts" name="Database Initialization &gt; should use default path when SQLITE_DB_PATH is not set" time="0">
+            <skipped/>
+        </testcase>
+        <testcase classname="server/__tests__/db.test.ts" name="Database Initialization &gt; should handle existing valid database file" time="0">
+            <skipped/>
+        </testcase>
+        <testcase classname="server/__tests__/db.test.ts" name="Database Initialization &gt; should handle when database path is a directory by appending sqlite.db" time="0">
+            <skipped/>
+        </testcase>
+        <testcase classname="server/__tests__/db.test.ts" name="Database Initialization &gt; should apply SQLite pragmas for performance" time="0">
+            <skipped/>
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/download-summary.test.ts" timestamp="2026-06-10T11:57:56.092Z" hostname="devbox" tests="12" failures="0" errors="0" skipped="0" time="0.075523432">
+        <testcase classname="server/__tests__/download-summary.test.ts" name="getDownloadSummaryByGame (MemStorage) &gt; returns empty object when no downloads exist" time="0.004553065">
+        </testcase>
+        <testcase classname="server/__tests__/download-summary.test.ts" name="getDownloadSummaryByGame (MemStorage) &gt; returns correct singleton for a game with a single download" time="0.002106201">
+        </testcase>
+        <testcase classname="server/__tests__/download-summary.test.ts" name="getDownloadSummaryByGame (MemStorage) &gt; aggregates count correctly" time="0.001188342">
+        </testcase>
+        <testcase classname="server/__tests__/download-summary.test.ts" name="getDownloadSummaryByGame (MemStorage) &gt; deduplicates downloadTypes" time="0.002242865">
+        </testcase>
+        <testcase classname="server/__tests__/download-summary.test.ts" name="getDownloadSummaryByGame (MemStorage) &gt; resolves topStatus with correct priority: failed &gt; downloading &gt; paused &gt; completed" time="0.000728592">
+        </testcase>
+        <testcase classname="server/__tests__/download-summary.test.ts" name="getDownloadSummaryByGame (MemStorage) &gt; does not downgrade topStatus when a lower-priority status is added" time="0.000761135">
+        </testcase>
+        <testcase classname="server/__tests__/download-summary.test.ts" name="getDownloadSummaryByGame (MemStorage) &gt; handles multiple games independently" time="0.00051511">
+        </testcase>
+        <testcase classname="server/__tests__/download-summary.test.ts" name="getDownloadSummaryByGame (MemStorage) &gt; sets hasUpdateDownload when a download title matches update patterns" time="0.000384018">
+        </testcase>
+        <testcase classname="server/__tests__/download-summary.test.ts" name="getDownloadSummaryByGame (MemStorage) &gt; leaves hasUpdateDownload false when no update title exists" time="0.000407523">
+        </testcase>
+        <testcase classname="server/__tests__/download-summary.test.ts" name="GET /api/downloads/summary &gt; returns 401 without auth token" time="0.043162306">
+        </testcase>
+        <testcase classname="server/__tests__/download-summary.test.ts" name="GET /api/downloads/summary &gt; returns {} when no downloads exist" time="0.009593473">
+        </testcase>
+        <testcase classname="server/__tests__/download-summary.test.ts" name="GET /api/downloads/summary &gt; returns correct summary map when downloads exist" time="0.006764534">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/downloaders.test.ts" timestamp="2026-06-10T11:57:56.096Z" hostname="devbox" tests="14" failures="0" errors="0" skipped="0" time="0.025838313">
+        <testcase classname="server/__tests__/downloaders.test.ts" name="TransmissionClient &gt; testConnection &gt; should return success on valid session-get response" time="0.006940219">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="TransmissionClient &gt; testConnection &gt; should handle authentication failure" time="0.001035488">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="TransmissionClient &gt; addDownload &gt; should add magnet link successfully" time="0.001703897">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="TransmissionClient &gt; addDownload &gt; should handle duplicates" time="0.00077444">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="TransmissionClient &gt; addDownload &gt; should fallback to local download for non-magnet URLs" time="0.001665139">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="TransmissionClient &gt; addDownload &gt; should include detailed Transmission RPC error in failure message" time="0.00059097">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="TransmissionClient &gt; addDownload &gt; should not expose non-string Transmission RPC error payloads" time="0.000531588">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="TransmissionClient &gt; getDownloadStatus &gt; should map status correctly" time="0.001112526">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="RTorrentClient &gt; testConnection &gt; should return success on valid system.client_version response" time="0.001953629">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="RTorrentClient &gt; addDownload &gt; should add download with downloadPath and category" time="0.001747826">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="RTorrentClient &gt; addDownload &gt; should add download with downloadPath only (no category)" time="0.000876032">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="RTorrentClient &gt; addDownload &gt; should handle directory.set failure gracefully" time="0.000778249">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="QBittorrentClient &gt; authenticate &gt; should authenticate and set &apos;SID&apos; cookie" time="0.001921356">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders.test.ts" name="QBittorrentClient &gt; authenticate &gt; should authenticate and set &apos;QBT_SID&apos; cookie" time="0.000581513">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/downloaders_comprehensive.test.ts" timestamp="2026-06-10T11:57:56.100Z" hostname="devbox" tests="16" failures="0" errors="0" skipped="0" time="0.043942462">
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; TransmissionClient &gt; should add download successfully" time="0.006589174">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; TransmissionClient &gt; should handle duplicate torrent as success" time="0.001013341">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; TransmissionClient &gt; should get download status" time="0.001120896">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; RTorrentClient &gt; should add download successfully" time="0.00263622">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; QBittorrentClient &gt; should add download successfully" time="0.008748669">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; QBittorrentClient &gt; should handle duplicate torrent (Fails.) as success" time="0.002666356">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; SABnzbdClient &gt; should add NZB successfully" time="0.001553757">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; SABnzbdClient &gt; should handle duplicate NZB as success" time="0.000739746">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; SABnzbdClient &gt; should return completed status when download is found in history" time="0.001808635">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; SABnzbdClient &gt; should return error status when history shows a failed download" time="0.000779114">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; SABnzbdClient &gt; should return null when download is not in queue or history" time="0.000726362">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; SABnzbdClient &gt; should pass nzo_ids parameter when querying history" time="0.000679697">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; SABnzbdClient &gt; should return success when status is true but no IDs returned (merged/duplicate)" time="0.000592068">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; NZBGetClient &gt; should add NZB successfully" time="0.008737216">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; NZBGetClient &gt; should handle failed NZB fetch" time="0.000644482">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_comprehensive.test.ts" name="Downloader Comprehensive Tests &gt; addDownloadWithFallback &gt; should stop falling back when first downloader returns duplicate (success: true)" time="0.001219461">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/downloaders_ssrf.test.ts" timestamp="2026-06-10T11:57:56.105Z" hostname="devbox" tests="7" failures="0" errors="0" skipped="0" time="0.046832657">
+        <testcase classname="server/__tests__/downloaders_ssrf.test.ts" name="Downloader SSRF Protection &gt; TransmissionClient &gt; should bypass isSafeUrl for magnet links (no hostname to validate)" time="0.037085491">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_ssrf.test.ts" name="Downloader SSRF Protection &gt; TransmissionClient &gt; should block unsafe URL in addDownload (http)" time="0.002231577">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_ssrf.test.ts" name="Downloader SSRF Protection &gt; RTorrentClient &gt; should block unsafe URL in addDownload" time="0.000930131">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_ssrf.test.ts" name="Downloader SSRF Protection &gt; QBittorrentClient &gt; should block unsafe URL in addDownload" time="0.001571114">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_ssrf.test.ts" name="Downloader SSRF Protection &gt; QBittorrentClient &gt; should block unsafe URL in fetchWithMagnetDetection (internal helper)" time="0.000259159">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_ssrf.test.ts" name="Downloader SSRF Protection &gt; SABnzbdClient &gt; should block unsafe URL in addDownload" time="0.000700271">
+        </testcase>
+        <testcase classname="server/__tests__/downloaders_ssrf.test.ts" name="Downloader SSRF Protection &gt; NZBGetClient &gt; should block unsafe URL in addDownload" time="0.000801211">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/health.test.ts" timestamp="2026-06-10T11:57:56.108Z" hostname="devbox" tests="5" failures="0" errors="0" skipped="0" time="0.014990358">
+        <testcase classname="server/__tests__/health.test.ts" name="Health and Readiness Endpoints &gt; Liveness Probe (/api/health) &gt; should always return a 200 OK status" time="0.004470692">
+        </testcase>
+        <testcase classname="server/__tests__/health.test.ts" name="Health and Readiness Endpoints &gt; Readiness Probe (/api/ready) &gt; should return ok: true when both db and igdb are healthy" time="0.005367462">
+        </testcase>
+        <testcase classname="server/__tests__/health.test.ts" name="Health and Readiness Endpoints &gt; Readiness Probe (/api/ready) &gt; should return ok: false when database is down" time="0.000757088">
+        </testcase>
+        <testcase classname="server/__tests__/health.test.ts" name="Health and Readiness Endpoints &gt; Readiness Probe (/api/ready) &gt; should return ok: false when IGDB API is down" time="0.000758022">
+        </testcase>
+        <testcase classname="server/__tests__/health.test.ts" name="Health and Readiness Endpoints &gt; Readiness Probe (/api/ready) &gt; should return ok: false when both services are down" time="0.000483889">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/hltb-routes.test.ts" timestamp="2026-06-10T11:57:56.111Z" hostname="devbox" tests="6" failures="0" errors="0" skipped="0" time="0.111545475">
+        <testcase classname="server/__tests__/hltb-routes.test.ts" name="HLTB Routes &gt; GET /api/hltb/lookup &gt; returns { data: null } when no match is found" time="0.054756277">
+        </testcase>
+        <testcase classname="server/__tests__/hltb-routes.test.ts" name="HLTB Routes &gt; GET /api/hltb/lookup &gt; returns entry data when a match is found" time="0.012056534">
+        </testcase>
+        <testcase classname="server/__tests__/hltb-routes.test.ts" name="HLTB Routes &gt; GET /api/hltb/lookup &gt; returns 400 when title param is missing" time="0.021248208">
+        </testcase>
+        <testcase classname="server/__tests__/hltb-routes.test.ts" name="HLTB Routes &gt; GET /api/hltb/lookup &gt; returns 400 when title param is empty string" time="0.006119">
+        </testcase>
+        <testcase classname="server/__tests__/hltb-routes.test.ts" name="HLTB Routes &gt; GET /api/hltb/lookup &gt; calls hltbClient.lookup with the provided title" time="0.008125239">
+        </testcase>
+        <testcase classname="server/__tests__/hltb-routes.test.ts" name="HLTB Routes &gt; GET /api/hltb/lookup &gt; returns 500 when hltbClient.lookup throws" time="0.006216811">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/hltb.test.ts" timestamp="2026-06-10T11:57:56.114Z" hostname="devbox" tests="11" failures="0" errors="0" skipped="0" time="0.035085707">
+        <testcase classname="server/__tests__/hltb.test.ts" name="HLTBClient &gt; returns null when safeFetch returns non-200" time="0.008661686">
+        </testcase>
+        <testcase classname="server/__tests__/hltb.test.ts" name="HLTBClient &gt; does not cache non-200 responses so retries can succeed" time="0.002181408">
+        </testcase>
+        <testcase classname="server/__tests__/hltb.test.ts" name="HLTBClient &gt; returns null when response has no data" time="0.000976311">
+        </testcase>
+        <testcase classname="server/__tests__/hltb.test.ts" name="HLTBClient &gt; returns the best matching entry for an exact title" time="0.001615067">
+        </testcase>
+        <testcase classname="server/__tests__/hltb.test.ts" name="HLTBClient &gt; converts seconds to hours correctly" time="0.006661999">
+        </testcase>
+        <testcase classname="server/__tests__/hltb.test.ts" name="HLTBClient &gt; treats comp_main = 0 as unknown (returns 0)" time="0.001040619">
+        </testcase>
+        <testcase classname="server/__tests__/hltb.test.ts" name="HLTBClient &gt; returns null when similarity is below threshold" time="0.000936108">
+        </testcase>
+        <testcase classname="server/__tests__/hltb.test.ts" name="HLTBClient &gt; returns null and does not throw when safeFetch throws" time="0.005138755">
+        </testcase>
+        <testcase classname="server/__tests__/hltb.test.ts" name="HLTBClient &gt; does not cache network errors so retries can succeed" time="0.001581367">
+        </testcase>
+        <testcase classname="server/__tests__/hltb.test.ts" name="HLTBClient &gt; caches result and does not call safeFetch a second time for the same title" time="0.001182055">
+        </testcase>
+        <testcase classname="server/__tests__/hltb.test.ts" name="HLTBClient &gt; is case-insensitive (normalizes title before cache lookup)" time="0.002033355">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/igdb.test.ts" timestamp="2026-06-10T11:57:56.119Z" hostname="devbox" tests="19" failures="0" errors="0" skipped="0" time="2.011233622">
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - Fallback Mechanism &gt; should try multiple search approaches when first approach returns no results" time="0.916414454">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - Fallback Mechanism &gt; should return empty array when all search approaches fail" time="0.02760857">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - Fallback Mechanism &gt; should cap total search attempts at MAX_SEARCH_ATTEMPTS (5)" time="0.020881485">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - Fallback Mechanism &gt; should return null for getGameById when not found" time="0.080166203">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - Fallback Mechanism &gt; Discovery Methods &gt; getPopularGames should return list of games" time="0.055105118">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - Fallback Mechanism &gt; Discovery Methods &gt; getRecentReleases should return list of games" time="0.08227538">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - Fallback Mechanism &gt; Discovery Methods &gt; getUpcomingReleases should return list of games" time="0.057287407">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - Fallback Mechanism &gt; Category Search &gt; getGamesByGenre should return games" time="0.039823844">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - Fallback Mechanism &gt; Category Search &gt; getGamesByPlatform should return games" time="0.124640791">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - Batch Operations &gt; should batch steam app ID lookups correctly" time="0.034554714">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - formatGameData metadata fields &gt; returns null rating when IGDB game has no rating field" time="0.064855292">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - formatGameData metadata fields &gt; returns null rating when IGDB game rating is 0" time="0.046000464">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - formatGameData metadata fields &gt; returns scaled rating (Math.round / 10) when IGDB rating exists" time="0.037433945">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - formatGameData metadata fields &gt; returns scaled rating for a whole-number IGDB rating" time="0.097182323">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - formatGameData metadata fields &gt; parses aggregatedRating from IGDB aggregated_rating field (rounds to 1 decimal)" time="0.050177346">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - formatGameData metadata fields &gt; leaves aggregatedRating undefined when IGDB field is absent" time="0.094165983">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - formatGameData metadata fields &gt; leaves aggregatedRating undefined when IGDB field is zero/falsy" time="0.043073889">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - formatGameData metadata fields &gt; parses igdbWebsites as array when websites are present" time="0.082497605">
+        </testcase>
+        <testcase classname="server/__tests__/igdb.test.ts" name="IGDBClient - formatGameData metadata fields &gt; uses empty array for igdbWebsites when websites field is absent" time="0.039324573">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/igdb_error.test.ts" timestamp="2026-06-10T11:57:56.128Z" hostname="devbox" tests="1" failures="0" errors="0" skipped="0" time="0.008060931">
+        <testcase classname="server/__tests__/igdb_error.test.ts" name="IGDB Client Error Handling &gt; should return empty array when credentials are missing" time="0.005316944">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/indexers-search.test.ts" timestamp="2026-06-10T11:57:56.129Z" hostname="devbox" tests="7" failures="0" errors="0" skipped="0" time="0.03894069">
+        <testcase classname="server/__tests__/indexers-search.test.ts" name="GET /api/indexers/search - Aggregated multi-indexer search &gt; should aggregate results from multiple enabled indexers" time="0.017156692">
+        </testcase>
+        <testcase classname="server/__tests__/indexers-search.test.ts" name="GET /api/indexers/search - Aggregated multi-indexer search &gt; should return items and errors when some indexers fail" time="0.002656434">
+        </testcase>
+        <testcase classname="server/__tests__/indexers-search.test.ts" name="GET /api/indexers/search - Aggregated multi-indexer search &gt; should return empty items with errors when all indexers fail" time="0.001628978">
+        </testcase>
+        <testcase classname="server/__tests__/indexers-search.test.ts" name="GET /api/indexers/search - Aggregated multi-indexer search &gt; should throw error when no enabled indexers are available" time="0.003568547">
+        </testcase>
+        <testcase classname="server/__tests__/indexers-search.test.ts" name="GET /api/indexers/search - Aggregated multi-indexer search &gt; should filter out disabled indexers" time="0.006183312">
+        </testcase>
+        <testcase classname="server/__tests__/indexers-search.test.ts" name="GET /api/indexers/search - Aggregated multi-indexer search &gt; Comments URL handling &gt; should pass through comments when provided by indexer" time="0.002430054">
+        </testcase>
+        <testcase classname="server/__tests__/indexers-search.test.ts" name="GET /api/indexers/search - Aggregated multi-indexer search &gt; Comments URL handling &gt; should include indexerUrl in results for fallback URL construction" time="0.002057876">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/logger.test.ts" timestamp="2026-06-10T11:57:56.133Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="0.053374511">
+        <testcase classname="server/__tests__/logger.test.ts" name="Logger Module &gt; should export logger and child loggers" time="0.037852133">
+        </testcase>
+        <testcase classname="server/__tests__/logger.test.ts" name="Logger Module &gt; should create child loggers with module property" time="0.004037381">
+        </testcase>
+        <testcase classname="server/__tests__/logger.test.ts" name="Logger Module &gt; should respect LOG_LEVEL environment variable" time="0.004651756">
+        </testcase>
+        <testcase classname="server/__tests__/logger.test.ts" name="Logger Module &gt; should default to debug level when LOG_LEVEL is not set" time="0.003955826">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/logging.test.ts" timestamp="2026-06-10T11:57:56.135Z" hostname="devbox" tests="1" failures="0" errors="0" skipped="0" time="0.020235655">
+        <testcase classname="server/__tests__/logging.test.ts" name="Search Logging &gt; should log search request and category parsing in TorznabClient" time="0.017237137">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/magnet_detection.test.ts" timestamp="2026-06-10T11:57:56.136Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="1.5284535">
+        <testcase classname="server/__tests__/magnet_detection.test.ts" name="Magnet Detection and Redirect Handling in QBittorrentClient &gt; should apply fixNzbUrlEncoding to convert + to %2B in the link parameter before fetching" time="0.514013487">
+        </testcase>
+        <testcase classname="server/__tests__/magnet_detection.test.ts" name="Magnet Detection and Redirect Handling in QBittorrentClient &gt; should detect magnet link redirects and handle them" time="0.505684204">
+        </testcase>
+        <testcase classname="server/__tests__/magnet_detection.test.ts" name="Magnet Detection and Redirect Handling in QBittorrentClient &gt; should handle relative redirect URLs" time="0.504096972">
+        </testcase>
+        <testcase classname="server/__tests__/magnet_detection.test.ts" name="Magnet Detection and Redirect Handling in QBittorrentClient &gt; should fail gracefully after max redirects" time="0.001595696">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/middleware.test.ts" timestamp="2026-06-10T11:57:56.139Z" hostname="devbox" tests="31" failures="0" errors="0" skipped="0" time="0.074856847">
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeSearchQuery &gt; should allow valid search query" time="0.00997912">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeSearchQuery &gt; should reject search query that is too long" time="0.005761759">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeSearchQuery &gt; should trim and sanitize search query" time="0.001509424">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeGameId &gt; should allow valid UUID" time="0.000893182">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeGameId &gt; should reject invalid UUID" time="0.001085295">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIgdbId &gt; should allow valid IGDB ID" time="0.000955092">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIgdbId &gt; should reject negative IGDB ID" time="0.000820948">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIgdbId &gt; should reject non-numeric IGDB ID" time="0.001350931">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeGameStatus &gt; should allow valid game status" time="0.002193568">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeGameStatus &gt; should reject invalid game status" time="0.000638257">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeGameData &gt; should allow valid game data" time="0.007154697">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeGameData &gt; should reject game with missing title" time="0.002086547">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeGameData &gt; should reject game with invalid rating" time="0.00201187">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeGameData &gt; should reject game with invalid URL" time="0.00260857">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeGameData &gt; should reject game with invalid date format" time="0.001829968">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIndexerData &gt; should allow valid indexer data" time="0.001887353">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIndexerData &gt; should reject indexer with invalid URL" time="0.001178592">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIndexerData &gt; should trim url, name, and apiKey fields" time="0.00124329">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeDownloaderData &gt; should allow valid downloader data" time="0.002013502">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeDownloaderData &gt; should reject downloader with invalid type" time="0.001519944">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeDownloaderData &gt; should trim url, username, password, and urlPath fields" time="0.002626387">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeDownloaderDownloadData &gt; should allow valid download data" time="0.001768326">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeDownloaderDownloadData &gt; should reject download with invalid URL" time="0.00140723">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeDownloaderDownloadData &gt; should reject download with invalid priority" time="0.001252953">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIndexerSearchQuery &gt; should allow valid search query" time="0.001080018">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIndexerSearchQuery &gt; should reject search query that is too long" time="0.001376225">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIndexerSearchQuery &gt; should reject limit greater than 100" time="0.001203465">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIndexerSearchQuery &gt; should reject limit less than 1" time="0.001004654">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIndexerSearchQuery &gt; should reject negative offset" time="0.001062109">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIndexerSearchQuery &gt; should allow valid limit and offset" time="0.008310423">
+        </testcase>
+        <testcase classname="server/__tests__/middleware.test.ts" name="Middleware - Input Sanitization &gt; sanitizeIndexerSearchQuery &gt; should convert limit and offset to integers" time="0.001177661">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/migrate.test.ts" timestamp="2026-06-10T11:57:56.153Z" hostname="devbox" tests="5" failures="0" errors="0" skipped="0" time="0.091307495">
+        <testcase classname="server/__tests__/migrate.test.ts" name="repairSchemaForV1_3_0 (via ensureDatabase) &gt; adds missing columns to drifted tables" time="0.067126696">
+        </testcase>
+        <testcase classname="server/__tests__/migrate.test.ts" name="repairSchemaForV1_3_0 (via ensureDatabase) &gt; creates the release_blacklist table and unique index when missing" time="0.005235007">
+        </testcase>
+        <testcase classname="server/__tests__/migrate.test.ts" name="repairSchemaForV1_3_0 (via ensureDatabase) &gt; de-duplicates existing release_blacklist rows before creating the unique index" time="0.006522007">
+        </testcase>
+        <testcase classname="server/__tests__/migrate.test.ts" name="repairSchemaForV1_3_0 (via ensureDatabase) &gt; keeps the oldest duplicate row when de-duplicating (lowest rowid)" time="0.004640521">
+        </testcase>
+        <testcase classname="server/__tests__/migrate.test.ts" name="repairSchemaForV1_3_0 (via ensureDatabase) &gt; is idempotent — running ensureDatabase twice does not throw" time="0.004831112">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/newznab.test.ts" timestamp="2026-06-10T11:57:56.156Z" hostname="devbox" tests="10" failures="0" errors="0" skipped="0" time="0.044188997">
+        <testcase classname="server/__tests__/newznab.test.ts" name="NewznabClient &gt; search &gt; should reject unsafe URLs" time="0.013256298">
+        </testcase>
+        <testcase classname="server/__tests__/newznab.test.ts" name="NewznabClient &gt; search &gt; should search successfully and parse results" time="0.009866598">
+        </testcase>
+        <testcase classname="server/__tests__/newznab.test.ts" name="NewznabClient &gt; search &gt; should filter results by category correctly" time="0.005297542">
+        </testcase>
+        <testcase classname="server/__tests__/newznab.test.ts" name="NewznabClient &gt; search &gt; should handle error response" time="0.002391296">
+        </testcase>
+        <testcase classname="server/__tests__/newznab.test.ts" name="NewznabClient &gt; getCategories &gt; should get categories successfully" time="0.003028389">
+        </testcase>
+        <testcase classname="server/__tests__/newznab.test.ts" name="NewznabClient &gt; testConnection &gt; should return success for valid connection" time="0.00116465">
+        </testcase>
+        <testcase classname="server/__tests__/newznab.test.ts" name="NewznabClient &gt; testConnection &gt; should handle failed HTTP response" time="0.000513415">
+        </testcase>
+        <testcase classname="server/__tests__/newznab.test.ts" name="NewznabClient &gt; testConnection &gt; should handle error XML response" time="0.000688143">
+        </testcase>
+        <testcase classname="server/__tests__/newznab.test.ts" name="NewznabClient &gt; searchMultipleIndexers &gt; should combine results" time="0.002745814">
+        </testcase>
+        <testcase classname="server/__tests__/newznab.test.ts" name="NewznabClient &gt; searchMultipleIndexers &gt; should handle errors from one indexer gracefully" time="0.002085161">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/nexusmods-routes.test.ts" timestamp="2026-06-10T11:57:56.160Z" hostname="devbox" tests="12" failures="0" errors="0" skipped="0" time="0.180465297">
+        <testcase classname="server/__tests__/nexusmods-routes.test.ts" name="NexusMods Routes &gt; GET /api/settings/nexusmods &gt; returns configured: false when API key is not set" time="0.079026952">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods-routes.test.ts" name="NexusMods Routes &gt; GET /api/settings/nexusmods &gt; returns configured: true and source: database when DB key is set" time="0.009318921">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods-routes.test.ts" name="NexusMods Routes &gt; POST /api/settings/nexusmods &gt; saves API key and returns success" time="0.01878303">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods-routes.test.ts" name="NexusMods Routes &gt; POST /api/settings/nexusmods &gt; returns 400 when API key is empty" time="0.01024933">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods-routes.test.ts" name="NexusMods Routes &gt; POST /api/settings/nexusmods &gt; returns 400 when API key is missing" time="0.006355377">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods-routes.test.ts" name="NexusMods Routes &gt; GET /api/nexusmods/game-domain &gt; returns configured: false when not configured" time="0.014448138">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods-routes.test.ts" name="NexusMods Routes &gt; GET /api/nexusmods/game-domain &gt; returns domain when configured and game found" time="0.006061062">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods-routes.test.ts" name="NexusMods Routes &gt; GET /api/nexusmods/game-domain &gt; returns domain: null when configured but game not found" time="0.005581977">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods-routes.test.ts" name="NexusMods Routes &gt; GET /api/nexusmods/game-domain &gt; returns 400 when title param is missing" time="0.008766964">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods-routes.test.ts" name="NexusMods Routes &gt; GET /api/nexusmods/trending-mods &gt; returns trending mods for a valid domain" time="0.006775929">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods-routes.test.ts" name="NexusMods Routes &gt; GET /api/nexusmods/trending-mods &gt; returns 400 when domain param is missing" time="0.005252959">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods-routes.test.ts" name="NexusMods Routes &gt; GET /api/nexusmods/trending-mods &gt; respects limit query param" time="0.006551356">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/nexusmods.test.ts" timestamp="2026-06-10T11:57:56.167Z" hostname="devbox" tests="18" failures="0" errors="0" skipped="0" time="0.029991509">
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; isConfigured() returns false when no key is set" time="0.006672232">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; isConfigured() returns true after configure() is called with a key" time="0.00089127">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; isConfigured() returns false when empty string is passed" time="0.000872754">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; getGames() &gt; returns empty array when not configured" time="0.002246193">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; getGames() &gt; fetches and returns games when configured" time="0.002456014">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; getGames() &gt; uses cache on second call — only one fetch" time="0.001083781">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; getGames() &gt; returns empty array on fetch failure" time="0.000877675">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; findGameDomain() &gt; returns null when not configured" time="0.001097139">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; findGameDomain() &gt; matches exact normalized title" time="0.001559639">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; findGameDomain() &gt; matches by substring (partial title)" time="0.001074927">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; findGameDomain() &gt; returns null when no match found" time="0.000891153">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; findGameDomain() &gt; does not match short game names that appear as substrings inside unrelated words" time="0.001068786">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; getTrendingMods() &gt; returns empty array when not configured" time="0.00096755">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; getTrendingMods() &gt; fetches trending mods and returns them" time="0.000968652">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; getTrendingMods() &gt; respects the limit parameter" time="0.001077863">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; getTrendingMods() &gt; uses cache on second call for same domain" time="0.000888718">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; getTrendingMods() &gt; returns empty array on fetch failure" time="0.000821394">
+        </testcase>
+        <testcase classname="server/__tests__/nexusmods.test.ts" name="NexusModsClient &gt; rate limit tracking &gt; logs warning when hourly remaining is low" time="0.001035865">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/path_traversal.test.ts" timestamp="2026-06-10T11:57:56.179Z" hostname="devbox" tests="3" failures="0" errors="0" skipped="0" time="0.085481034">
+        <testcase classname="server/__tests__/path_traversal.test.ts" name="Path Traversal Vulnerability in Routes &gt; should block path traversal in /api/system/filesystem" time="0.058429895">
+        </testcase>
+        <testcase classname="server/__tests__/path_traversal.test.ts" name="Path Traversal Vulnerability in Routes &gt; should block path traversal in /api/settings/ssl for certPath" time="0.017678273">
+        </testcase>
+        <testcase classname="server/__tests__/path_traversal.test.ts" name="Path Traversal Vulnerability in Routes &gt; should block path traversal in /api/settings/ssl for keyPath" time="0.00619934">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/pcgamingwiki_routes.test.ts" timestamp="2026-06-10T11:57:56.182Z" hostname="devbox" tests="9" failures="0" errors="0" skipped="0" time="0.075068404">
+        <testcase classname="server/__tests__/pcgamingwiki_routes.test.ts" name="GET /api/external/pcgamingwiki &gt; returns direct wiki URL when page is found" time="0.042763728">
+        </testcase>
+        <testcase classname="server/__tests__/pcgamingwiki_routes.test.ts" name="GET /api/external/pcgamingwiki &gt; returns null url when cargoquery is empty" time="0.005289095">
+        </testcase>
+        <testcase classname="server/__tests__/pcgamingwiki_routes.test.ts" name="GET /api/external/pcgamingwiki &gt; returns 400 when steamAppId is missing" time="0.003811786">
+        </testcase>
+        <testcase classname="server/__tests__/pcgamingwiki_routes.test.ts" name="GET /api/external/pcgamingwiki &gt; returns 400 when steamAppId is not a positive integer" time="0.009058168">
+        </testcase>
+        <testcase classname="server/__tests__/pcgamingwiki_routes.test.ts" name="GET /api/external/pcgamingwiki &gt; returns null url gracefully when safeFetch throws" time="0.003518775">
+        </testcase>
+        <testcase classname="server/__tests__/pcgamingwiki_routes.test.ts" name="GET /api/external/pcgamingwiki &gt; uses cache on second request — safeFetch called only once" time="0.005452445">
+        </testcase>
+        <testcase classname="server/__tests__/pcgamingwiki_routes.test.ts" name="lookupPcgwUrl (unit) &gt; encodes page names with spaces using underscores" time="0.000552015">
+        </testcase>
+        <testcase classname="server/__tests__/pcgamingwiki_routes.test.ts" name="lookupPcgwUrl (unit) &gt; caches failures with a short TTL so transient errors are retried sooner" time="0.000689534">
+        </testcase>
+        <testcase classname="server/__tests__/pcgamingwiki_routes.test.ts" name="lookupPcgwUrl (unit) &gt; caches successful results with the full 24-hour TTL" time="0.000616097">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/prowlarr.test.ts" timestamp="2026-06-10T11:57:56.188Z" hostname="devbox" tests="3" failures="0" errors="0" skipped="0" time="0.035908475">
+        <testcase classname="server/__tests__/prowlarr.test.ts" name="ProwlarrClient &gt; should fetch and map indexers correctly" time="0.022681412">
+        </testcase>
+        <testcase classname="server/__tests__/prowlarr.test.ts" name="ProwlarrClient &gt; should handle Prowlarr API errors" time="0.003615007">
+        </testcase>
+        <testcase classname="server/__tests__/prowlarr.test.ts" name="ProwlarrClient &gt; should normalize Prowlarr URL" time="0.000821228">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/qbittorrent_features.test.ts" timestamp="2026-06-10T11:57:56.190Z" hostname="devbox" tests="9" failures="0" errors="0" skipped="0" time="0.053103648">
+        <testcase classname="server/__tests__/qbittorrent_features.test.ts" name="QBittorrentClient - Advanced Features &gt; should handle adding download from http URL (non-magnet) and resolve hash" time="0.025712484">
+        </testcase>
+        <testcase classname="server/__tests__/qbittorrent_features.test.ts" name="QBittorrentClient - Advanced Features &gt; should support force-started mode via settings" time="0.006603755">
+        </testcase>
+        <testcase classname="server/__tests__/qbittorrent_features.test.ts" name="QBittorrentClient - Advanced Features &gt; should support stopped (paused) mode via settings" time="0.001842151">
+        </testcase>
+        <testcase classname="server/__tests__/qbittorrent_features.test.ts" name="QBittorrentClient - Advanced Features &gt; should return free space using app/free_space when supported" time="0.001908276">
+        </testcase>
+        <testcase classname="server/__tests__/qbittorrent_features.test.ts" name="QBittorrentClient - Advanced Features &gt; should fall back when app/free_space returns null free_space_on_disk" time="0.002090138">
+        </testcase>
+        <testcase classname="server/__tests__/qbittorrent_features.test.ts" name="QBittorrentClient - Advanced Features &gt; should fall back when preferences fails but sync/maindata succeeds" time="0.001323854">
+        </testcase>
+        <testcase classname="server/__tests__/qbittorrent_features.test.ts" name="QBittorrentClient - Advanced Features &gt; should fall back to transfer/info when app/free_space and sync/maindata fail" time="0.001677576">
+        </testcase>
+        <testcase classname="server/__tests__/qbittorrent_features.test.ts" name="QBittorrentClient - Advanced Features &gt; should return 0 when all free space endpoints fail" time="0.007361123">
+        </testcase>
+        <testcase classname="server/__tests__/qbittorrent_features.test.ts" name="QBittorrentClient - Advanced Features &gt; should fall back when sync/maindata is ok but free space is missing/invalid" time="0.001444734">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/routes.test.ts" timestamp="2026-06-10T11:57:56.195Z" hostname="devbox" tests="2" failures="0" errors="0" skipped="0" time="0.01608101">
+        <testcase classname="server/__tests__/routes.test.ts" name="/api/downloads endpoint &gt; should return errors when a downloader fails" time="0.011829007">
+        </testcase>
+        <testcase classname="server/__tests__/routes.test.ts" name="/api/downloads endpoint &gt; should return empty errors array when all downloaders succeed" time="0.001373124">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/rss-routes.test.ts" timestamp="2026-06-10T11:57:56.196Z" hostname="devbox" tests="12" failures="0" errors="0" skipped="0" time="0.351655116">
+        <testcase classname="server/__tests__/rss-routes.test.ts" name="RSS Routes &gt; GET /api/rss/feeds &gt; should return all rss feeds" time="0.068577379">
+        </testcase>
+        <testcase classname="server/__tests__/rss-routes.test.ts" name="RSS Routes &gt; GET /api/rss/feeds &gt; should handle errors" time="0.022604653">
+        </testcase>
+        <testcase classname="server/__tests__/rss-routes.test.ts" name="RSS Routes &gt; POST /api/rss/feeds &gt; should create a new feed and trigger refresh" time="0.057750946">
+        </testcase>
+        <testcase classname="server/__tests__/rss-routes.test.ts" name="RSS Routes &gt; POST /api/rss/feeds &gt; should validate input" time="0.019033307">
+        </testcase>
+        <testcase classname="server/__tests__/rss-routes.test.ts" name="RSS Routes &gt; POST /api/rss/feeds &gt; should reject unsafe URLs with 400" time="0.017976357">
+        </testcase>
+        <testcase classname="server/__tests__/rss-routes.test.ts" name="RSS Routes &gt; PUT /api/rss/feeds/:id &gt; should update a feed" time="0.016938733">
+        </testcase>
+        <testcase classname="server/__tests__/rss-routes.test.ts" name="RSS Routes &gt; PUT /api/rss/feeds/:id &gt; should return 404 if feed not found" time="0.024262776">
+        </testcase>
+        <testcase classname="server/__tests__/rss-routes.test.ts" name="RSS Routes &gt; PUT /api/rss/feeds/:id &gt; should reject unsafe URLs with 400" time="0.015504606">
+        </testcase>
+        <testcase classname="server/__tests__/rss-routes.test.ts" name="RSS Routes &gt; PUT /api/rss/feeds/:id &gt; should not call isSafeUrl when URL is not being updated" time="0.016299997">
+        </testcase>
+        <testcase classname="server/__tests__/rss-routes.test.ts" name="RSS Routes &gt; DELETE /api/rss/feeds/:id &gt; should delete a feed" time="0.014784084">
+        </testcase>
+        <testcase classname="server/__tests__/rss-routes.test.ts" name="RSS Routes &gt; DELETE /api/rss/feeds/:id &gt; should return 404 if feed not found" time="0.045806557">
+        </testcase>
+        <testcase classname="server/__tests__/rss-routes.test.ts" name="RSS Routes &gt; POST /api/rss/refresh &gt; should trigger refresh of all feeds" time="0.027728588">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/rss-ssrf.test.ts" timestamp="2026-06-10T11:57:56.202Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="0.18481385">
+        <testcase classname="server/__tests__/rss-ssrf.test.ts" name="RSS Routes SSRF &gt; should prevent SSRF by blocking metadata service" time="0.109984135">
+        </testcase>
+        <testcase classname="server/__tests__/rss-ssrf.test.ts" name="RSS Routes SSRF &gt; should allow safe public URLs" time="0.02162522">
+        </testcase>
+        <testcase classname="server/__tests__/rss-ssrf.test.ts" name="RSS Routes SSRF &gt; should prevent SSRF by blocking metadata service on feed update (PUT)" time="0.031024057">
+        </testcase>
+        <testcase classname="server/__tests__/rss-ssrf.test.ts" name="RSS Routes SSRF &gt; should allow safe public URLs on feed update (PUT)" time="0.019220894">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/rss.test.ts" timestamp="2026-06-10T11:57:56.203Z" hostname="devbox" tests="5" failures="0" errors="0" skipped="0" time="0.054934298">
+        <testcase classname="server/__tests__/rss.test.ts" name="RssService &gt; should refresh feeds and store new items" time="0.031711377">
+        </testcase>
+        <testcase classname="server/__tests__/rss.test.ts" name="RssService &gt; should handle parsing errors gracefully" time="0.001618496">
+        </testcase>
+        <testcase classname="server/__tests__/rss.test.ts" name="RssService &gt; should handle SSRF/unsafe URL errors gracefully" time="0.001621298">
+        </testcase>
+        <testcase classname="server/__tests__/rss.test.ts" name="RssService &gt; should respect custom mappings" time="0.002706714">
+        </testcase>
+        <testcase classname="server/__tests__/rss.test.ts" name="RssService &gt; should use cache for IGDB lookups" time="0.014206242">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/rtorrent_features.test.ts" timestamp="2026-06-10T11:57:56.206Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="0.017005254">
+        <testcase classname="server/__tests__/rtorrent_features.test.ts" name="RTorrentClient - magnet link handling &gt; should add a direct magnet link via load.start" time="0.010568768">
+        </testcase>
+        <testcase classname="server/__tests__/rtorrent_features.test.ts" name="RTorrentClient - magnet link handling &gt; should detect a magnet redirect and add via load.start" time="0.001923479">
+        </testcase>
+        <testcase classname="server/__tests__/rtorrent_features.test.ts" name="RTorrentClient - magnet link handling &gt; should download a torrent file and add via load.raw_start" time="0.0009321">
+        </testcase>
+        <testcase classname="server/__tests__/rtorrent_features.test.ts" name="RTorrentClient - magnet link handling &gt; should use load.normal (not load.start) when addStopped is true" time="0.00078724">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/search.test.ts" timestamp="2026-06-10T11:57:56.208Z" hostname="devbox" tests="19" failures="0" errors="0" skipped="0" time="0.032138524">
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should return empty results when no indexers are configured" time="0.005099028">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should search torznab indexers and return formatted results" time="0.008215897">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should search newznab indexers and return formatted results" time="0.001068571">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should combine results from both torznab and newznab indexers" time="0.003081378">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should sort results by date (newest first)" time="0.000701011">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should aggregate errors from indexers" time="0.001029704">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should construct comments URL when not provided by indexer" time="0.000724321">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should handle limit and offset parameters" time="0.003726017">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should use default limit of 50 when not specified" time="0.000724096">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should extract release group from title for torznab items" time="0.000659813">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should map downloadVolumeFactor and uploadVolumeFactor from torznab items" time="0.000668995">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should pass through undefined downloadVolumeFactor when not provided by indexer" time="0.000560129">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should map files from newznab items" time="0.000533338">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="Search Module - searchAllIndexers &gt; should pass through undefined files when not provided by newznab indexer" time="0.00052791">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="filterBlacklistedReleases &gt; returns all items when blacklist is empty" time="0.000319786">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="filterBlacklistedReleases &gt; filters out blacklisted titles" time="0.000351025">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="filterBlacklistedReleases &gt; returns empty array when all items are blacklisted" time="0.000327338">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="filterBlacklistedReleases &gt; is case-sensitive (does not filter non-matching case)" time="0.000272631">
+        </testcase>
+        <testcase classname="server/__tests__/search.test.ts" name="filterBlacklistedReleases &gt; returns original array reference when blacklist is empty (fast path)" time="0.000206802">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/search_utils.test.ts" timestamp="2026-06-10T11:57:56.215Z" hostname="devbox" tests="6" failures="0" errors="0" skipped="0" time="0.008426967">
+        <testcase classname="server/__tests__/search_utils.test.ts" name="parseCategories &gt; should return undefined for null/undefined input" time="0.003095463">
+        </testcase>
+        <testcase classname="server/__tests__/search_utils.test.ts" name="parseCategories &gt; should parse single string" time="0.001302556">
+        </testcase>
+        <testcase classname="server/__tests__/search_utils.test.ts" name="parseCategories &gt; should parse comma-separated string" time="0.000336977">
+        </testcase>
+        <testcase classname="server/__tests__/search_utils.test.ts" name="parseCategories &gt; should parse array of strings" time="0.000309286">
+        </testcase>
+        <testcase classname="server/__tests__/search_utils.test.ts" name="parseCategories &gt; should handle mixed array inputs (if express parser produces them)" time="0.000235494">
+        </testcase>
+        <testcase classname="server/__tests__/search_utils.test.ts" name="parseCategories &gt; should filter empty strings" time="0.000410759">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/security.test.ts" timestamp="2026-06-10T11:57:56.218Z" hostname="devbox" tests="6" failures="0" errors="0" skipped="0" time="0.086380192">
+        <testcase classname="server/__tests__/security.test.ts" name="Security Headers &gt; should set permissive CSP in development (non-production)" time="0.045561782">
+        </testcase>
+        <testcase classname="server/__tests__/security.test.ts" name="Security Headers &gt; should set strict CSP in production" time="0.006887173">
+        </testcase>
+        <testcase classname="server/__tests__/security.test.ts" name="Security Headers &gt; should set X-Frame-Options header" time="0.004885948">
+        </testcase>
+        <testcase classname="server/__tests__/security.test.ts" name="Security Headers &gt; should set X-Content-Type-Options header" time="0.004878142">
+        </testcase>
+        <testcase classname="server/__tests__/security.test.ts" name="Credential Exposure Prevention &gt; should not expose IGDB clientId in the unauthenticated /api/config response" time="0.015632109">
+        </testcase>
+        <testcase classname="server/__tests__/security.test.ts" name="Credential Exposure Prevention &gt; should not expose IGDB clientSecret in the unauthenticated /api/config response" time="0.005660542">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/security_error_handling.test.ts" timestamp="2026-06-10T11:57:56.220Z" hostname="devbox" tests="6" failures="0" errors="0" skipped="0" time="0.066750603">
+        <testcase classname="server/__tests__/security_error_handling.test.ts" name="Security Error Handling &gt; should sanitize 500 errors in production" time="0.044664333">
+        </testcase>
+        <testcase classname="server/__tests__/security_error_handling.test.ts" name="Security Error Handling &gt; should show details in development" time="0.004957002">
+        </testcase>
+        <testcase classname="server/__tests__/security_error_handling.test.ts" name="Security Error Handling &gt; should pass through client errors (4xx) unchanged" time="0.00375539">
+        </testcase>
+        <testcase classname="server/__tests__/security_error_handling.test.ts" name="Security Error Handling &gt; should handle errors explicitly thrown without status" time="0.003270274">
+        </testcase>
+        <testcase classname="server/__tests__/security_error_handling.test.ts" name="Security Error Handling &gt; should include error details when provided" time="0.004566801">
+        </testcase>
+        <testcase classname="server/__tests__/security_error_handling.test.ts" name="Security Error Handling &gt; should delegate when headers are already sent" time="0.002520296">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/ssl.test.ts" timestamp="2026-06-10T11:57:56.223Z" hostname="devbox" tests="5" failures="0" errors="0" skipped="0" time="0.026639436">
+        <testcase classname="server/__tests__/ssl.test.ts" name="SSL Module &gt; generateSelfSignedCert &gt; should generate and save certificate and key files" time="0.014781162">
+            <system-out>
+Mock mkdir called [ [32m&apos;/app/data/ssl&apos;[39m, { recursive: [33mtrue[39m } ]
+
+Generating 2048-bit key-pair...
+Mock writeFile called [ [32m&apos;/app/data/ssl/server.key&apos;[39m, [32m&apos;PEM_KEY&apos;[39m ]
+
+Mock writeFile called [ [32m&apos;/app/data/ssl/server.crt&apos;[39m, [32m&apos;PEM_CERT&apos;[39m ]
+
+            </system-out>
+        </testcase>
+        <testcase classname="server/__tests__/ssl.test.ts" name="SSL Module &gt; validateCertFiles &gt; should return valid: true for valid matching files" time="0.002630399">
+        </testcase>
+        <testcase classname="server/__tests__/ssl.test.ts" name="SSL Module &gt; validateCertFiles &gt; should return valid: false if certificate is expired" time="0.001880703">
+        </testcase>
+        <testcase classname="server/__tests__/ssl.test.ts" name="SSL Module &gt; getCertInfo &gt; should parse certificate info correctly" time="0.002285135">
+        </testcase>
+        <testcase classname="server/__tests__/ssl.test.ts" name="SSL Module &gt; getCertInfo &gt; should detect self-signed certificate" time="0.001708425">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/ssrf.test.ts" timestamp="2026-06-10T11:57:56.225Z" hostname="devbox" tests="18" failures="0" errors="0" skipped="0" time="0.039117593">
+        <testcase classname="server/__tests__/ssrf.test.ts" name="isSafeUrl Security Check &gt; should allow private IPs by default (self-hosted posture)" time="0.012896846">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="isSafeUrl Security Check &gt; should allow private IPs when allowPrivate is true" time="0.0010595">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="isSafeUrl Security Check &gt; should block IPv4 metadata service" time="0.000375185">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="isSafeUrl Security Check &gt; should block IPv6 metadata service" time="0.000308148">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="isSafeUrl Security Check &gt; should block IPv4-mapped IPv6 metadata service" time="0.000494609">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="isSafeUrl Security Check &gt; should handle DNS lookup failure gracefully" time="0.000366837">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="isSafeUrl Security Check &gt; should block hostnames that resolve to both safe and unsafe IPs (DNS Rebinding)" time="0.000435508">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="isSafeUrl Security Check &gt; should block hostnames that resolve to metadata service regardless of allowPrivate" time="0.000340273">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="isSafeUrl Security Check &gt; should reject hostnames that resolve to empty addresses array" time="0.000488882">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="isSafeUrl Security Check &gt; should allow magnet links without DNS validation (no SSRF risk)" time="0.000805771">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="safeFetch &gt; should use original hostname for HTTPS (SSL certificate compatibility)" time="0.008188015">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="safeFetch &gt; should rewrite HTTP URLs to use resolved IP for DNS rebinding protection" time="0.002771224">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="safeFetch &gt; should reject URLs that resolve to metadata service IPs" time="0.004010152">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="safeFetch &gt; should reject URLs that fail DNS resolution" time="0.000814155">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="safeFetch &gt; should allow private IPs by default for HTTPS" time="0.000636471">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="safeFetch &gt; should allow private IPs for HTTPS when allowPrivate is true" time="0.000725602">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="safeFetch &gt; should reject if any resolved IP is unsafe (DNS Rebinding prevention)" time="0.000592706">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf.test.ts" name="safeFetch &gt; should reject URLs that resolve to empty addresses array" time="0.00050014">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/ssrf_routes.test.ts" timestamp="2026-06-10T11:57:56.233Z" hostname="devbox" tests="2" failures="0" errors="0" skipped="0" time="0.09788479">
+        <testcase classname="server/__tests__/ssrf_routes.test.ts" name="SSRF Vulnerability in Routes &gt; should allow unsafe URL in /api/indexers/prowlarr/sync (VULNERABILITY)" time="0.08381267">
+        </testcase>
+        <testcase classname="server/__tests__/ssrf_routes.test.ts" name="SSRF Vulnerability in Routes &gt; should block unsafe URL in /api/indexers/test" time="0.011185416">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/steam_routes.test.ts" timestamp="2026-06-10T11:57:56.234Z" hostname="devbox" tests="8" failures="0" errors="0" skipped="0" time="0.116322745">
+        <testcase classname="server/__tests__/steam_routes.test.ts" name="steamRoutes &gt; PATCH /api/user/steam-id &gt; returns 400 when steamId is missing" time="0.057590237">
+        </testcase>
+        <testcase classname="server/__tests__/steam_routes.test.ts" name="steamRoutes &gt; PATCH /api/user/steam-id &gt; returns 400 when steamId format is invalid" time="0.006495612">
+        </testcase>
+        <testcase classname="server/__tests__/steam_routes.test.ts" name="steamRoutes &gt; PATCH /api/user/steam-id &gt; updates steamId for valid requests" time="0.009344562">
+        </testcase>
+        <testcase classname="server/__tests__/steam_routes.test.ts" name="steamRoutes &gt; PATCH /api/user/steam-id &gt; returns 500 when storage update fails" time="0.00882484">
+        </testcase>
+        <testcase classname="server/__tests__/steam_routes.test.ts" name="steamRoutes &gt; POST /api/steam/wishlist/sync &gt; returns 400 when user has no linked steamId" time="0.004860543">
+        </testcase>
+        <testcase classname="server/__tests__/steam_routes.test.ts" name="steamRoutes &gt; POST /api/steam/wishlist/sync &gt; returns 400 when sync reports failure" time="0.00316291">
+        </testcase>
+        <testcase classname="server/__tests__/steam_routes.test.ts" name="steamRoutes &gt; POST /api/steam/wishlist/sync &gt; returns 200 with successful sync payload" time="0.015907952">
+        </testcase>
+        <testcase classname="server/__tests__/steam_routes.test.ts" name="steamRoutes &gt; POST /api/steam/wishlist/sync &gt; returns 500 when sync throws" time="0.006912145">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/steam_service.test.ts" timestamp="2026-06-10T11:57:56.238Z" hostname="devbox" tests="9" failures="0" errors="0" skipped="0" time="0.022151879">
+        <testcase classname="server/__tests__/steam_service.test.ts" name="steamService &gt; validateSteamId &gt; should return true for valid Steam IDs" time="0.004705882">
+        </testcase>
+        <testcase classname="server/__tests__/steam_service.test.ts" name="steamService &gt; validateSteamId &gt; should return false for invalid Steam IDs" time="0.000585227">
+        </testcase>
+        <testcase classname="server/__tests__/steam_service.test.ts" name="steamService &gt; getWishlist &gt; should throw error for invalid Steam ID" time="0.002738236">
+        </testcase>
+        <testcase classname="server/__tests__/steam_service.test.ts" name="steamService &gt; getWishlist &gt; should fetch wishlist games correctly via IWishlistService" time="0.007218706">
+        </testcase>
+        <testcase classname="server/__tests__/steam_service.test.ts" name="steamService &gt; getWishlist &gt; should map 403 API errors to actionable messages" time="0.000841851">
+        </testcase>
+        <testcase classname="server/__tests__/steam_service.test.ts" name="steamService &gt; getWishlist &gt; should map 404 API errors to actionable messages" time="0.000688572">
+        </testcase>
+        <testcase classname="server/__tests__/steam_service.test.ts" name="steamService &gt; getWishlist &gt; should map 429 API errors to actionable messages" time="0.000714703">
+        </testcase>
+        <testcase classname="server/__tests__/steam_service.test.ts" name="steamService &gt; getWishlist &gt; should handle empty wishlist (no items)" time="0.000563103">
+        </testcase>
+        <testcase classname="server/__tests__/steam_service.test.ts" name="steamService &gt; getWishlist &gt; should handle empty response with items array" time="0.000601263">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/steam_wishlist.test.ts" timestamp="2026-06-10T11:57:56.241Z" hostname="devbox" tests="15" failures="0" errors="0" skipped="0" time="0.025282691">
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should return failure and skip sync when steamSyncFailures &gt;= MAX_STEAM_SYNC_FAILURES" time="0.005199771">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should increment steamSyncFailures and return failure when wishlist fetch throws" time="0.004936286">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should reset steamSyncFailures to 0 on a successful sync after prior failures" time="0.001382099">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should skip IGDB lookup when all wishlist games are already owned by steamAppId" time="0.001229201">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should not overwrite steamAppId when existing game already has one set for that igdbId" time="0.001618045">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should return failure if user has no Steam ID" time="0.000534062">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should fetch wishlist games and add them in batches" time="0.001467707">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should skip Steam App IDs with no matching IGDB ID" time="0.000560013">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should NOT skip a Steam App ID whose IGDB mapping is 0 (falsy but valid)" time="0.000884565">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should link an existing game that has igdbId but no steamAppId" time="0.000759278">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should link multiple existing games via precomputed map and add truly new ones" time="0.000879621">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should avoid adding games already in collection" time="0.000533357">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should return success with addedCount 0 when wishlist is empty" time="0.000529653">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should skip a new game when IGDB returns no details for its igdbId" time="0.000511425">
+        </testcase>
+        <testcase classname="server/__tests__/steam_wishlist.test.ts" name="syncUserSteamWishlist &gt; should add only games for which IGDB returns details when response is partial" time="0.000649967">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/storage.test.ts" timestamp="2026-06-10T11:57:56.246Z" hostname="devbox" tests="35" failures="0" errors="0" skipped="0" time="0.045962061">
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; User Management &gt; should create and retrieve a user" time="0.009053343">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; User Management &gt; should return undefined for non-existent user" time="0.000440908">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Game Management &gt; should add and retrieve games" time="0.000703293">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Game Management &gt; should preserve status when explicitly set to &quot;owned&quot;" time="0.000339258">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Game Management &gt; should update game status" time="0.000768247">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Game Management &gt; should remove a game" time="0.000339323">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Game Management &gt; should filter games by status" time="0.002019579">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Game Management &gt; should return null/false when updating/removing non-existent game" time="0.000448553">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Game Management &gt; should set and update user rating" time="0.000438627">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Game Management &gt; should clear user rating with null" time="0.000336776">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Game Management &gt; should return undefined when updating user rating for non-existent game" time="0.000272967">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Indexer Management &gt; should create, retreive and sync indexers" time="0.000857497">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Downloader Management &gt; should CRUD downloaders" time="0.000942133">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; System Config &gt; should set and get system config" time="0.00028553">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; System Config &gt; should return undefined for missing config" time="0.000206865">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; User Settings Management &gt; should create and update user settings" time="0.000762052">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; User Settings Management &gt; should use default values for new settings" time="0.00032128">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; User Settings Management &gt; should persist and retrieve preferredPlatform" time="0.000448342">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Release Blacklist Management &gt; should add a release to the blacklist" time="0.000602732">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Release Blacklist Management &gt; should return existing entry on duplicate add" time="0.000356137">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Release Blacklist Management &gt; should list blacklist entries for a game" time="0.001113357">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Release Blacklist Management &gt; should return all blacklist entries with game titles for a user" time="0.000674461">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Release Blacklist Management &gt; should not return entries from other users&apos; games" time="0.000374748">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Release Blacklist Management &gt; should remove a blacklist entry and return true" time="0.000625695">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Release Blacklist Management &gt; should return false when removing a non-existent entry" time="0.000273741">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Release Blacklist Management &gt; should return a Set of release titles for a game" time="0.000768685">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Release Blacklist Management &gt; should return an empty Set for a game with no blacklist entries" time="0.000306311">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Release Blacklist Management &gt; should store and return indexerName when provided" time="0.000269635">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; Release Blacklist Management &gt; should sort getAllReleaseBlacklists by gameTitle then newest first" time="0.013768799">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; getDownloadsByGameId &gt; returns empty array when game has no downloads" time="0.000876445">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; getDownloadsByGameId &gt; returns downloads for the given game with downloaderName joined" time="0.000771627">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; getDownloadsByGameId &gt; only returns downloads belonging to the specified game" time="0.000548816">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; getDownloadsByGameId &gt; sets downloaderName to null when downloader no longer exists" time="0.000456023">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; getDownloadsByGameId &gt; getTrackedDownloadKeys &gt; returns an empty set when there are no game downloads" time="0.000346612">
+        </testcase>
+        <testcase classname="server/__tests__/storage.test.ts" name="MemStorage &gt; getDownloadsByGameId &gt; getTrackedDownloadKeys &gt; returns a key for each game download as downloaderId:downloadHash" time="0.000467892">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/syncIndexers.test.ts" timestamp="2026-06-10T11:57:56.258Z" hostname="devbox" tests="3" failures="0" errors="0" skipped="0" time="0.026167395">
+        <testcase classname="server/__tests__/syncIndexers.test.ts" name="DatabaseStorage - syncIndexers &gt; should add new indexers" time="0.020708093">
+        </testcase>
+        <testcase classname="server/__tests__/syncIndexers.test.ts" name="DatabaseStorage - syncIndexers &gt; should update existing indexers" time="0.001399616">
+        </testcase>
+        <testcase classname="server/__tests__/syncIndexers.test.ts" name="DatabaseStorage - syncIndexers &gt; should fail validation for missing fields" time="0.000966436">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/torznab.test.ts" timestamp="2026-06-10T11:57:56.260Z" hostname="devbox" tests="6" failures="0" errors="0" skipped="0" time="0.022613932">
+        <testcase classname="server/__tests__/torznab.test.ts" name="TorznabClient — download link rewriting &gt; leaves the link unchanged when it already points to the indexer host" time="0.012173026">
+        </testcase>
+        <testcase classname="server/__tests__/torznab.test.ts" name="TorznabClient — download link rewriting &gt; applies standard host rewrite for non-Prowlarr indexers returning an internal URL" time="0.001500368">
+        </testcase>
+        <testcase classname="server/__tests__/torznab.test.ts" name="TorznabClient — download link rewriting &gt; builds a Prowlarr proxy URL when a Prowlarr indexer returns a raw external download URL" time="0.001948189">
+        </testcase>
+        <testcase classname="server/__tests__/torznab.test.ts" name="TorznabClient — download link rewriting &gt; uses Prowlarr proxy URL format when Prowlarr indexer has numeric ID in URL path" time="0.00158261">
+        </testcase>
+        <testcase classname="server/__tests__/torznab.test.ts" name="TorznabClient — download link rewriting &gt; leaves Prowlarr proxy URLs unchanged when Prowlarr already returned its own proxy URL" time="0.001285042">
+        </testcase>
+        <testcase classname="server/__tests__/torznab.test.ts" name="TorznabClient — download link rewriting &gt; falls back to standard host rewrite for Prowlarr-style URL path but missing apiKey" time="0.000984437">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/transmission_features.test.ts" timestamp="2026-06-10T11:57:56.262Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="0.016701879">
+        <testcase classname="server/__tests__/transmission_features.test.ts" name="TransmissionClient - Advanced Features &gt; should handle session ID conflict (409) and retry" time="0.008044384">
+        </testcase>
+        <testcase classname="server/__tests__/transmission_features.test.ts" name="TransmissionClient - Advanced Features &gt; should handle authentication failure (401)" time="0.001003949">
+        </testcase>
+        <testcase classname="server/__tests__/transmission_features.test.ts" name="TransmissionClient - Advanced Features &gt; should detect magnet redirect and pass magnet URI to Transmission" time="0.002857055">
+        </testcase>
+        <testcase classname="server/__tests__/transmission_features.test.ts" name="TransmissionClient - Advanced Features &gt; should download file server-side and upload metainfo" time="0.001150046">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/usenet_integration.test.ts" timestamp="2026-06-10T11:57:56.264Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="0.079559348">
+        <testcase classname="server/__tests__/usenet_integration.test.ts" name="Usenet Integration &gt; Aggregated Search &gt; should call both Torznab and Newznab clients and merge results" time="0.006988908">
+        </testcase>
+        <testcase classname="server/__tests__/usenet_integration.test.ts" name="Usenet Integration &gt; DownloaderManager Fallback Filtering &gt; should only attempt Usenet downloaders for usenet type" time="0.050061594">
+        </testcase>
+        <testcase classname="server/__tests__/usenet_integration.test.ts" name="Usenet Integration &gt; DownloaderManager Fallback Filtering &gt; should only attempt downloaders for download type" time="0.012956203">
+        </testcase>
+        <testcase classname="server/__tests__/usenet_integration.test.ts" name="Usenet Integration &gt; Search Item Mapping &gt; should correctly identify Usenet items in search results" time="0.006422766">
+        </testcase>
+    </testsuite>
+    <testsuite name="server/__tests__/xrel.test.ts" timestamp="2026-06-10T11:57:56.265Z" hostname="devbox" tests="11" failures="0" errors="0" skipped="0" time="0.040200473">
+        <testcase classname="server/__tests__/xrel.test.ts" name="xREL Client &gt; searchReleases &gt; should fetch and parse scene releases correctly" time="0.016099228">
+        </testcase>
+        <testcase classname="server/__tests__/xrel.test.ts" name="xREL Client &gt; searchReleases &gt; should fetch and parse p2p releases correctly when requested" time="0.002850979">
+        </testcase>
+        <testcase classname="server/__tests__/xrel.test.ts" name="xREL Client &gt; searchReleases &gt; should handle API errors gracefully" time="0.006755286">
+        </testcase>
+        <testcase classname="server/__tests__/xrel.test.ts" name="xREL Client &gt; searchReleases &gt; should handle rate limiting errors" time="0.001159978">
+        </testcase>
+        <testcase classname="server/__tests__/xrel.test.ts" name="xREL Client &gt; searchReleases &gt; should respect rate limit intervals" time="0.00258379">
+        </testcase>
+        <testcase classname="server/__tests__/xrel.test.ts" name="xREL Client &gt; getLatestReleases &gt; should return latest game releases" time="0.001705404">
+        </testcase>
+        <testcase classname="server/__tests__/xrel.test.ts" name="xREL Client &gt; titleMatches &gt; should match identical titles" time="0.000876109">
+        </testcase>
+        <testcase classname="server/__tests__/xrel.test.ts" name="xREL Client &gt; titleMatches &gt; should match case-insensitive" time="0.000655389">
+        </testcase>
+        <testcase classname="server/__tests__/xrel.test.ts" name="xREL Client &gt; titleMatches &gt; should match loose inclusion" time="0.000911348">
+        </testcase>
+        <testcase classname="server/__tests__/xrel.test.ts" name="xREL Client &gt; titleMatches &gt; should not match unrelated titles" time="0.002329271">
+        </testcase>
+        <testcase classname="server/__tests__/xrel.test.ts" name="xREL Client &gt; titleMatches &gt; should normalize whitespace" time="0.000787791">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/src/__tests__/SetupPage.test.tsx" timestamp="2026-06-10T11:57:56.269Z" hostname="devbox" tests="2" failures="0" errors="0" skipped="0" time="1.018028501">
+        <testcase classname="client/src/__tests__/SetupPage.test.tsx" name="SetupPage &gt; submits form successfully without IGDB fields when IGDB is already configured" time="0.532003207">
+        </testcase>
+        <testcase classname="client/src/__tests__/SetupPage.test.tsx" name="SetupPage &gt; requires IGDB fields when IGDB is NOT configured" time="0.480268945">
+            <system-err>
+Warning: An update to SetupPage inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() =&gt; {
+  /* fire events that update state */
+});
+/* assert on the output */
+
+This ensures that you&apos;re testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
+    at SetupPage (/app/client/src/pages/auth/setup.tsx:40:89)
+    at QueryClientProvider (file:///app/node_modules/@tanstack/react-query/build/modern/QueryClientProvider.js:20:3)
+
+            </system-err>
+        </testcase>
+    </testsuite>
+    <testsuite name="client/src/__tests__/auth-provider.test.tsx" timestamp="2026-06-10T11:57:56.271Z" hostname="devbox" tests="4" failures="0" errors="0" skipped="0" time="1.197395006">
+        <testcase classname="client/src/__tests__/auth-provider.test.tsx" name="AuthProvider /api/auth/me handling &gt; clears stored token on 401 responses" time="0.100869646">
+        </testcase>
+        <testcase classname="client/src/__tests__/auth-provider.test.tsx" name="AuthProvider /api/auth/me handling &gt; clears stored token on 403 responses" time="0.059926469">
+        </testcase>
+        <testcase classname="client/src/__tests__/auth-provider.test.tsx" name="AuthProvider /api/auth/me handling &gt; does not clear token and throws error on 500 server responses" time="0.006164944">
+        </testcase>
+        <testcase classname="client/src/__tests__/auth-provider.test.tsx" name="AuthProvider /api/auth/me handling &gt; keeps stored token and retries on transient failures" time="1.024819711">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/src/lib/__tests__/queryClient.test.ts" timestamp="2026-06-10T11:57:56.272Z" hostname="devbox" tests="11" failures="0" errors="0" skipped="0" time="0.030293018">
+        <testcase classname="client/src/lib/__tests__/queryClient.test.ts" name="queryClient utilities &gt; creates ApiError instances with status and payload" time="0.005624967">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/queryClient.test.ts" name="queryClient utilities &gt; apiRequest sends JSON body and authorization when token is present" time="0.006618254">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/queryClient.test.ts" name="queryClient utilities &gt; apiRequest surfaces API message from JSON error payload" time="0.005138507">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/queryClient.test.ts" name="queryClient utilities &gt; apiRequest falls back to plain text payload when error body is not JSON" time="0.00107519">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/queryClient.test.ts" name="queryClient utilities &gt; apiRequest uses JSON message field when error is provided that way" time="0.000971237">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/queryClient.test.ts" name="queryClient utilities &gt; apiRequest falls back to numeric status when no message source is available" time="0.0007039">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/queryClient.test.ts" name="queryClient utilities &gt; getQueryFn returns null on 401 when configured to returnNull" time="0.000842807">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/queryClient.test.ts" name="queryClient utilities &gt; getQueryFn throws on 401 when configured to throw" time="0.000743633">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/queryClient.test.ts" name="queryClient utilities &gt; getQueryFn joins query keys and includes auth header" time="0.001191376">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/queryClient.test.ts" name="queryClient utilities &gt; queryClient default options disable retries and refetching" time="0.000570809">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/queryClient.test.ts" name="queryClient utilities &gt; clearSearchCache removes only /api/search query entries" time="0.003380923">
+        </testcase>
+    </testsuite>
+    <testsuite name="client/src/lib/__tests__/stats.test.ts" timestamp="2026-06-10T11:57:56.276Z" hostname="devbox" tests="5" failures="0" errors="0" skipped="0" time="0.021325412">
+        <testcase classname="client/src/lib/__tests__/stats.test.ts" name="calculateLibraryStats &gt; calculates stats correctly for a mixed library" time="0.017123698">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/stats.test.ts" name="calculateLibraryStats &gt; handles empty library" time="0.000468721">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/stats.test.ts" name="calculateLibraryStats &gt; handles games with missing optional fields" time="0.000361153">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/stats.test.ts" name="calculateLibraryStats &gt; calculates metadata health correctly" time="0.000316796">
+        </testcase>
+        <testcase classname="client/src/lib/__tests__/stats.test.ts" name="calculateLibraryStats &gt; handles invalid release dates in avgReleaseYear" time="0.000276643">
+        </testcase>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
### 💡 What

Added an `aria-label` to the "More Options" (`<MoreHorizontal />`) icon-only button in the downloads page row (`client/src/pages/downloads.tsx`).

### 🎯 Why

Icon-only buttons must have an explicit accessible name for screen reader users to understand their purpose. Without an `aria-label`, assistive technologies would likely just read out "button" without providing context on what the button does.

### ♿ Accessibility

The button now clearly announces "Options for [Game Title]" or "Options for download" if the title is missing, significantly improving the experience for visually impaired users relying on screen readers.

---

*PR created automatically by Jules for task [4936385872271287968](https://jules.google.com/task/4936385872271287968) started by @Doezer*