### PR TITLE
fix: correct Docker port mapping and improve SQLite/permission error handling

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -106,7 +106,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@ services:
   app:
     image: ghcr.io/doezer/questarr:latest
     ports:
-      - "${PORT:-5000}:${PORT:-5000}"
+      - "${HOST_SIDE_PORT:-5000}:${CONTAINER_INTERNAL_SIDE_PORT:-5000}"
       - "${SSL_PORT:-9898}:${SSL_PORT:-9898}"
     environment:
-      - PORT=${PORT:-5000}
+      - PORT=${CONTAINER_INTERNAL_SIDE_PORT:-5000}
       # - SQLITE_DB_PATH=/app/data/sqlite.db  # Default path for sqlite db, uncomment and change if needed
     volumes:
       # Persist SQLite database and other data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,11 @@ services:
   app:
     image: ghcr.io/doezer/questarr:latest
     ports:
-      - "${PORT:-5000}:5000"
+      - "${PORT:-5000}:${PORT:-5000}"
       - "${SSL_PORT:-9898}:${SSL_PORT:-9898}"
-    # environment:
-    #   - SQLITE_DB_PATH=/app/data/sqlite.db  # Default path for sqlite db, uncomment and change if needed
+    environment:
+      - PORT=${PORT:-5000}
+      # - SQLITE_DB_PATH=/app/data/sqlite.db  # Default path for sqlite db, uncomment and change if needed
     volumes:
       # Persist SQLite database and other data
       - ./data:/app/data
@@ -16,7 +17,7 @@ services:
           "CMD",
           "node",
           "-e",
-          "require('http').get('http://localhost:5000/api/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))",
+          "require('http').get('http://localhost:' + (process.env.PORT || 5000) + '/api/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1))",
         ]
       interval: 30s
       timeout: 10s

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,5 +53,15 @@ if find /app/data \( ! -uid "$QUESTARR_UID" -o ! -gid "$QUESTARR_GID" \) -print 
   chown -R questarr:questarr /app/data
 fi
 
+# Verify the questarr user can actually write to /app/data before dropping privileges.
+# If this fails, the DB would crash at startup with an unhelpful SQLite error.
+if ! su-exec questarr sh -c "test -w /app/data" 2>/dev/null; then
+  echo "ERROR: questarr (UID ${QUESTARR_UID}) cannot write to /app/data."
+  echo "  The chown above may have failed due to filesystem restrictions (e.g. rootless Docker, NFS)."
+  echo "  Fix on the host: sudo chown -R ${QUESTARR_UID}:${QUESTARR_GID} ./data"
+  echo "  Or match the data directory's owner by setting PUID/PGID in your compose environment."
+  exit 1
+fi
+
 # Drop root privileges and exec the CMD as questarr
 exec su-exec questarr "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,5 +63,14 @@ if ! su-exec questarr sh -c "test -w /app/data" 2>/dev/null; then
   exit 1
 fi
 
+# If the database file already exists, verify it is writable too.
+# A recursive chown on the directory won't help if the file itself has a mode like 400.
+_DB_FILE="${SQLITE_DB_PATH:-/app/data/sqlite.db}"
+if [ -f "$_DB_FILE" ] && ! su-exec questarr sh -c "test -w \"$_DB_FILE\"" 2>/dev/null; then
+  echo "ERROR: questarr (UID ${QUESTARR_UID}) cannot write to existing database file ${_DB_FILE}."
+  echo "  Fix on the host: sudo chown ${QUESTARR_UID}:${QUESTARR_GID} \"${_DB_FILE}\""
+  exit 1
+fi
+
 # Drop root privileges and exec the CMD as questarr
 exec su-exec questarr "$@"

--- a/server/__tests__/db-error.test.ts
+++ b/server/__tests__/db-error.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Isolated test for the db.ts open-failure error path.
+// Kept in a separate file so module-cache resets don't interfere with other suites
+// that import db.js through the app's module graph.
+describe("Database - open failure error handling", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("logs UID, GID and calls process.exit(1) when the database cannot be opened", async () => {
+    // Use a path whose parent (/tmp) already exists so no mkdir is attempted,
+    // but the file itself won't exist so no file-stat branch runs either.
+    process.env.SQLITE_DB_PATH = "/tmp/db-open-failure-questarr-test.db";
+
+    const mockError = vi.fn();
+    vi.doMock("../logger.js", () => ({
+      logger: { info: vi.fn(), warn: vi.fn(), error: mockError },
+    }));
+
+    vi.doMock("better-sqlite3", () => ({
+      default: vi.fn().mockImplementation(() => {
+        throw new Error("SQLITE_CANTOPEN: unable to open database file");
+      }),
+    }));
+
+    // Intercept process.exit so the test process doesn't actually terminate.
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+
+    // The module rejects because our process.exit mock throws.
+    await expect(import("../db.js")).rejects.toThrow("process.exit called");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockError).toHaveBeenCalledWith(
+      expect.objectContaining({ dbPath: "/tmp/db-open-failure-questarr-test.db" }),
+      expect.stringContaining("Cannot open SQLite database")
+    );
+  });
+});

--- a/server/__tests__/db-error.test.ts
+++ b/server/__tests__/db-error.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import os from "os";
+import path from "path";
 
 // Isolated test for the db.ts open-failure error path.
 // Kept in a separate file so module-cache resets don't interfere with other suites
@@ -18,9 +20,10 @@ describe("Database - open failure error handling", () => {
   });
 
   it("logs UID, GID and calls process.exit(1) when the database cannot be opened", async () => {
-    // Use a path whose parent (/tmp) already exists so no mkdir is attempted,
+    // Use os.tmpdir() so the parent directory exists (no mkdir attempted),
     // but the file itself won't exist so no file-stat branch runs either.
-    process.env.SQLITE_DB_PATH = "/tmp/db-open-failure-questarr-test.db";
+    const testDbPath = path.join(os.tmpdir(), "db-open-failure-questarr-test.db");
+    process.env.SQLITE_DB_PATH = testDbPath;
 
     const mockError = vi.fn();
     vi.doMock("../logger.js", () => ({
@@ -43,7 +46,7 @@ describe("Database - open failure error handling", () => {
 
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(mockError).toHaveBeenCalledWith(
-      expect.objectContaining({ dbPath: "/tmp/db-open-failure-questarr-test.db" }),
+      expect.objectContaining({ dbPath: testDbPath }),
       expect.stringContaining("Cannot open SQLite database")
     );
   });

--- a/server/db.ts
+++ b/server/db.ts
@@ -37,11 +37,12 @@ try {
   sqlite = new Database(dbPath);
 } catch (err) {
   const uid = process.getuid?.() ?? "unknown";
+  const gid = process.getgid?.() ?? "unknown";
   logger.error(
-    { err, dbPath, uid },
+    { err, dbPath, uid, gid },
     `Cannot open SQLite database at ${dbPath}. ` +
-      `Process is running as UID ${uid}. ` +
-      `Ensure the directory ${dbDir} exists and is writable by that UID. ` +
+      `Process is running as UID ${uid} GID ${gid}. ` +
+      `Ensure the directory ${path.dirname(dbPath)} exists and is writable. ` +
       `In Docker: set PUID/PGID in your compose environment to match the host volume owner, ` +
       `or run: sudo chown -R <UID>:<GID> ./data on the host.`
   );

--- a/server/db.ts
+++ b/server/db.ts
@@ -32,7 +32,21 @@ try {
 logger.info(`Initializing SQLite database at: ${dbPath}`);
 
 // Initialize the database connection
-const sqlite = new Database(dbPath);
+let sqlite: Database.Database;
+try {
+  sqlite = new Database(dbPath);
+} catch (err) {
+  const uid = process.getuid?.() ?? "unknown";
+  logger.error(
+    { err, dbPath, uid },
+    `Cannot open SQLite database at ${dbPath}. ` +
+      `Process is running as UID ${uid}. ` +
+      `Ensure the directory ${dbDir} exists and is writable by that UID. ` +
+      `In Docker: set PUID/PGID in your compose environment to match the host volume owner, ` +
+      `or run: sudo chown -R <UID>:<GID> ./data on the host.`
+  );
+  process.exit(1);
+}
 
 // Apply pragmas for performance and compatibility
 sqlite.pragma("journal_mode = WAL");


### PR DESCRIPTION
## Problem

Users deploying via Docker Compose and changing the port (e.g. to 5001) get `ERR_CONNECTION_REFUSED` from their browser. Two separate bugs combine to cause this.

## Root Causes

### 1. Port mapping only controlled the host side

`docker-compose.yml` had:

```yaml
ports:
  - "${PORT:-5000}:5000"
```

The right-hand side (container port) was hardcoded to `5000`. Docker Compose variable substitution in `ports:` reads from the **host** `.env` file or shell — NOT from the container `environment:` section. So if a user added `PORT: 5001` under `environment:`, the app inside listened on 5001 but Docker kept mapping host→container on port 5000. Nothing reached the app.

### 2. SQLite CANTOPEN crash → nothing listens on any port

When the `./data` volume mount has wrong ownership (e.g. created as `root:root` by Docker before the user sets it up), the `questarr` user (UID 1000) can't write the SQLite file. `new Database()` in `db.ts` was outside any try/catch, so the process crashed with a raw SQLite stack trace. With the server down, even a correctly-mapped port gets `ERR_CONNECTION_REFUSED`.

The `docker exec <container> id` showing `root` is a red herring — `docker exec` spawns a new shell as root (no `USER` instruction in the Dockerfile). The actual app process runs as `questarr` via `su-exec`. But this confused the diagnosis.

## Fixes

### `docker-compose.yml`

- Change `${PORT:-5000}:5000` → `${PORT:-5000}:${PORT:-5000}` so both sides use the same port value
- Add `PORT=${PORT:-5000}` to the container `environment:` so the app listens on the same port Docker maps to
- Update healthcheck to read `process.env.PORT` at runtime instead of hardcoding `5000`

**For users**: to expose on port 5001, create a `.env` file next to `docker-compose.yml` with `PORT=5001`. Both the port mapping and the app's listen port will use it.

### `entrypoint.sh`

- After the `chown` logic, test that `questarr` can actually write to `/app/data` before dropping privileges. If not, print a clear error with the running UID/GID and the exact `chown` command to fix it on the host — instead of letting the server crash 3 seconds later with a cryptic SQLite exception.

### `server/db.ts`

- Wrap `new Database(dbPath)` in try/catch. On failure, log the running UID, the DB path, and actionable remediation steps, then `process.exit(1)` cleanly.

## Test plan

- [ ] Default deploy (`PORT` unset): container maps `5000:5000`, app responds on port 5000
- [ ] Custom port via `.env` (`PORT=5001`): container maps `5001:5001`, app responds on port 5001, healthcheck passes
- [ ] Wrong `./data` ownership: entrypoint prints the clear error and exits before Node.js starts
- [ ] Correct `./data` ownership: no change in behaviour, app starts normally

---

_Generated by [Claude Code](https://claude.ai/code/session_015jA8ssas7A4uYed9bR1HBG)_