### PR TITLE
⚡ Bolt: optimize AddGameModal collection status lookups

### DIFF
--- a/client/src/components/AddGameModal.tsx
+++ b/client/src/components/AddGameModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query";
 import {
   Dialog,
@@ -133,11 +133,21 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
     addGameMutation.mutate(gameData);
   };
 
+  const userGameIgdbIds = useMemo(() => {
+    const ids = new Set<number>();
+    for (const g of userGames) {
+      if (g.igdbId != null) ids.add(g.igdbId);
+    }
+    return ids;
+  }, [userGames]);
+
   // Mark games already in collection
-  const resultsWithCollectionStatus: SearchResult[] = searchResults.map((game: Game) => ({
-    ...game,
-    inCollection: userGames.some((userGame) => userGame.igdbId === game.igdbId),
-  }));
+  const resultsWithCollectionStatus: SearchResult[] = useMemo(() => {
+    return searchResults.map((game: Game) => ({
+      ...game,
+      inCollection: game.igdbId != null ? userGameIgdbIds.has(game.igdbId) : false,
+    }));
+  }, [searchResults, userGameIgdbIds]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
**💡 What:**
Modified `AddGameModal` to use a `Set` for `userGames` ID lookups and wrapped the `resultsWithCollectionStatus` calculation in a `useMemo` hook.

**🎯 Why:**
Previously, for every render cycle of `AddGameModal` while searching, the component executed an $O(N \times M)$ nested loop operation by calling `userGames.some(...)` inside `searchResults.map(...)`. As the user's library (`userGames`) grows, this implicit array traversal caused unnecessary CPU overhead, especially since React state updates during typing or debouncing trigger frequent re-renders.

**📊 Impact:**
Reduces the time complexity of the collection status check from $O(N \times M)$ to $O(N + M)$ by converting the library IDs to a `Set` for $O(1)$ lookups. The use of `useMemo` also prevents this calculation from running entirely unless `searchResults` or `userGames` actually changes, preventing unnecessary work during extraneous renders.

**🔬 Measurement:**
Run the frontend test suite. Behavior is identical, but the CPU time spent in the component render loop is significantly reduced, yielding a snappier search experience for users with large libraries.

---

*PR created automatically by Jules for task [9751160314203721095](https://jules.google.com/task/9751160314203721095) started by @Doezer*