### PR TITLE
chore: upgrade codecov/codecov-action from v5 to v7.0.0 [backport release/1.4.0]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
-          context: ..
+          context: .
           push: false
           tags: questarr:test
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           echo "Build successful - dist directory created"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
@@ -94,7 +94,7 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
-          context: .
+          context: ..
           push: false
           tags: questarr:test
           cache-from: type=gha


### PR DESCRIPTION
Backport of #682 for `release/1.4.0`.

## Summary

- Upgrades both `codecov/codecov-action` steps (coverage upload + test results) from `v5` (`e79a6962`) to `v7.0.0` (`fb8b3582`)
- Fixes CI failure caused by Codecov migrating their CLI signing key — older versions can no longer verify the GPG signature of the Codecov CLI binary

## Root cause

Codecov intentionally disabled their old Keybase signing account and migrated to a new key. Any `codecov-action` before v6.0.2 / v7.0.0 targets the old key and fails signature verification. See: https://github.com/Expensify/App/issues/92883

## Test plan

- [ ] CI passes on `release/1.4.0` with the new action version
- [ ] Coverage report uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyKjQ9np6qATBUudg81BDo

---

_Generated by [Claude Code](https://claude.ai/code/session_01JyKjQ9np6qATBUudg81BDo)_