### PR TITLE
feat: Add Deluge downloader support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ pr_status.json
 data_test/
 docker-compose.test.yml
 check-sonar.mjs
+.eslintcache

--- a/client/src/pages/downloaders.tsx
+++ b/client/src/pages/downloaders.tsx
@@ -47,6 +47,7 @@ const downloaderTypes = [
   { value: "rtorrent", label: "rTorrent", protocol: "torrent" },
   { value: "qbittorrent", label: "qBittorrent", protocol: "torrent" },
   { value: "synology", label: "Synology Download Station", protocol: "torrent" },
+  { value: "deluge", label: "Deluge", protocol: "torrent" },
   { value: "sabnzbd", label: "SABnzbd", protocol: "usenet" },
   { value: "nzbget", label: "NZBGet", protocol: "usenet" },
 ] as const;
@@ -67,6 +68,8 @@ function getDefaultDownloaderPort(type: string, useSsl: boolean): number | undef
       return 6789;
     case "synology":
       return useSsl ? 5001 : 5000;
+    case "deluge":
+      return 8112;
     default:
       return undefined;
   }

--- a/server/__tests__/downloaders_deluge.test.ts
+++ b/server/__tests__/downloaders_deluge.test.ts
@@ -282,7 +282,7 @@ describe("DelugeClient", () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
-          result: { "recenthash123": { name: "Recent", time_added: Date.now() / 1000 } },
+          result: { recenthash123: { name: "Recent", time_added: Date.now() / 1000 } },
           error: null,
           id: 5,
         }),
@@ -427,7 +427,7 @@ describe("DelugeClient", () => {
           result: {
             name: "Linux ISO",
             state: "Downloading",
-            progress: 0.5,
+            progress: 50,
             download_payload_rate: 1024,
             upload_payload_rate: 0,
             eta: 3600,
@@ -463,7 +463,7 @@ describe("DelugeClient", () => {
           result: {
             name: "Done",
             state: "Paused",
-            progress: 1.0,
+            progress: 100,
             download_payload_rate: 0,
             upload_payload_rate: 0,
             eta: 0,
@@ -547,7 +547,7 @@ describe("DelugeClient", () => {
             hash1: {
               name: "Game A",
               state: "Downloading",
-              progress: 0.25,
+              progress: 25,
               download_payload_rate: 512,
               upload_payload_rate: 0,
               eta: 7200,
@@ -561,7 +561,7 @@ describe("DelugeClient", () => {
             hash2: {
               name: "Game B",
               state: "Seeding",
-              progress: 1.0,
+              progress: 100,
               download_payload_rate: 0,
               upload_payload_rate: 256,
               eta: 0,
@@ -681,7 +681,7 @@ describe("DelugeClient", () => {
           result: {
             name: "Detailed Game",
             state: "Downloading",
-            progress: 0.5,
+            progress: 50,
             download_payload_rate: 1024,
             upload_payload_rate: 0,
             eta: 3600,
@@ -695,8 +695,8 @@ describe("DelugeClient", () => {
             time_added: 1700000000,
             completed_time: 0,
             files: [
-              { path: "game/setup.exe", size: 500000, progress: 0.5, priority: 1 },
-              { path: "game/readme.txt", size: 1000, progress: 1.0, priority: 2 },
+              { path: "game/setup.exe", size: 500000, progress: 50, priority: 1 },
+              { path: "game/readme.txt", size: 1000, progress: 100, priority: 2 },
             ],
             file_priorities: [1, 2],
             file_progress: [0.5, 1.0],
@@ -794,15 +794,15 @@ describe("DelugeClient", () => {
   describe("status mapping", () => {
     // Use it.each so beforeEach runs before every test case, keeping mocks fresh
     it.each([
-      { state: "Downloading", expected: "downloading", progress: 0.5 },
-      { state: "Checking", expected: "downloading", progress: 0.5 },
-      { state: "Allocating", expected: "downloading", progress: 0.5 },
-      { state: "Seeding", expected: "seeding", progress: 1.0 },
-      { state: "Paused", expected: "paused", progress: 0.5 },
-      { state: "Queued", expected: "paused", progress: 0.5 },
-      { state: "Error", expected: "error", progress: 0.1 },
-      { state: "Moving", expected: "downloading", progress: 0.8 },
-      { state: "Paused", expected: "completed", progress: 1.0 },
+      { state: "Downloading", expected: "downloading", progress: 50 },
+      { state: "Checking", expected: "downloading", progress: 50 },
+      { state: "Allocating", expected: "downloading", progress: 50 },
+      { state: "Seeding", expected: "seeding", progress: 100 },
+      { state: "Paused", expected: "paused", progress: 50 },
+      { state: "Queued", expected: "paused", progress: 50 },
+      { state: "Error", expected: "error", progress: 10 },
+      { state: "Moving", expected: "downloading", progress: 80 },
+      { state: "Paused", expected: "completed", progress: 100 },
     ])("maps Deluge state '$state' to '$expected'", async ({ state, expected, progress }) => {
       const client = new DelugeClient(createDownloader());
       setupAuthAndConnect();

--- a/server/__tests__/downloaders_deluge.test.ts
+++ b/server/__tests__/downloaders_deluge.test.ts
@@ -1,0 +1,982 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Downloader } from "../../shared/schema.js";
+
+const fetchMock = vi.fn();
+
+vi.mock("parse-torrent", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  downloadersLogger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("../ssrf.js", () => ({
+  isSafeUrl: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../downloaders/utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../downloaders/utils.js")>();
+  return {
+    ...actual,
+    fetchWithMagnetDetection: vi.fn(),
+  };
+});
+
+global.fetch = fetchMock as unknown as typeof fetch;
+
+const { isSafeUrl } = await import("../ssrf.js");
+const { fetchWithMagnetDetection } = await import("../downloaders/utils.js");
+const { DelugeClient } = await import("../downloaders/deluge.js");
+
+const createDownloader = (overrides: Partial<Downloader> = {}): Downloader => {
+  const now = new Date("2024-01-01T00:00:00.000Z");
+  return {
+    id: "deluge-coverage",
+    name: "Deluge",
+    type: "deluge",
+    url: "http://deluge.local",
+    enabled: true,
+    priority: 1,
+    port: null,
+    useSsl: false,
+    urlPath: null,
+    username: "",
+    password: "secret",
+    downloadPath: null,
+    category: null,
+    label: null,
+    addStopped: false,
+    removeCompleted: false,
+    postImportCategory: null,
+    settings: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+};
+
+describe("DelugeClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+    vi.mocked(isSafeUrl).mockResolvedValue(true);
+    vi.mocked(fetchWithMagnetDetection).mockReset();
+  });
+
+  describe("testConnection", () => {
+    it("should return success on valid connection", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      // auth.login
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 1 }),
+        headers: new Headers({ "set-cookie": "_session_id=abc123; Path=/" }),
+      } as Response);
+
+      // web.connected
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 2 }),
+        headers: new Headers(),
+      } as Response);
+
+      // daemon.get_version
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: "2.1.1", error: null, id: 3 }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.testConnection();
+      expect(result.success).toBe(true);
+      expect(result.message).toBe("Connected successfully to Deluge 2.1.1");
+    });
+
+    it("should handle authentication failure", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: false, error: null, id: 1 }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.testConnection();
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("authentication failed");
+    });
+
+    it("should auto-connect when not connected to daemon", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      // auth.login
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 1 }),
+        headers: new Headers({ "set-cookie": "_session_id=abc123; Path=/" }),
+      } as Response);
+
+      // web.connected (false initially)
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: false, error: null, id: 2 }),
+        headers: new Headers(),
+      } as Response);
+
+      // web.get_hosts
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: [["host-1", "127.0.0.1", 58846, "", ""]],
+          error: null,
+          id: 3,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      // web.connect
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 4 }),
+        headers: new Headers(),
+      } as Response);
+
+      // web.connected (verify after connect)
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 5 }),
+        headers: new Headers(),
+      } as Response);
+
+      // daemon.get_version
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: "2.1.1", error: null, id: 6 }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.testConnection();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("addDownload", () => {
+    it("should add a magnet link successfully", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: "abcdef1234567890abcdef1234567890abcdef12",
+          error: null,
+          id: 4,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "magnet:?xt=urn:btih:abcdef1234567890abcdef1234567890abcdef12",
+        title: "Test Magnet",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.id).toBe("abcdef1234567890abcdef1234567890abcdef12");
+    });
+
+    it("should handle duplicate magnet links", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      // add_torrent_magnet returns null for duplicate
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null, id: 4 }),
+        headers: new Headers(),
+      } as Response);
+
+      // Verify by checking torrent status
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { name: "Test Magnet" },
+          error: null,
+          id: 5,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "magnet:?xt=urn:btih:abcdef1234567890abcdef1234567890abcdef12",
+        title: "Test Magnet",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("already exists");
+    });
+
+    it("should add a torrent file via local download and upload", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      vi.mocked(fetchWithMagnetDetection).mockResolvedValueOnce({
+        response: {
+          ok: true,
+          headers: { get: () => null },
+          arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+        } as Response,
+      });
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: "deadbeef1234567890abcdef1234567890abcdef12",
+          error: null,
+          id: 4,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "http://indexer.local/file.torrent",
+        title: "Test File",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.id).toBe("deadbeef1234567890abcdef1234567890abcdef12");
+    });
+
+    it("should handle torrent file add returning null (fallback)", async () => {
+      const client = new DelugeClient(createDownloader());
+      vi.useFakeTimers();
+
+      setupAuthAndConnect();
+
+      vi.mocked(fetchWithMagnetDetection).mockResolvedValueOnce({
+        response: {
+          ok: true,
+          headers: { get: () => null },
+          arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+        } as Response,
+      });
+
+      // add_torrent_file returns null
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null, id: 4 }),
+        headers: new Headers(),
+      } as Response);
+
+      // No hash match from URL — findRecentlyAddedDownload
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { "recenthash123": { name: "Recent", time_added: Date.now() / 1000 } },
+          error: null,
+          id: 5,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const addPromise = client.addDownload({
+        url: "http://indexer.local/file.torrent",
+        title: "Test File",
+      });
+
+      // Advance past the 1s delay in findRecentlyAddedDownload
+      await vi.advanceTimersByTimeAsync(1200);
+
+      const result = await addPromise;
+
+      expect(result.success).toBe(true);
+      vi.useRealTimers();
+    });
+
+    it("should handle torrent download failure with URL fallback", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      vi.mocked(fetchWithMagnetDetection).mockRejectedValueOnce(new Error("download failed"));
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: "fallbackhash1234567890abcdef1234567890ab",
+          error: null,
+          id: 4,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "http://indexer.local/file.torrent",
+        title: "Test File",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("via URL");
+    });
+
+    it("should return error for unsafe URLs", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      vi.mocked(isSafeUrl).mockResolvedValueOnce(false);
+
+      const result = await client.addDownload({
+        url: "http://unsafe.local/file.torrent",
+        title: "Unsafe",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Unsafe URL blocked");
+    });
+
+    it("should return error when add fails completely", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null, id: 4 }),
+        headers: new Headers(),
+      } as Response);
+
+      // Verify hash mock — return null so torrent doesn't "exist"
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null, id: 5 }),
+        headers: new Headers(),
+      } as Response);
+
+      vi.useFakeTimers();
+
+      // No recent download found
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: {}, error: null, id: 6 }),
+        headers: new Headers(),
+      } as Response);
+
+      const addPromise = client.addDownload({
+        url: "magnet:?xt=urn:btih:nonexistent1234567890abcdef1234567890ab",
+        title: "Test Magnet",
+      });
+
+      await vi.advanceTimersByTimeAsync(1200);
+      const result = await addPromise;
+      vi.useRealTimers();
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should redirect to magnet when fetchWithMagnetDetection returns magnetLink", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      vi.mocked(fetchWithMagnetDetection).mockResolvedValueOnce({
+        magnetLink: "magnet:?xt=urn:btih:magnetredirect1234567890abcdef123456",
+      });
+
+      // Extra mocks for recursive addDownload: ensureConnected + add_torrent_magnet
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: "magnetredirect1234567890abcdef123456",
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "http://indexer.local/file.torrent",
+        title: "Test File",
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("getDownloadStatus", () => {
+    it("should map downloading status correctly", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            name: "Linux ISO",
+            state: "Downloading",
+            progress: 0.5,
+            download_payload_rate: 1024,
+            upload_payload_rate: 0,
+            eta: 3600,
+            total_size: 1000000,
+            all_time_download: 500000,
+            ratio: 0.1,
+            num_peers: 10,
+            num_seeds: 5,
+            message: "",
+          },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const status = await client.getDownloadStatus("hash123");
+
+      expect(status).not.toBeNull();
+      expect(status?.status).toBe("downloading");
+      expect(status?.progress).toBe(50);
+      expect(status?.downloadSpeed).toBe(1024);
+      expect(status?.eta).toBe(3600);
+    });
+
+    it("should map completed status from 100% progress", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            name: "Done",
+            state: "Paused",
+            progress: 1.0,
+            download_payload_rate: 0,
+            upload_payload_rate: 0,
+            eta: 0,
+            total_size: 1000000,
+            all_time_download: 1000000,
+            ratio: 1.0,
+            num_peers: 0,
+            num_seeds: 0,
+            message: "",
+          },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const status = await client.getDownloadStatus("hash123");
+
+      expect(status?.status).toBe("completed");
+      expect(status?.progress).toBe(100);
+    });
+
+    it("should map error status from message", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            name: "Broken",
+            state: "Downloading",
+            progress: 0.1,
+            download_payload_rate: 0,
+            upload_payload_rate: 0,
+            eta: 0,
+            total_size: 1000000,
+            all_time_download: 100000,
+            ratio: 0,
+            num_peers: 0,
+            num_seeds: 0,
+            message: "Tracker error",
+          },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const status = await client.getDownloadStatus("hash123");
+
+      expect(status?.status).toBe("error");
+      expect(status?.error).toBe("Tracker error");
+    });
+
+    it("should return null when torrent not found", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const status = await client.getDownloadStatus("nonexistent");
+      expect(status).toBeNull();
+    });
+  });
+
+  describe("getAllDownloads", () => {
+    it("should return all downloads mapped correctly", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            hash1: {
+              name: "Game A",
+              state: "Downloading",
+              progress: 0.25,
+              download_payload_rate: 512,
+              upload_payload_rate: 0,
+              eta: 7200,
+              total_size: 5000000,
+              all_time_download: 1250000,
+              ratio: 0,
+              num_peers: 5,
+              num_seeds: 2,
+              message: "",
+            },
+            hash2: {
+              name: "Game B",
+              state: "Seeding",
+              progress: 1.0,
+              download_payload_rate: 0,
+              upload_payload_rate: 256,
+              eta: 0,
+              total_size: 3000000,
+              all_time_download: 3000000,
+              ratio: 2.0,
+              num_peers: 1,
+              num_seeds: 1,
+              message: "",
+            },
+          },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const downloads = await client.getAllDownloads();
+
+      expect(downloads).toHaveLength(2);
+      expect(downloads[0].status).toBe("downloading");
+      expect(downloads[1].status).toBe("seeding");
+    });
+
+    it("should return empty array when no torrents", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: {}, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const downloads = await client.getAllDownloads();
+      expect(downloads).toEqual([]);
+    });
+  });
+
+  describe("download control", () => {
+    it("should pause a download", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.pauseDownload("hash123");
+      expect(result.success).toBe(true);
+    });
+
+    it("should resume a download", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.resumeDownload("hash123");
+      expect(result.success).toBe(true);
+    });
+
+    it("should remove a download", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.removeDownload("hash123", false);
+      expect(result.success).toBe(true);
+    });
+
+    it("should remove a download with files", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.removeDownload("hash123", true);
+      expect(result.success).toBe(true);
+    });
+
+    it("should handle pause errors gracefully", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockRejectedValueOnce(new Error("pause error"));
+
+      const result = await client.pauseDownload("hash123");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("pause error");
+    });
+  });
+
+  describe("getDownloadDetails", () => {
+    it("should return detailed download info with files and trackers", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            name: "Detailed Game",
+            state: "Downloading",
+            progress: 0.5,
+            download_payload_rate: 1024,
+            upload_payload_rate: 0,
+            eta: 3600,
+            total_size: 1000000,
+            all_time_download: 500000,
+            all_time_upload: 0,
+            ratio: 0,
+            num_peers: 10,
+            num_seeds: 5,
+            save_path: "/downloads",
+            time_added: 1700000000,
+            completed_time: 0,
+            files: [
+              { path: "game/setup.exe", size: 500000, progress: 0.5, priority: 1 },
+              { path: "game/readme.txt", size: 1000, progress: 1.0, priority: 2 },
+            ],
+            file_priorities: [1, 2],
+            file_progress: [0.5, 1.0],
+            trackers: [
+              {
+                url: "https://tracker1.com/announce",
+                tier: 0,
+                send_stats: true,
+                fails: 0,
+                verified: true,
+              },
+              {
+                url: "https://tracker2.com/announce",
+                tier: 1,
+                send_stats: true,
+                fails: 2,
+                verified: false,
+                last_error: { category: "tracker", value: "Connection refused" },
+              },
+            ],
+            tracker_status: "Announcing",
+            message: "",
+          },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const details = await client.getDownloadDetails("hash123");
+
+      expect(details).not.toBeNull();
+      expect(details?.files).toHaveLength(2);
+      expect(details?.files[0].name).toBe("game/setup.exe");
+      expect(details?.trackers).toHaveLength(2);
+      expect(details?.trackers[0].status).toBe("working");
+      expect(details?.trackers[1].status).toBe("error");
+      expect(details?.downloadDir).toBe("/downloads");
+    });
+
+    it("should return null when torrent not found", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const details = await client.getDownloadDetails("nonexistent");
+      expect(details).toBeNull();
+    });
+  });
+
+  describe("getFreeSpace", () => {
+    it("should return free space", async () => {
+      const client = new DelugeClient(createDownloader({ downloadPath: "/downloads" }));
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: 10737418240, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.getFreeSpace();
+      expect(result).toBe(10737418240);
+    });
+
+    it("should return 0 on error", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockRejectedValueOnce(new Error("space error"));
+
+      const result = await client.getFreeSpace();
+      expect(result).toBe(0);
+    });
+
+    it("should return 0 for invalid response", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: -1, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.getFreeSpace();
+      expect(result).toBe(0);
+    });
+  });
+
+  describe("status mapping", () => {
+    // Use it.each so beforeEach runs before every test case, keeping mocks fresh
+    it.each([
+      { state: "Downloading", expected: "downloading", progress: 0.5 },
+      { state: "Checking", expected: "downloading", progress: 0.5 },
+      { state: "Allocating", expected: "downloading", progress: 0.5 },
+      { state: "Seeding", expected: "seeding", progress: 1.0 },
+      { state: "Paused", expected: "paused", progress: 0.5 },
+      { state: "Queued", expected: "paused", progress: 0.5 },
+      { state: "Error", expected: "error", progress: 0.1 },
+      { state: "Moving", expected: "downloading", progress: 0.8 },
+      { state: "Paused", expected: "completed", progress: 1.0 },
+    ])("maps Deluge state '$state' to '$expected'", async ({ state, expected, progress }) => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            name: state,
+            state,
+            progress,
+            download_payload_rate: 0,
+            upload_payload_rate: 0,
+            eta: 0,
+            total_size: 1000,
+            all_time_download: 0,
+            ratio: 0,
+            num_peers: 0,
+            num_seeds: 0,
+            message: "",
+          },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const status = await client.getDownloadStatus("hash");
+      expect(status?.status).toBe(expected);
+    });
+  });
+
+  describe("RPC error handling", () => {
+    it("should return failed result on Deluge RPC error", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: null,
+          error: { message: "Invalid torrent", code: 5 },
+          id: 4,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "magnet:?xt=urn:btih:abc123",
+        title: "Test",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Invalid torrent");
+    });
+
+    it("should return failed result on HTTP errors", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockRejectedValueOnce(new Error("Server error"));
+
+      const result = await client.addDownload({
+        url: "magnet:?xt=urn:btih:abc123",
+        title: "Test",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Server error");
+    });
+
+    it("should return failed result on invalid JSON", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new Error("not json");
+        },
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "magnet:?xt=urn:btih:abc123",
+        title: "Test",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Invalid JSON");
+    });
+  });
+
+  describe("URL path support", () => {
+    it("should include urlPath in the RPC URL", async () => {
+      const client = new DelugeClient(
+        createDownloader({ url: "http://deluge.local", urlPath: "/deluge" })
+      );
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 1 }),
+        headers: new Headers({ "set-cookie": "_session_id=abc123; Path=/" }),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 2 }),
+        headers: new Headers(),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: "2.1.1", error: null, id: 3 }),
+        headers: new Headers(),
+      } as Response);
+
+      await client.testConnection();
+
+      const calls = fetchMock.mock.calls;
+      expect(calls[0][0]).toContain("/deluge/json");
+    });
+
+    it("should handle SSL and custom port", async () => {
+      const client = new DelugeClient(
+        createDownloader({ url: "deluge.local", useSsl: true, port: 8443 })
+      );
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 1 }),
+        headers: new Headers({ "set-cookie": "_session_id=abc123; Path=/" }),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 2 }),
+        headers: new Headers(),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: "2.1.1", error: null, id: 3 }),
+        headers: new Headers(),
+      } as Response);
+
+      await client.testConnection();
+
+      const calls = fetchMock.mock.calls;
+      expect(calls[0][0]).toBe("https://deluge.local:8443/json");
+    });
+  });
+});
+
+// Helper to set up common auth + connection mocks for Deluge tests
+function setupAuthAndConnect(): void {
+  // auth.login
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ result: true, error: null, id: 1 }),
+    headers: new Headers({ "set-cookie": "_session_id=abc123; Path=/" }),
+  } as Response);
+
+  // web.connected
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ result: true, error: null, id: 2 }),
+    headers: new Headers(),
+  } as Response);
+}
+
+describe("DownloaderManager with Deluge", () => {
+  it("creates a DelugeClient for deluge type", async () => {
+    const { DownloaderManager } = await import("../downloaders/manager.js");
+    const client = DownloaderManager.createClient(createDownloader());
+    expect(client.constructor.name).toBe("DelugeClient");
+  });
+});

--- a/server/__tests__/downloaders_deluge.test.ts
+++ b/server/__tests__/downloaders_deluge.test.ts
@@ -485,7 +485,7 @@ describe("DelugeClient", () => {
       expect(status?.progress).toBe(100);
     });
 
-    it("should map error status from message", async () => {
+    it("should map error status from Deluge Error state with message", async () => {
       const client = new DelugeClient(createDownloader());
 
       setupAuthAndConnect();
@@ -495,7 +495,7 @@ describe("DelugeClient", () => {
         json: async () => ({
           result: {
             name: "Broken",
-            state: "Downloading",
+            state: "Error",
             progress: 0.1,
             download_payload_rate: 0,
             upload_payload_rate: 0,
@@ -516,6 +516,38 @@ describe("DelugeClient", () => {
 
       expect(status?.status).toBe("error");
       expect(status?.error).toBe("Tracker error");
+    });
+
+    it("should not treat innocuous tracker message 'OK' as an error — regression for #568", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            name: "My Game",
+            state: "Seeding",
+            progress: 100,
+            download_payload_rate: 0,
+            upload_payload_rate: 1024,
+            eta: 0,
+            total_size: 5000000,
+            all_time_download: 5000000,
+            ratio: 1.5,
+            num_peers: 3,
+            num_seeds: 5,
+            message: "OK",
+          },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const status = await client.getDownloadStatus("abc123");
+      expect(status?.status).toBe("seeding");
+      expect(status?.error).toBeUndefined();
     });
 
     it("should return null when torrent not found", async () => {

--- a/server/__tests__/downloaders_deluge_coverage.test.ts
+++ b/server/__tests__/downloaders_deluge_coverage.test.ts
@@ -755,4 +755,51 @@ describe("DelugeClient — coverage gaps", () => {
       expect(authCalls.length).toBe(2);
     });
   });
+
+  describe("makeRequest — cookie fallback (line 783)", () => {
+    it("extracts first cookie when no _session_id cookie is present", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      // auth.login returns a non-_session_id cookie (e.g. from a reverse proxy)
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 1 }),
+        headers: new Headers({ "set-cookie": "proxy_session=xyz789; Path=/" }),
+      } as Response);
+
+      // web.connected
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 2 }),
+        headers: new Headers(),
+      } as Response);
+
+      // daemon.get_version
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: "2.0.0", error: null, id: 3 }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.testConnection();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("makeRequest — RPC error without message (line 826)", () => {
+    it("falls back to generic RPC error when error object has no message", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      // auth.login returns an error object with no message field
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: { code: 99 }, id: 1 }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.testConnection();
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Deluge RPC error");
+    });
+  });
 });

--- a/server/__tests__/downloaders_deluge_coverage.test.ts
+++ b/server/__tests__/downloaders_deluge_coverage.test.ts
@@ -1,0 +1,758 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Downloader } from "../../shared/schema.js";
+
+const fetchMock = vi.fn();
+
+vi.mock("parse-torrent", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  downloadersLogger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("../ssrf.js", () => ({
+  isSafeUrl: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../downloaders/utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../downloaders/utils.js")>();
+  return {
+    ...actual,
+    fetchWithMagnetDetection: vi.fn(),
+  };
+});
+
+global.fetch = fetchMock as unknown as typeof fetch;
+
+const { isSafeUrl } = await import("../ssrf.js");
+const { fetchWithMagnetDetection } = await import("../downloaders/utils.js");
+const { DelugeClient } = await import("../downloaders/deluge.js");
+
+const createDownloader = (overrides: Partial<Downloader> = {}): Downloader => {
+  const now = new Date("2024-01-01T00:00:00.000Z");
+  return {
+    id: "deluge-cov",
+    name: "Deluge",
+    type: "deluge",
+    url: "http://deluge.local",
+    enabled: true,
+    priority: 1,
+    port: null,
+    useSsl: false,
+    urlPath: null,
+    username: "",
+    password: "secret",
+    downloadPath: null,
+    category: null,
+    label: null,
+    addStopped: false,
+    removeCompleted: false,
+    postImportCategory: null,
+    settings: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+};
+
+function setupAuthAndConnect() {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ result: true, error: null, id: 1 }),
+    headers: new Headers({ "set-cookie": "_session_id=abc123; Path=/" }),
+  } as Response);
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ result: true, error: null, id: 2 }),
+    headers: new Headers(),
+  } as Response);
+}
+
+describe("DelugeClient — coverage gaps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+    vi.mocked(isSafeUrl).mockResolvedValue(true);
+    vi.mocked(fetchWithMagnetDetection).mockReset();
+  });
+
+  describe("getBaseUrl — invalid URL fallback (line 106)", () => {
+    it("falls back to raw URL when URL parsing fails", async () => {
+      // "http://[invalid" causes new URL() to throw → line 106 executes
+      const client = new DelugeClient(createDownloader({ url: "http://[invalid" }));
+
+      setupAuthAndConnect();
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: "2.0.0", error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.testConnection();
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("addDownload — options (lines 249, 252)", () => {
+    it("includes download_location and add_paused when set", async () => {
+      const client = new DelugeClient(
+        createDownloader({ downloadPath: "/mnt/downloads", addStopped: true })
+      );
+
+      setupAuthAndConnect();
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: "abcdef1234567890abcdef1234567890abcdef12",
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "magnet:?xt=urn:btih:abcdef1234567890abcdef1234567890abcdef12",
+        title: "Test",
+      });
+
+      expect(result.success).toBe(true);
+      const addCall = fetchMock.mock.calls.find((c) => {
+        const body = JSON.parse((c[1]?.body as string) || "{}") as { method?: string };
+        return body.method === "core.add_torrent_magnet";
+      });
+      const body = JSON.parse((addCall?.[1]?.body as string) || "{}") as {
+        params?: [string, Record<string, unknown>];
+      };
+      expect(body.params?.[1]?.download_location).toBe("/mnt/downloads");
+      expect(body.params?.[1]?.add_paused).toBe(true);
+    });
+  });
+
+  describe("addDownload — label application (lines 231-240)", () => {
+    it("applies label after successful add and warns when label.set_torrent fails", async () => {
+      const client = new DelugeClient(createDownloader({ category: "games" }));
+
+      setupAuthAndConnect();
+
+      // core.add_torrent_magnet succeeds
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: "aabbcc1234567890abcdef1234567890abcdef12",
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      // label.add succeeds
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      // label.set_torrent throws an RPC error
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: { message: "No such method", code: 2 } }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "magnet:?xt=urn:btih:aabbcc1234567890abcdef1234567890abcdef12",
+        title: "Labeled Torrent",
+      });
+
+      expect(result.success).toBe(true);
+      const { downloadersLogger } = await import("../logger.js");
+      expect(downloadersLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ category: "games" }),
+        "Failed to apply Deluge label"
+      );
+    });
+
+    it("silently ignores label.add failure (label already exists)", async () => {
+      const client = new DelugeClient(createDownloader({ category: "games" }));
+
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: "aabbcc1234567890abcdef1234567890abcdef12",
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      // label.add fails (already exists)
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: { message: "Label already exists", code: 1 } }),
+        headers: new Headers(),
+      } as Response);
+
+      // label.set_torrent succeeds
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "magnet:?xt=urn:btih:aabbcc1234567890abcdef1234567890abcdef12",
+        title: "Labeled Torrent",
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("addDownload — non-ok torrent response (lines 305-307)", () => {
+    it("throws when torrent download returns non-ok response", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      vi.mocked(fetchWithMagnetDetection).mockResolvedValueOnce({
+        response: {
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+          headers: { get: () => null },
+        } as unknown as Response,
+      });
+
+      // Fallback: core.add_torrent_url
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: "deadbeef1234567890abcdef1234567890abcdef",
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "http://indexer.local/file.torrent",
+        title: "404 Torrent",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("via URL");
+    });
+  });
+
+  describe("addDownload — content-disposition filename (lines 312-314)", () => {
+    it("uses filename from content-disposition header", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      vi.mocked(fetchWithMagnetDetection).mockResolvedValueOnce({
+        response: {
+          ok: true,
+          headers: {
+            get: (h: string) =>
+              h === "content-disposition" ? 'attachment; filename="mygame.torrent"' : null,
+          },
+          arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+        } as unknown as Response,
+      });
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: "cafebabe1234567890abcdef1234567890abcdef",
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "http://indexer.local/download?id=123",
+        title: "My Game",
+      });
+
+      expect(result.success).toBe(true);
+      const addFileCall = fetchMock.mock.calls.find((c) => {
+        const body = JSON.parse((c[1]?.body as string) || "{}") as { method?: string };
+        return body.method === "core.add_torrent_file";
+      });
+      const body = JSON.parse((addFileCall?.[1]?.body as string) || "{}") as {
+        params?: [string];
+      };
+      expect(body.params?.[0]).toBe("mygame.torrent");
+    });
+  });
+
+  describe("addDownload — URL fallback null with hash (lines 343-357)", () => {
+    it("verifies existing torrent by hash in URL fallback path", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      vi.mocked(fetchWithMagnetDetection).mockRejectedValueOnce(new Error("download failed"));
+
+      // core.add_torrent_url returns null
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      // core.get_torrent_status verifies the torrent exists
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { name: "Existing Game" },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      // URL contains the btih hash so extractHashFromUrl can find it
+      const result = await client.addDownload({
+        url: "http://indexer.local/dl?xt=urn:btih:abcdef1234567890abcdef1234567890abcdef12",
+        title: "Existing",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("already exists");
+    });
+
+    it("returns failure when URL fallback null and no hash in URL", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      vi.mocked(fetchWithMagnetDetection).mockRejectedValueOnce(new Error("download failed"));
+
+      // core.add_torrent_url returns null, URL has no extractable hash
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "http://indexer.local/file.torrent",
+        title: "No Hash",
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("addDownload — file add null with hash match (lines 380-396)", () => {
+    it("verifies existing torrent by hash when add_torrent_file returns null", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      vi.mocked(fetchWithMagnetDetection).mockResolvedValueOnce({
+        response: {
+          ok: true,
+          headers: { get: () => null },
+          arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+        } as unknown as Response,
+      });
+
+      // core.add_torrent_file returns null
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      // core.get_torrent_status confirms torrent exists
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { name: "Existing" },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      // URL contains the btih hash so extractHashFromUrl can find it
+      const result = await client.addDownload({
+        url: "http://indexer.local/dl?xt=urn:btih:deadbeef1234567890abcdef1234567890abcdef",
+        title: "Existing File",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain("already exists");
+    });
+
+    it("returns failure when add_torrent_file null, no hash, and no recent download", async () => {
+      vi.useFakeTimers();
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      vi.mocked(fetchWithMagnetDetection).mockResolvedValueOnce({
+        response: {
+          ok: true,
+          headers: { get: () => null },
+          arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+        } as unknown as Response,
+      });
+
+      // core.add_torrent_file returns null
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      // findRecentlyAddedDownload → no results
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: {}, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const addPromise = client.addDownload({
+        url: "http://indexer.local/file.torrent",
+        title: "Nothing",
+      });
+
+      await vi.advanceTimersByTimeAsync(1200);
+      const result = await addPromise;
+      vi.useRealTimers();
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Failed to add download to Deluge");
+    });
+  });
+
+  describe("findRecentlyAddedDownload — edge cases (lines 431, 433-434)", () => {
+    it("returns null when most recent torrent was added more than 10s ago", async () => {
+      vi.useFakeTimers();
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      vi.mocked(fetchWithMagnetDetection).mockResolvedValueOnce({
+        response: {
+          ok: true,
+          headers: { get: () => null },
+          arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+        } as unknown as Response,
+      });
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const oldTime = Math.floor(Date.now() / 1000) - 60;
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { oldhash: { name: "Old Torrent", time_added: oldTime } },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const addPromise = client.addDownload({
+        url: "http://indexer.local/file.torrent",
+        title: "Old",
+      });
+
+      await vi.advanceTimersByTimeAsync(1200);
+      const result = await addPromise;
+      vi.useRealTimers();
+
+      expect(result.success).toBe(false);
+    });
+
+    it("handles exception in findRecentlyAddedDownload gracefully", async () => {
+      vi.useFakeTimers();
+      const client = new DelugeClient(createDownloader());
+
+      setupAuthAndConnect();
+
+      vi.mocked(fetchWithMagnetDetection).mockResolvedValueOnce({
+        response: {
+          ok: true,
+          headers: { get: () => null },
+          arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+        } as unknown as Response,
+      });
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      // get_torrents_status throws
+      fetchMock.mockRejectedValueOnce(new Error("network failure in findRecent"));
+
+      const addPromise = client.addDownload({
+        url: "http://indexer.local/file.torrent",
+        title: "Error Recovery",
+      });
+
+      await vi.advanceTimersByTimeAsync(1200);
+      const result = await addPromise;
+      vi.useRealTimers();
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("getDownloadDetails — tracker status branches (lines 543, 547, 551)", () => {
+    const makeTrackerResponse = (trackers: object[]) => ({
+      ok: true,
+      json: async () => ({
+        result: {
+          name: "Tracker Test",
+          state: "Seeding",
+          progress: 100,
+          download_payload_rate: 0,
+          upload_payload_rate: 0,
+          eta: 0,
+          total_size: 1000,
+          all_time_download: 1000,
+          all_time_upload: 500,
+          ratio: 1,
+          num_peers: 0,
+          num_seeds: 3,
+          save_path: "/downloads",
+          time_added: 1700000000,
+          completed_time: 1700001000,
+          files: [],
+          file_priorities: [],
+          file_progress: [],
+          trackers,
+          tracker_status: "OK",
+          message: "",
+          label: "",
+        },
+        error: null,
+      }),
+      headers: new Headers(),
+    });
+
+    it("maps send_stats=false to inactive tracker status (line 543)", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce(
+        makeTrackerResponse([{ url: "udp://t1.example.com:6969", tier: 0, send_stats: false }])
+      );
+
+      const details = await client.getDownloadDetails("hash1");
+      expect(details?.trackers?.[0]?.status).toBe("inactive");
+    });
+
+    it("maps last_error.value to error tracker status (line 547)", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce(
+        makeTrackerResponse([
+          {
+            url: "udp://t2.example.com:6969",
+            tier: 0,
+            send_stats: true,
+            last_error: { category: "http", value: "Connection timed out" },
+            fails: 0,
+            verified: false,
+          },
+        ])
+      );
+
+      const details = await client.getDownloadDetails("hash2");
+      expect(details?.trackers?.[0]?.status).toBe("error");
+    });
+
+    it("maps fails>0 to error tracker status (line 547)", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce(
+        makeTrackerResponse([
+          {
+            url: "udp://t3.example.com:6969",
+            tier: 0,
+            send_stats: true,
+            fails: 3,
+            verified: false,
+          },
+        ])
+      );
+
+      const details = await client.getDownloadDetails("hash3");
+      expect(details?.trackers?.[0]?.status).toBe("error");
+    });
+
+    it("maps verified=true to working tracker status (line 551)", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce(
+        makeTrackerResponse([
+          {
+            url: "udp://t4.example.com:6969",
+            tier: 1,
+            send_stats: true,
+            fails: 0,
+            verified: true,
+          },
+        ])
+      );
+
+      const details = await client.getDownloadDetails("hash4");
+      expect(details?.trackers?.[0]?.status).toBe("working");
+    });
+
+    it("maps unverified non-error tracker to updating status (line 551 else)", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce(
+        makeTrackerResponse([
+          {
+            url: "udp://t5.example.com:6969",
+            tier: 0,
+            send_stats: true,
+            fails: 0,
+            verified: false,
+          },
+        ])
+      );
+
+      const details = await client.getDownloadDetails("hash5");
+      expect(details?.trackers?.[0]?.status).toBe("updating");
+    });
+  });
+
+  describe("getDownloadDetails — error path (lines 580-581)", () => {
+    it("returns null on exception", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockRejectedValueOnce(new Error("network failure"));
+
+      const result = await client.getDownloadDetails("hashX");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("resumeDownload — error path (lines 638-639)", () => {
+    it("returns failure message on error", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockRejectedValueOnce(new Error("timeout"));
+
+      const result = await client.resumeDownload("hashY");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("timeout");
+    });
+  });
+
+  describe("removeDownload — error path (lines 653-654)", () => {
+    it("returns failure message on error", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockRejectedValueOnce(new Error("RPC error"));
+
+      const result = await client.removeDownload("hashZ");
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("RPC error");
+    });
+  });
+
+  describe("401 cookie clearing", () => {
+    it("clears cookie on 401 so next request re-authenticates", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      // First successful auth
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 1 }),
+        headers: new Headers({ "set-cookie": "_session_id=expiredcookie; Path=/" }),
+      } as Response);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 2 }),
+        headers: new Headers(),
+      } as Response);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: "2.0", error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      await client.testConnection();
+
+      // Next call: 401 → cookie should be cleared
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        text: async () => "Session expired",
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.getDownloadStatus("hashA");
+      expect(result).toBeNull();
+
+      // Next call: re-authentication should be attempted (auth.login called again)
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null }),
+        headers: new Headers({ "set-cookie": "_session_id=newcookie; Path=/" }),
+      } as Response);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null }),
+        headers: new Headers(),
+      } as Response);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            name: "Test",
+            state: "Seeding",
+            progress: 100,
+            download_payload_rate: 0,
+            upload_payload_rate: 0,
+            eta: 0,
+            total_size: 1000,
+            all_time_download: 1000,
+            ratio: 1,
+            num_peers: 0,
+            num_seeds: 1,
+            message: "",
+          },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const result2 = await client.getDownloadStatus("hashA");
+      expect(result2).not.toBeNull();
+
+      const authCalls = fetchMock.mock.calls.filter((c) => {
+        const body = JSON.parse((c[1]?.body as string) || "{}") as { method?: string };
+        return body.method === "auth.login";
+      });
+      expect(authCalls.length).toBe(2);
+    });
+  });
+});

--- a/server/__tests__/downloaders_deluge_coverage.test.ts
+++ b/server/__tests__/downloaders_deluge_coverage.test.ts
@@ -784,6 +784,30 @@ describe("DelugeClient — coverage gaps", () => {
       const result = await client.testConnection();
       expect(result.success).toBe(true);
     });
+
+    it("does not set cookie when Set-Cookie header contains no extractable value", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      // Both regexes return null when the cookie header is just ";" (no name=value before it)
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 1 }),
+        headers: new Headers({ "set-cookie": ";" }),
+      } as Response);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 2 }),
+        headers: new Headers(),
+      } as Response);
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: "2.0.0", error: null, id: 3 }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.testConnection();
+      expect(result.success).toBe(true);
+    });
   });
 
   describe("makeRequest — RPC error without message (line 826)", () => {

--- a/server/__tests__/downloaders_deluge_remaining.test.ts
+++ b/server/__tests__/downloaders_deluge_remaining.test.ts
@@ -1,0 +1,430 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Downloader } from "../../shared/schema.js";
+
+const fetchMock = vi.fn();
+
+vi.mock("parse-torrent", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  downloadersLogger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+global.fetch = fetchMock as unknown as typeof fetch;
+
+const { DelugeClient } = await import("../downloaders/deluge.js");
+
+const createDownloader = (overrides: Partial<Downloader> = {}): Downloader => {
+  const now = new Date("2024-01-01T00:00:00.000Z");
+  return {
+    id: "deluge-remaining",
+    name: "Deluge",
+    type: "deluge",
+    url: "http://deluge.local",
+    enabled: true,
+    priority: 1,
+    port: null,
+    useSsl: false,
+    urlPath: null,
+    username: "",
+    password: "secret",
+    downloadPath: null,
+    category: null,
+    label: null,
+    addStopped: false,
+    removeCompleted: false,
+    postImportCategory: null,
+    settings: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+};
+
+describe("DelugeClient — remaining coverage edge cases", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockReset();
+  });
+
+  describe("status mapping", () => {
+    it("warns on unknown state and maps to paused", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            name: "Weird",
+            state: "SomeUnknownState",
+            progress: 0.3,
+            download_payload_rate: 0,
+            upload_payload_rate: 0,
+            eta: 0,
+            total_size: 1000,
+            all_time_download: 0,
+            ratio: 0,
+            num_peers: 0,
+            num_seeds: 0,
+            message: "",
+          },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const status = await client.getDownloadStatus("hash");
+      expect(status?.status).toBe("paused");
+    });
+
+    it("forces seeding when progress is 100% during downloading", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            name: "AlmostDone",
+            state: "Downloading",
+            progress: 1.0,
+            download_payload_rate: 0,
+            upload_payload_rate: 256,
+            eta: 0,
+            total_size: 1000,
+            all_time_download: 1000,
+            ratio: 0,
+            num_peers: 0,
+            num_seeds: 1,
+            message: "",
+          },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const status = await client.getDownloadStatus("hash");
+      expect(status?.status).toBe("seeding");
+    });
+  });
+
+  describe("makeRequest error handling", () => {
+    it("returns failed result on Deluge RPC error", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        text: async () => "Bad credentials",
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.addDownload({
+        url: "magnet:?xt=urn:btih:abc123",
+        title: "Test",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Authentication failed");
+    });
+
+    it("returns null on non-401 HTTP errors for getDownloadStatus", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: async () => "Boom",
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.getDownloadStatus("hash");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("testConnection logVersionInfo", () => {
+    it("returns success even when version is not a string", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 1 }),
+        headers: new Headers({ "set-cookie": "_session_id=abc123; Path=/" }),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 2 }),
+        headers: new Headers(),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: 123, error: null, id: 3 }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.testConnection();
+      expect(result.success).toBe(true);
+      expect(result.message).toBe("Connected successfully to Deluge");
+    });
+
+    it("logVersionInfo logs version when available", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 1 }),
+        headers: new Headers({ "set-cookie": "_session_id=abc123; Path=/" }),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 2 }),
+        headers: new Headers(),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: "2.1.1", error: null, id: 3 }),
+        headers: new Headers(),
+      } as Response);
+
+      await client.logVersionInfo();
+      const { downloadersLogger } = await import("../logger.js");
+      expect(downloadersLogger.info).toHaveBeenCalled();
+    });
+
+    it("logVersionInfo handles errors gracefully", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      fetchMock.mockRejectedValueOnce(new Error("connect refused"));
+
+      await client.logVersionInfo();
+      const { downloadersLogger } = await import("../logger.js");
+      expect(downloadersLogger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe("ensureConnected edge cases", () => {
+    it("throws when no hosts are configured", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 1 }),
+        headers: new Headers({ "set-cookie": "_session_id=abc123; Path=/" }),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: false, error: null, id: 2 }),
+        headers: new Headers(),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: [], error: null, id: 3 }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.testConnection();
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("No Deluge daemon hosts");
+    });
+
+    it("throws when daemon connection verification fails", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 1 }),
+        headers: new Headers({ "set-cookie": "_session_id=abc123; Path=/" }),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: false, error: null, id: 2 }),
+        headers: new Headers(),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: [["host-1", "127.0.0.1", 58846, "", ""]],
+          error: null,
+          id: 3,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 4 }),
+        headers: new Headers(),
+      } as Response);
+
+      // verification connected returns false
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: false, error: null, id: 5 }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.testConnection();
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Failed to connect");
+    });
+  });
+
+  describe("addDownload edge cases", () => {
+    it("returns error when URL is missing", async () => {
+      const client = new DelugeClient(createDownloader());
+      const result = await client.addDownload({ url: "", title: "Empty" });
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("required");
+    });
+  });
+
+  describe("getAllDownloads edge cases", () => {
+    it("returns empty array on error", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockRejectedValueOnce(new Error("network"));
+
+      const result = await client.getAllDownloads();
+      expect(result).toEqual([]);
+    });
+
+    it("handles null result from get_torrents_status", async () => {
+      const client = new DelugeClient(createDownloader());
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: null, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.getAllDownloads();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getFreeSpace edge cases", () => {
+    it("works when downloadPath is not set", async () => {
+      const client = new DelugeClient(createDownloader({ downloadPath: null }));
+      setupAuthAndConnect();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: 5000, error: null }),
+        headers: new Headers(),
+      } as Response);
+
+      const result = await client.getFreeSpace();
+      expect(result).toBe(5000);
+    });
+  });
+
+  describe("cookie handling", () => {
+    it("extracts and reuses session cookie", async () => {
+      const client = new DelugeClient(createDownloader());
+
+      // First call: auth login returns cookie
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 1 }),
+        headers: new Headers({ "set-cookie": "_session_id=cookie123; Path=/; HttpOnly" }),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 2 }),
+        headers: new Headers(),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: "2.1.1", error: null, id: 3 }),
+        headers: new Headers(),
+      } as Response);
+
+      await client.testConnection();
+
+      // Second call: should reuse cookie (no auth/login fetch)
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: true, error: null, id: 4 }),
+        headers: new Headers(),
+      } as Response);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            hash1: {
+              name: "Cached",
+              state: "Seeding",
+              progress: 1.0,
+              download_payload_rate: 0,
+              upload_payload_rate: 0,
+              eta: 0,
+              total_size: 1000,
+              all_time_download: 1000,
+              ratio: 1,
+              num_peers: 0,
+              num_seeds: 1,
+              message: "",
+            },
+          },
+          error: null,
+        }),
+        headers: new Headers(),
+      } as Response);
+
+      const downloads = await client.getAllDownloads();
+      expect(downloads).toHaveLength(1);
+
+      // Should NOT have called auth.login again (only 1 extra fetch for get_torrents_status after testConnection)
+      const authCalls = fetchMock.mock.calls.filter(
+        (call) => {
+          const body = JSON.parse((call[1]?.body as string) || "{}") as Record<string, unknown>;
+          return body.method === "auth.login";
+        }
+      );
+      expect(authCalls).toHaveLength(1);
+    });
+  });
+});
+
+// Helper to set up common auth + connection mocks for Deluge tests
+function setupAuthAndConnect(): void {
+  // auth.login
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ result: true, error: null, id: 1 }),
+    headers: new Headers({ "set-cookie": "_session_id=abc123; Path=/" }),
+  } as Response);
+
+  // web.connected
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ result: true, error: null, id: 2 }),
+    headers: new Headers(),
+  } as Response);
+}

--- a/server/__tests__/downloaders_deluge_remaining.test.ts
+++ b/server/__tests__/downloaders_deluge_remaining.test.ts
@@ -65,7 +65,7 @@ describe("DelugeClient — remaining coverage edge cases", () => {
           result: {
             name: "Weird",
             state: "SomeUnknownState",
-            progress: 0.3,
+            progress: 30,
             download_payload_rate: 0,
             upload_payload_rate: 0,
             eta: 0,
@@ -95,7 +95,7 @@ describe("DelugeClient — remaining coverage edge cases", () => {
           result: {
             name: "AlmostDone",
             state: "Downloading",
-            progress: 1.0,
+            progress: 100,
             download_payload_rate: 0,
             upload_payload_rate: 256,
             eta: 0,
@@ -380,7 +380,7 @@ describe("DelugeClient — remaining coverage edge cases", () => {
             hash1: {
               name: "Cached",
               state: "Seeding",
-              progress: 1.0,
+              progress: 100,
               download_payload_rate: 0,
               upload_payload_rate: 0,
               eta: 0,
@@ -401,12 +401,10 @@ describe("DelugeClient — remaining coverage edge cases", () => {
       expect(downloads).toHaveLength(1);
 
       // Should NOT have called auth.login again (only 1 extra fetch for get_torrents_status after testConnection)
-      const authCalls = fetchMock.mock.calls.filter(
-        (call) => {
-          const body = JSON.parse((call[1]?.body as string) || "{}") as Record<string, unknown>;
-          return body.method === "auth.login";
-        }
-      );
+      const authCalls = fetchMock.mock.calls.filter((call) => {
+        const body = JSON.parse((call[1]?.body as string) || "{}") as Record<string, unknown>;
+        return body.method === "auth.login";
+      });
       expect(authCalls).toHaveLength(1);
     });
   });

--- a/server/__tests__/downloaders_utils_manager.test.ts
+++ b/server/__tests__/downloaders_utils_manager.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Downloader, DownloadStatus } from "../../shared/schema.js";
+import { DelugeClient } from "../downloaders/deluge.js";
 import { DownloaderManager } from "../downloaders.js";
 import {
   DOWNLOAD_CLIENT_USER_AGENT,

--- a/server/downloaders/deluge.ts
+++ b/server/downloaders/deluge.ts
@@ -743,7 +743,7 @@ export class DelugeClient implements DownloaderClient {
       size: status.total_size ?? 0,
       downloaded: status.all_time_download ?? 0,
       seeders: status.num_seeds ?? 0,
-      leechers: (status.num_peers ?? 0) - (status.num_seeds ?? 0),
+      leechers: status.num_peers ?? 0,
       ratio: status.ratio ?? 0,
       error: errorMessage,
       category: status.label || undefined,
@@ -789,6 +789,7 @@ export class DelugeClient implements DownloaderClient {
     if (!response.ok) {
       const errorText = await response.text().catch(() => "No error details available");
       if (response.status === 401) {
+        this.cookie = null;
         downloadersLogger.error(
           {
             status: response.status,

--- a/server/downloaders/deluge.ts
+++ b/server/downloaders/deluge.ts
@@ -290,7 +290,6 @@ export class DelugeClient implements DownloaderClient {
 
       let torrentFileBuffer: Buffer;
       let torrentFileName = "torrent.torrent";
-      const parsedInfoHash: string | null = null;
 
       try {
         const { response: torrentResponse, magnetLink } = await fetchWithMagnetDetection(
@@ -723,12 +722,12 @@ export class DelugeClient implements DownloaderClient {
       }
     }
 
-    // Override with error message
-    if (status.message && status.message.length > 0) {
-      downloadStatus = "error";
-    }
-
     const eta = status.eta ?? undefined;
+
+    // Only surface the tracker message as an error when Deluge itself reports an Error state.
+    // The message field is also used for normal tracker responses (e.g. "OK") and must not
+    // override the status — doing so caused every seeding torrent to appear as "Error: OK".
+    const errorMessage = downloadStatus === "error" ? status.message || undefined : undefined;
 
     return {
       id: hash.toLowerCase(),
@@ -746,7 +745,7 @@ export class DelugeClient implements DownloaderClient {
       seeders: status.num_seeds ?? 0,
       leechers: (status.num_peers ?? 0) - (status.num_seeds ?? 0),
       ratio: status.ratio ?? 0,
-      error: status.message || undefined,
+      error: errorMessage,
       category: status.label || undefined,
     };
   }

--- a/server/downloaders/deluge.ts
+++ b/server/downloaders/deluge.ts
@@ -1,0 +1,833 @@
+import type {
+  Downloader,
+  DownloadStatus,
+  DownloadFile,
+  DownloadTracker,
+  DownloadDetails,
+} from "../../shared/schema.js";
+import { downloadersLogger } from "../logger.js";
+import { isSafeUrl } from "../ssrf.js";
+import type { DownloadRequest, DownloaderClient } from "./types.js";
+import { fetchWithMagnetDetection, extractHashFromUrl } from "./utils.js";
+
+interface DelugeTorrentStatus {
+  name?: string;
+  state?: string;
+  progress?: number;
+  download_payload_rate?: number;
+  upload_payload_rate?: number;
+  eta?: number;
+  total_size?: number;
+  all_time_download?: number;
+  all_time_upload?: number;
+  ratio?: number;
+  num_peers?: number;
+  num_seeds?: number;
+  save_path?: string;
+  time_added?: number;
+  completed_time?: number;
+  files?: Array<{
+    path: string;
+    size: number;
+    progress: number;
+    priority: number;
+  }>;
+  file_priorities?: number[];
+  file_progress?: number[];
+  trackers?: Array<{
+    url: string;
+    tier?: number;
+    send_stats?: boolean;
+    fails?: number;
+    verified?: boolean;
+    downloading?: boolean;
+    announcing?: boolean;
+    start_sent?: boolean;
+    complete_sent?: boolean;
+    last_error?: { category?: string; value?: string };
+  }>;
+  tracker_status?: string;
+  message?: string;
+  label?: string;
+  [key: string]: unknown;
+}
+
+interface DelugeJSONRPCResponse {
+  result?: unknown;
+  error?: { message?: string; code?: number } | null;
+  id?: number;
+}
+
+/**
+ * Deluge client implementation using the Web UI JSON-RPC API.
+ *
+ * @remarks
+ * - Communicates via JSON-RPC v1 to the /json endpoint
+ * - Authenticates with auth.login (password-only) using cookie-based sessions
+ * - Auto-connects to daemon hosts if not already connected
+ * - Supports magnet links, torrent file upload, and URL-based adds
+ * - Status mapping: Deluge state strings (Downloading, Seeding, Paused, etc.)
+ */
+export class DelugeClient implements DownloaderClient {
+  private downloader: Downloader;
+  private cookie: string | null = null;
+  private requestId = 0;
+
+  // Maximum ETA value to consider valid (100 days in seconds)
+  private static readonly MAX_VALID_ETA_SECONDS = 8640000;
+
+  constructor(downloader: Downloader) {
+    this.downloader = downloader;
+  }
+
+  private getBaseUrl(): string {
+    let baseUrl = this.downloader.url;
+    if (!baseUrl.startsWith("http://") && !baseUrl.startsWith("https://")) {
+      const protocol = this.downloader.useSsl ? "https://" : "http://";
+      baseUrl = protocol + baseUrl;
+    }
+
+    try {
+      const urlObj = new URL(baseUrl);
+      if (this.downloader.port) {
+        urlObj.port = this.downloader.port.toString();
+      }
+
+      if (this.downloader.urlPath) {
+        let path = this.downloader.urlPath;
+        if (!path.startsWith("/")) path = `/${path}`;
+        if (path.endsWith("/")) path = path.slice(0, -1);
+        urlObj.pathname = `${urlObj.pathname.replace(/\/$/, "")}${path}`;
+      }
+
+      return urlObj.toString().replace(/\/$/, "");
+    } catch {
+      return baseUrl.replace(/\/$/, "");
+    }
+  }
+
+  private getRpcUrl(): string {
+    const base = this.getBaseUrl();
+    // Deluge WebUI JSON-RPC is at /json
+    if (base.endsWith("/json")) return base;
+    return `${base}/json`;
+  }
+
+  private async authenticate(): Promise<void> {
+    if (this.cookie) return;
+
+    const password = this.downloader.password || "";
+    const response = await this.makeRequest("auth.login", [password]);
+
+    if (response.result !== true) {
+      throw new Error(
+        `Deluge authentication failed: ${response.result === false ? "Invalid password" : "Unexpected response"}`
+      );
+    }
+  }
+
+  private async ensureConnected(): Promise<void> {
+    const connectedResponse = await this.makeRequest("web.connected", []);
+    if (connectedResponse.result === true) return;
+
+    // Not connected — try to connect to the first available host
+    downloadersLogger.info(
+      { downloaderId: this.downloader.id },
+      "Deluge web UI not connected to daemon, auto-connecting"
+    );
+
+    const hostsResponse = await this.makeRequest("web.get_hosts", []);
+    const hosts = hostsResponse.result as Array<[string, string, number, string, string]> | undefined;
+
+    if (!hosts || hosts.length === 0) {
+      throw new Error("No Deluge daemon hosts configured in Web UI");
+    }
+
+    const [hostId] = hosts[0];
+    await this.makeRequest("web.connect", [hostId]);
+
+    // Verify connection
+    const verifyResponse = await this.makeRequest("web.connected", []);
+    if (verifyResponse.result !== true) {
+      throw new Error("Failed to connect Deluge Web UI to daemon");
+    }
+
+    downloadersLogger.info(
+      { downloaderId: this.downloader.id, hostId },
+      "Deluge auto-connected to daemon"
+    );
+  }
+
+  async testConnection(): Promise<{ success: boolean; message: string }> {
+    try {
+      await this.authenticate();
+      await this.ensureConnected();
+
+      // Get daemon version via core.get_libtorrent_version or just check a core call works
+      const versionResponse = await this.makeRequest("daemon.get_version", []);
+      const version =
+        typeof versionResponse.result === "string" ? versionResponse.result : undefined;
+
+      return {
+        success: true,
+        message: version
+          ? `Connected successfully to Deluge ${version}`
+          : "Connected successfully to Deluge",
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      return { success: false, message: `Failed to connect to Deluge: ${errorMessage}` };
+    }
+  }
+
+  async logVersionInfo(): Promise<void> {
+    try {
+      await this.authenticate();
+      await this.ensureConnected();
+      const versionResponse = await this.makeRequest("daemon.get_version", []);
+      const version =
+        typeof versionResponse.result === "string" ? versionResponse.result : undefined;
+
+      downloadersLogger.info(
+        {
+          downloaderId: this.downloader.id,
+          downloaderType: this.downloader.type,
+          version,
+        },
+        "Downloader version probe completed"
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      downloadersLogger.warn(
+        { downloaderId: this.downloader.id, downloaderType: this.downloader.type, error: errorMessage },
+        "Downloader version probe failed"
+      );
+    }
+  }
+
+  async addDownload(
+    request: DownloadRequest
+  ): Promise<{ success: boolean; id?: string; message: string }> {
+    try {
+      if (!request.url) {
+        return { success: false, message: "Download URL is required" };
+      }
+
+      await this.authenticate();
+      await this.ensureConnected();
+
+      const isMagnet = request.url.startsWith("magnet:");
+      const downloadPath = request.downloadPath || this.downloader.downloadPath;
+      const category = request.category || this.downloader.category;
+      const addPaused = this.downloader.addStopped ?? false;
+
+      const options: Record<string, unknown> = {};
+      if (downloadPath) {
+        options.download_location = downloadPath;
+      }
+      if (addPaused) {
+        options.add_paused = addPaused;
+      }
+
+      if (isMagnet) {
+        // Validate magnet hash for later verification
+        const hashFromUrl = extractHashFromUrl(request.url);
+
+        const response = await this.makeRequest("core.add_torrent_magnet", [
+          request.url,
+          options,
+        ]);
+
+        const result = response.result;
+        if (typeof result === "string" && result.length > 0) {
+          // result is the torrent ID (info hash)
+          return {
+            success: true,
+            id: result.toLowerCase(),
+            message: "Download added successfully",
+          };
+        }
+
+        if (result === null && hashFromUrl) {
+          // Could be a duplicate — verify by checking if torrent exists
+          const verifyResponse = await this.makeRequest("core.get_torrent_status", [
+            hashFromUrl,
+            ["name"],
+          ]);
+          if (verifyResponse.result && typeof verifyResponse.result === "object") {
+            return {
+              success: true,
+              id: hashFromUrl,
+              message: "Download already exists (Deluge)",
+            };
+          }
+        }
+
+        return {
+          success: false,
+          message: "Failed to add magnet link to Deluge",
+        };
+      }
+
+      // Non-magnet URL: download torrent file locally, then upload
+      if (!(await isSafeUrl(request.url))) {
+        return { success: false, message: `Unsafe URL blocked: ${request.url}` };
+      }
+
+      downloadersLogger.info({ url: request.url }, "Downloading torrent file for Deluge");
+
+      let torrentFileBuffer: Buffer;
+      let torrentFileName = "torrent.torrent";
+      let parsedInfoHash: string | null = null;
+
+      try {
+        const { response: torrentResponse, magnetLink } = await fetchWithMagnetDetection(
+          request.url
+        );
+
+        if (magnetLink) {
+          // Redirected to magnet — recurse
+          return this.addDownload({ ...request, url: magnetLink });
+        }
+
+        if (!torrentResponse || !torrentResponse.ok) {
+          const status = torrentResponse?.status || "unknown";
+          const statusText = torrentResponse?.statusText || "No response";
+          throw new Error(`Failed to download torrent: ${status} ${statusText}`);
+        }
+
+        const contentDisposition = torrentResponse.headers.get("content-disposition");
+        if (contentDisposition) {
+          const filenameMatch = contentDisposition.match(
+            /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/
+          );
+          if (filenameMatch && filenameMatch[1]) {
+            torrentFileName = filenameMatch[1].replace(/['"]/g, "").trim();
+          }
+        }
+
+        const arrayBuffer = await torrentResponse.arrayBuffer();
+        torrentFileBuffer = Buffer.from(arrayBuffer);
+
+        downloadersLogger.info(
+          { size: torrentFileBuffer.length, filename: torrentFileName },
+          "Successfully downloaded torrent file for Deluge"
+        );
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error";
+        downloadersLogger.error({ error: errorMessage, url: request.url }, "Failed to download torrent file");
+
+        // Fallback: try core.add_torrent_url (Deluge downloads the URL itself)
+        downloadersLogger.info({ url: request.url }, "Falling back to Deluge URL download");
+        const fallbackResponse = await this.makeRequest("core.add_torrent_url", [
+          request.url,
+          options,
+        ]);
+
+        const fallbackResult = fallbackResponse.result;
+        if (typeof fallbackResult === "string" && fallbackResult.length > 0) {
+          return {
+            success: true,
+            id: fallbackResult.toLowerCase(),
+            message: "Download added successfully (via URL)",
+          };
+        }
+        if (fallbackResult === null) {
+          // Could be duplicate or failure —Deluge returns null for existing torrents sometimes
+          const hashFromUrl = extractHashFromUrl(request.url);
+          if (hashFromUrl) {
+            const verifyResponse = await this.makeRequest("core.get_torrent_status", [
+              hashFromUrl,
+              ["name"],
+            ]);
+            if (verifyResponse.result && typeof verifyResponse.result === "object") {
+              return {
+                success: true,
+                id: hashFromUrl,
+                message: "Download already exists (Deluge)",
+              };
+            }
+          }
+        }
+
+        return {
+          success: false,
+          message: `Failed to add download: ${errorMessage}`,
+        };
+      }
+
+      // Upload torrent file via core.add_torrent_file
+      const fileDump = torrentFileBuffer.toString("base64");
+      const response = await this.makeRequest("core.add_torrent_file", [
+        torrentFileName,
+        fileDump,
+        options,
+      ]);
+
+      const result = response.result;
+      if (typeof result === "string" && result.length > 0) {
+        return {
+          success: true,
+          id: result.toLowerCase(),
+          message: "Download added successfully",
+        };
+      }
+
+      if (result === null) {
+        // Could be duplicate or failure
+        const hashFromUrl = extractHashFromUrl(request.url);
+        if (hashFromUrl) {
+          const verifyResponse = await this.makeRequest("core.get_torrent_status", [
+            hashFromUrl,
+            ["name"],
+          ]);
+          if (verifyResponse.result && typeof verifyResponse.result === "object") {
+            return {
+              success: true,
+              id: hashFromUrl,
+              message: "Download already exists (Deluge)",
+            };
+          }
+        }
+
+        // Try to find by the most recently added torrent
+        const recent = await this.findRecentlyAddedDownload();
+        if (recent) {
+          return {
+            success: true,
+            id: recent.hash,
+            message: "Download added successfully",
+          };
+        }
+      }
+
+      return {
+        success: false,
+        message: "Failed to add download to Deluge",
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      downloadersLogger.error({ error: errorMessage }, "Error adding download to Deluge");
+      return { success: false, message: `Failed to add download: ${errorMessage}` };
+    }
+  }
+
+  private async findRecentlyAddedDownload(): Promise<{ hash: string; name?: string } | null> {
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      const response = await this.makeRequest("core.get_torrents_status", [
+        {},
+        ["name", "time_added"],
+      ]);
+
+      const torrents = response.result as Record<string, { name?: string; time_added?: number }> | undefined;
+      if (!torrents || Object.keys(torrents).length === 0) return null;
+
+      const entries = Object.entries(torrents);
+      // Sort by time_added descending
+      entries.sort((a, b) => (b[1].time_added ?? 0) - (a[1].time_added ?? 0));
+
+      const [mostRecentHash, mostRecentStatus] = entries[0];
+      const now = Date.now() / 1000;
+      if (mostRecentStatus.time_added && now - mostRecentStatus.time_added < 10) {
+        return { hash: mostRecentHash.toLowerCase(), name: mostRecentStatus.name };
+      }
+
+      return null;
+    } catch (error) {
+      downloadersLogger.warn({ error }, "Failed to find recently added Deluge download");
+      return null;
+    }
+  }
+
+  async getDownloadStatus(id: string): Promise<DownloadStatus | null> {
+    try {
+      await this.authenticate();
+      await this.ensureConnected();
+
+      const response = await this.makeRequest("core.get_torrent_status", [
+        id,
+        [
+          "name",
+          "state",
+          "progress",
+          "download_payload_rate",
+          "upload_payload_rate",
+          "eta",
+          "total_size",
+          "all_time_download",
+          "ratio",
+          "num_peers",
+          "num_seeds",
+          "message",
+          "label",
+        ],
+      ]);
+
+      if (response.result && typeof response.result === "object") {
+        return this.mapDelugeStatus(id, response.result as DelugeTorrentStatus);
+      }
+
+      return null;
+    } catch (error) {
+      downloadersLogger.error({ error, id }, "Error getting download status from Deluge");
+      return null;
+    }
+  }
+
+  async getDownloadDetails(id: string): Promise<DownloadDetails | null> {
+    try {
+      await this.authenticate();
+      await this.ensureConnected();
+
+      const response = await this.makeRequest("core.get_torrent_status", [
+        id,
+        [
+          "name",
+          "state",
+          "progress",
+          "download_payload_rate",
+          "upload_payload_rate",
+          "eta",
+          "total_size",
+          "all_time_download",
+          "all_time_upload",
+          "ratio",
+          "num_peers",
+          "num_seeds",
+          "save_path",
+          "time_added",
+          "completed_time",
+          "files",
+          "file_priorities",
+          "file_progress",
+          "trackers",
+          "tracker_status",
+          "message",
+          "label",
+        ],
+      ]);
+
+      if (!response.result || typeof response.result !== "object") {
+        return null;
+      }
+
+      const status = response.result as DelugeTorrentStatus;
+      const baseStatus = this.mapDelugeStatus(id, status);
+
+      // Map files
+      const files: DownloadFile[] = [];
+      if (status.files && status.file_priorities && status.file_progress) {
+        for (let i = 0; i < status.files.length; i++) {
+          const file = status.files[i];
+          const priority = status.file_priorities[i] ?? 1;
+          const progress = status.file_progress[i] ?? 0;
+
+          let filePriority: DownloadFile["priority"] = "normal";
+          if (priority === 0) filePriority = "off";
+          else if (priority === 2) filePriority = "high";
+
+          files.push({
+            name: file.path,
+            size: file.size,
+            progress: Math.round(progress * 100),
+            priority: filePriority,
+            wanted: priority !== 0,
+          });
+        }
+      }
+
+      // Map trackers
+      const trackers: DownloadTracker[] = [];
+      if (status.trackers) {
+        for (const tracker of status.trackers) {
+          let trackerStatus: DownloadTracker["status"] = "inactive";
+          if (tracker.send_stats === false) {
+            trackerStatus = "inactive";
+          } else if (tracker.last_error && tracker.last_error.value) {
+            trackerStatus = "error";
+          } else if (tracker.fails && tracker.fails > 0) {
+            trackerStatus = "error";
+          } else if (tracker.verified) {
+            trackerStatus = "working";
+          } else {
+            trackerStatus = "updating";
+          }
+
+          trackers.push({
+            url: tracker.url,
+            tier: tracker.tier ?? 0,
+            status: trackerStatus,
+          });
+        }
+      }
+
+      return {
+        ...baseStatus,
+        hash: id,
+        downloadDir: status.save_path,
+        addedDate:
+          status.time_added && status.time_added > 0
+            ? new Date(status.time_added * 1000).toISOString()
+            : undefined,
+        completedDate:
+          status.completed_time && status.completed_time > 0
+            ? new Date(status.completed_time * 1000).toISOString()
+            : undefined,
+        files,
+        trackers,
+        totalPeers: status.num_peers,
+        connectedPeers: status.num_peers,
+      };
+    } catch (error) {
+      downloadersLogger.error({ error, id }, "Error getting download details from Deluge");
+      return null;
+    }
+  }
+
+  async getAllDownloads(): Promise<DownloadStatus[]> {
+    try {
+      await this.authenticate();
+      await this.ensureConnected();
+
+      const response = await this.makeRequest("core.get_torrents_status", [
+        {},
+        [
+          "name",
+          "state",
+          "progress",
+          "download_payload_rate",
+          "upload_payload_rate",
+          "eta",
+          "total_size",
+          "all_time_download",
+          "ratio",
+          "num_peers",
+          "num_seeds",
+          "message",
+          "label",
+        ],
+      ]);
+
+      const torrents = response.result as Record<string, DelugeTorrentStatus> | undefined;
+      if (!torrents) return [];
+
+      return Object.entries(torrents).map(([hash, status]) =>
+        this.mapDelugeStatus(hash, status)
+      );
+    } catch (error) {
+      downloadersLogger.error({ error }, "Error getting all downloads from Deluge");
+      return [];
+    }
+  }
+
+  async pauseDownload(id: string): Promise<{ success: boolean; message: string }> {
+    try {
+      await this.authenticate();
+      await this.ensureConnected();
+      await this.makeRequest("core.pause_torrent", [[id]]);
+      return { success: true, message: "Download paused successfully" };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      return { success: false, message: `Failed to pause download: ${errorMessage}` };
+    }
+  }
+
+  async resumeDownload(id: string): Promise<{ success: boolean; message: string }> {
+    try {
+      await this.authenticate();
+      await this.ensureConnected();
+      await this.makeRequest("core.resume_torrent", [[id]]);
+      return { success: true, message: "Download resumed successfully" };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      return { success: false, message: `Failed to resume download: ${errorMessage}` };
+    }
+  }
+
+  async removeDownload(
+    id: string,
+    deleteFiles = false
+  ): Promise<{ success: boolean; message: string }> {
+    try {
+      await this.authenticate();
+      await this.ensureConnected();
+      await this.makeRequest("core.remove_torrent", [id, deleteFiles]);
+      return { success: true, message: "Download removed successfully" };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "Unknown error";
+      return { success: false, message: `Failed to remove download: ${errorMessage}` };
+    }
+  }
+
+  async getFreeSpace(): Promise<number> {
+    try {
+      await this.authenticate();
+      await this.ensureConnected();
+
+      const path = this.downloader.downloadPath || "";
+      const response = await this.makeRequest("core.get_free_space", [path]);
+
+      if (typeof response.result === "number" && response.result >= 0) {
+        return response.result;
+      }
+
+      downloadersLogger.debug(
+        { result: response.result, path },
+        "Deluge free space returned unexpected value"
+      );
+      return 0;
+    } catch (error) {
+      downloadersLogger.error({ error }, "Error getting free space from Deluge");
+      return 0;
+    }
+  }
+
+  private mapDelugeStatus(hash: string, status: DelugeTorrentStatus): DownloadStatus {
+    // Deluge states: Downloading, Seeding, Paused, Checking, Queued, Error, Allocating, Moving
+    let downloadStatus: DownloadStatus["status"] = "paused";
+
+    switch (status.state) {
+      case "Downloading":
+      case "Checking":
+      case "Allocating":
+        downloadStatus = "downloading";
+        break;
+      case "Seeding":
+        downloadStatus = "seeding";
+        break;
+      case "Paused":
+        downloadStatus = "paused";
+        break;
+      case "Queued":
+        downloadStatus = "paused";
+        break;
+      case "Error":
+        downloadStatus = "error";
+        break;
+      case "Moving":
+        downloadStatus = "downloading";
+        break;
+      default:
+        downloadStatus = "paused";
+        if (status.state) {
+          downloadersLogger.warn(
+            { state: status.state, hash },
+            "Unknown Deluge state encountered"
+          );
+        }
+        break;
+    }
+
+    const progress = Math.round((status.progress ?? 0) * 100);
+
+    // Force completed/seeding based on progress
+    if (progress >= 100) {
+      if (downloadStatus === "downloading") {
+        downloadStatus = "seeding";
+      } else if (downloadStatus === "paused") {
+        downloadStatus = "completed";
+      }
+    }
+
+    // Override with error message
+    if (status.message && status.message.length > 0) {
+      downloadStatus = "error";
+    }
+
+    const eta = status.eta ?? undefined;
+
+    return {
+      id: hash.toLowerCase(),
+      name: status.name || "Unknown",
+      status: downloadStatus,
+      progress,
+      downloadSpeed: status.download_payload_rate ?? 0,
+      uploadSpeed: status.upload_payload_rate ?? 0,
+      eta:
+        typeof eta === "number" && eta > 0 && eta < DelugeClient.MAX_VALID_ETA_SECONDS
+          ? eta
+          : undefined,
+      size: status.total_size ?? 0,
+      downloaded: status.all_time_download ?? 0,
+      seeders: status.num_seeds ?? 0,
+      leechers: (status.num_peers ?? 0) - (status.num_seeds ?? 0),
+      ratio: status.ratio ?? 0,
+      error: status.message || undefined,
+      category: status.label || undefined,
+    };
+  }
+
+  private async makeRequest(method: string, params: unknown[]): Promise<DelugeJSONRPCResponse> {
+    const url = this.getRpcUrl();
+    this.requestId++;
+
+    const body: { method: string; params: unknown[]; id: number } = {
+      method,
+      params,
+      id: this.requestId,
+    };
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "User-Agent": "Questarr/1.0",
+    };
+
+    if (this.cookie) {
+      headers["Cookie"] = this.cookie;
+    }
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30000),
+    });
+
+    // Extract cookies from response for future requests
+    const setCookieHeader = response.headers.get("set-cookie");
+    if (setCookieHeader) {
+      const cookieMatch = setCookieHeader.match(/([^;]+)/);
+      if (cookieMatch) {
+        this.cookie = cookieMatch[1];
+      }
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "No error details available");
+      if (response.status === 401) {
+        downloadersLogger.error(
+          {
+            status: response.status,
+            url,
+            method,
+            errorText,
+          },
+          "Deluge authentication failed - check password"
+        );
+        throw new Error(
+          `Authentication failed: Invalid password for Deluge - ${errorText}`
+        );
+      }
+      throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
+    }
+
+    let data: DelugeJSONRPCResponse;
+    try {
+      data = (await response.json()) as DelugeJSONRPCResponse;
+    } catch {
+      throw new Error("Invalid JSON response from Deluge");
+    }
+
+    if (data.error) {
+      const errorMessage =
+        typeof data.error === "object" && data.error.message
+          ? data.error.message
+          : "Deluge RPC error";
+      throw new Error(`Deluge RPC error: ${errorMessage}`);
+    }
+
+    return data;
+  }
+}

--- a/server/downloaders/deluge.ts
+++ b/server/downloaders/deluge.ts
@@ -9,6 +9,7 @@ import { downloadersLogger } from "../logger.js";
 import { isSafeUrl } from "../ssrf.js";
 import type { DownloadRequest, DownloaderClient } from "./types.js";
 import { fetchWithMagnetDetection, extractHashFromUrl } from "./utils.js";
+import { z } from "zod";
 
 interface DelugeTorrentStatus {
   name?: string;
@@ -137,7 +138,9 @@ export class DelugeClient implements DownloaderClient {
     );
 
     const hostsResponse = await this.makeRequest("web.get_hosts", []);
-    const hosts = hostsResponse.result as Array<[string, string, number, string, string]> | undefined;
+    const hosts = hostsResponse.result as
+      | Array<[string, string, number, string, string]>
+      | undefined;
 
     if (!hosts || hosts.length === 0) {
       throw new Error("No Deluge daemon hosts configured in Web UI");
@@ -199,7 +202,11 @@ export class DelugeClient implements DownloaderClient {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
       downloadersLogger.warn(
-        { downloaderId: this.downloader.id, downloaderType: this.downloader.type, error: errorMessage },
+        {
+          downloaderId: this.downloader.id,
+          downloaderType: this.downloader.type,
+          error: errorMessage,
+        },
         "Downloader version probe failed"
       );
     }
@@ -219,6 +226,22 @@ export class DelugeClient implements DownloaderClient {
       const isMagnet = request.url.startsWith("magnet:");
       const downloadPath = request.downloadPath || this.downloader.downloadPath;
       const category = request.category || this.downloader.category;
+      const succeed = async (id: string, message: string) => {
+        if (category) {
+          try {
+            await this.makeRequest("label.add", [category]);
+          } catch {
+            // Label may already exist
+          }
+          try {
+            await this.makeRequest("label.set_torrent", [id, category]);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : "Unknown error";
+            downloadersLogger.warn({ id, category, error: msg }, "Failed to apply Deluge label");
+          }
+        }
+        return { success: true as const, id, message };
+      };
       const addPaused = this.downloader.addStopped ?? false;
 
       const options: Record<string, unknown> = {};
@@ -233,19 +256,12 @@ export class DelugeClient implements DownloaderClient {
         // Validate magnet hash for later verification
         const hashFromUrl = extractHashFromUrl(request.url);
 
-        const response = await this.makeRequest("core.add_torrent_magnet", [
-          request.url,
-          options,
-        ]);
+        const response = await this.makeRequest("core.add_torrent_magnet", [request.url, options]);
 
         const result = response.result;
         if (typeof result === "string" && result.length > 0) {
           // result is the torrent ID (info hash)
-          return {
-            success: true,
-            id: result.toLowerCase(),
-            message: "Download added successfully",
-          };
+          return succeed(result.toLowerCase(), "Download added successfully");
         }
 
         if (result === null && hashFromUrl) {
@@ -255,11 +271,7 @@ export class DelugeClient implements DownloaderClient {
             ["name"],
           ]);
           if (verifyResponse.result && typeof verifyResponse.result === "object") {
-            return {
-              success: true,
-              id: hashFromUrl,
-              message: "Download already exists (Deluge)",
-            };
+            return succeed(hashFromUrl, "Download already exists (Deluge)");
           }
         }
 
@@ -278,7 +290,7 @@ export class DelugeClient implements DownloaderClient {
 
       let torrentFileBuffer: Buffer;
       let torrentFileName = "torrent.torrent";
-      let parsedInfoHash: string | null = null;
+      const parsedInfoHash: string | null = null;
 
       try {
         const { response: torrentResponse, magnetLink } = await fetchWithMagnetDetection(
@@ -298,9 +310,7 @@ export class DelugeClient implements DownloaderClient {
 
         const contentDisposition = torrentResponse.headers.get("content-disposition");
         if (contentDisposition) {
-          const filenameMatch = contentDisposition.match(
-            /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/
-          );
+          const filenameMatch = contentDisposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
           if (filenameMatch && filenameMatch[1]) {
             torrentFileName = filenameMatch[1].replace(/['"]/g, "").trim();
           }
@@ -315,7 +325,10 @@ export class DelugeClient implements DownloaderClient {
         );
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : "Unknown error";
-        downloadersLogger.error({ error: errorMessage, url: request.url }, "Failed to download torrent file");
+        downloadersLogger.error(
+          { error: errorMessage, url: request.url },
+          "Failed to download torrent file"
+        );
 
         // Fallback: try core.add_torrent_url (Deluge downloads the URL itself)
         downloadersLogger.info({ url: request.url }, "Falling back to Deluge URL download");
@@ -326,11 +339,7 @@ export class DelugeClient implements DownloaderClient {
 
         const fallbackResult = fallbackResponse.result;
         if (typeof fallbackResult === "string" && fallbackResult.length > 0) {
-          return {
-            success: true,
-            id: fallbackResult.toLowerCase(),
-            message: "Download added successfully (via URL)",
-          };
+          return succeed(fallbackResult.toLowerCase(), "Download added successfully (via URL)");
         }
         if (fallbackResult === null) {
           // Could be duplicate or failure —Deluge returns null for existing torrents sometimes
@@ -341,11 +350,7 @@ export class DelugeClient implements DownloaderClient {
               ["name"],
             ]);
             if (verifyResponse.result && typeof verifyResponse.result === "object") {
-              return {
-                success: true,
-                id: hashFromUrl,
-                message: "Download already exists (Deluge)",
-              };
+              return succeed(hashFromUrl, "Download already exists (Deluge)");
             }
           }
         }
@@ -366,11 +371,7 @@ export class DelugeClient implements DownloaderClient {
 
       const result = response.result;
       if (typeof result === "string" && result.length > 0) {
-        return {
-          success: true,
-          id: result.toLowerCase(),
-          message: "Download added successfully",
-        };
+        return succeed(result.toLowerCase(), "Download added successfully");
       }
 
       if (result === null) {
@@ -382,22 +383,14 @@ export class DelugeClient implements DownloaderClient {
             ["name"],
           ]);
           if (verifyResponse.result && typeof verifyResponse.result === "object") {
-            return {
-              success: true,
-              id: hashFromUrl,
-              message: "Download already exists (Deluge)",
-            };
+            return succeed(hashFromUrl, "Download already exists (Deluge)");
           }
         }
 
         // Try to find by the most recently added torrent
         const recent = await this.findRecentlyAddedDownload();
         if (recent) {
-          return {
-            success: true,
-            id: recent.hash,
-            message: "Download added successfully",
-          };
+          return succeed(recent.hash, "Download added successfully");
         }
       }
 
@@ -421,7 +414,9 @@ export class DelugeClient implements DownloaderClient {
         ["name", "time_added"],
       ]);
 
-      const torrents = response.result as Record<string, { name?: string; time_added?: number }> | undefined;
+      const torrents = response.result as
+        | Record<string, { name?: string; time_added?: number }>
+        | undefined;
       if (!torrents || Object.keys(torrents).length === 0) return null;
 
       const entries = Object.entries(torrents);
@@ -518,11 +513,13 @@ export class DelugeClient implements DownloaderClient {
 
       // Map files
       const files: DownloadFile[] = [];
-      if (status.files && status.file_priorities && status.file_progress) {
+      if (status.files) {
+        const filePriorities = status.file_priorities || [];
+        const fileProgresses = status.file_progress || [];
         for (let i = 0; i < status.files.length; i++) {
           const file = status.files[i];
-          const priority = status.file_priorities[i] ?? 1;
-          const progress = status.file_progress[i] ?? 0;
+          const priority = filePriorities[i] ?? 1;
+          const progress = fileProgresses[i] ?? 0;
 
           let filePriority: DownloadFile["priority"] = "normal";
           if (priority === 0) filePriority = "off";
@@ -613,9 +610,7 @@ export class DelugeClient implements DownloaderClient {
       const torrents = response.result as Record<string, DelugeTorrentStatus> | undefined;
       if (!torrents) return [];
 
-      return Object.entries(torrents).map(([hash, status]) =>
-        this.mapDelugeStatus(hash, status)
-      );
+      return Object.entries(torrents).map(([hash, status]) => this.mapDelugeStatus(hash, status));
     } catch (error) {
       downloadersLogger.error({ error }, "Error getting all downloads from Deluge");
       return [];
@@ -712,15 +707,12 @@ export class DelugeClient implements DownloaderClient {
       default:
         downloadStatus = "paused";
         if (status.state) {
-          downloadersLogger.warn(
-            { state: status.state, hash },
-            "Unknown Deluge state encountered"
-          );
+          downloadersLogger.warn({ state: status.state, hash }, "Unknown Deluge state encountered");
         }
         break;
     }
 
-    const progress = Math.round((status.progress ?? 0) * 100);
+    const progress = Math.round(status.progress ?? 0);
 
     // Force completed/seeding based on progress
     if (progress >= 100) {
@@ -788,7 +780,8 @@ export class DelugeClient implements DownloaderClient {
     // Extract cookies from response for future requests
     const setCookieHeader = response.headers.get("set-cookie");
     if (setCookieHeader) {
-      const cookieMatch = setCookieHeader.match(/([^;]+)/);
+      const cookieMatch =
+        setCookieHeader.match(/(_session_id=[^;]+)/) ?? setCookieHeader.match(/([^;]+)/);
       if (cookieMatch) {
         this.cookie = cookieMatch[1];
       }
@@ -806,16 +799,24 @@ export class DelugeClient implements DownloaderClient {
           },
           "Deluge authentication failed - check password"
         );
-        throw new Error(
-          `Authentication failed: Invalid password for Deluge - ${errorText}`
-        );
+        throw new Error(`Authentication failed: Invalid password for Deluge - ${errorText}`);
       }
       throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
     }
 
+    const delugeResponseSchema = z.object({
+      result: z.unknown().optional(),
+      error: z
+        .object({ message: z.string().optional(), code: z.number().optional() })
+        .nullable()
+        .optional(),
+      id: z.number().optional(),
+    });
+
     let data: DelugeJSONRPCResponse;
     try {
-      data = (await response.json()) as DelugeJSONRPCResponse;
+      const raw = await response.json();
+      data = delugeResponseSchema.parse(raw);
     } catch {
       throw new Error("Invalid JSON response from Deluge");
     }

--- a/server/downloaders/deluge.ts
+++ b/server/downloaders/deluge.ts
@@ -620,7 +620,7 @@ export class DelugeClient implements DownloaderClient {
     try {
       await this.authenticate();
       await this.ensureConnected();
-      await this.makeRequest("core.pause_torrent", [[id]]);
+      await this.makeRequest("core.pause_torrent", [id]);
       return { success: true, message: "Download paused successfully" };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
@@ -632,7 +632,7 @@ export class DelugeClient implements DownloaderClient {
     try {
       await this.authenticate();
       await this.ensureConnected();
-      await this.makeRequest("core.resume_torrent", [[id]]);
+      await this.makeRequest("core.resume_torrent", [id]);
       return { success: true, message: "Download resumed successfully" };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Unknown error";

--- a/server/downloaders/index.ts
+++ b/server/downloaders/index.ts
@@ -6,3 +6,4 @@ export { QBittorrentClient } from "./qbittorrent.js";
 export { SABnzbdClient } from "./sabnzbd.js";
 export { NZBGetClient } from "./nzbget.js";
 export { SynologyDownloadStationClient } from "./synology.js";
+export { DelugeClient } from "./deluge.js";

--- a/server/downloaders/manager.ts
+++ b/server/downloaders/manager.ts
@@ -13,6 +13,7 @@ import { QBittorrentClient } from "./qbittorrent.js";
 import { SABnzbdClient } from "./sabnzbd.js";
 import { NZBGetClient } from "./nzbget.js";
 import { SynologyDownloadStationClient } from "./synology.js";
+import { DelugeClient } from "./deluge.js";
 
 // To add a new downloader:
 // 1. Create server/downloaders/mynewclient.ts — implement DownloaderClient from ./types.js
@@ -36,6 +37,8 @@ export class DownloaderManager {
         return new NZBGetClient(downloader);
       case "synology":
         return new SynologyDownloadStationClient(downloader);
+      case "deluge":
+        return new DelugeClient(downloader);
       default:
         throw new Error(`Unsupported downloader type: ${downloader.type}`);
     }

--- a/shared/downloader-types.ts
+++ b/shared/downloader-types.ts
@@ -5,6 +5,7 @@ export const TORRENT_DOWNLOADER_TYPES = [
   "rtorrent",
   "qbittorrent",
   "synology",
+  "deluge",
 ] as const;
 
 export function isUsenetDownloaderType(type: string): boolean {


### PR DESCRIPTION
Rebased and conflict-resolved continuation of #657 — adds Deluge Web UI JSON-RPC as a new download client.

## What's included

- **`server/downloaders/deluge.ts`** — Full `DelugeClient` implementation:
  - Magnet link support via `core.add_torrent_magnet`
  - Torrent file upload via `core.add_torrent_file` (with `core.add_torrent_url` fallback)
  - Auto-connection to Deluge daemon hosts (`web.get_hosts` / `web.connect`)
  - Full status mapping: Downloading, Seeding, Paused, Queued, Error, Allocating, Moving
  - Cookie session reuse (`_session_id`-first extraction)
  - Label support via `label.add_torrent` / `label.set_torrent`
  - Free space checking
  - Zod-validated JSON-RPC responses
- **`client/src/pages/downloaders.tsx`** — Adds Deluge to the downloader type list (default port 8112)
- **`server/downloaders/index.ts`** / **`manager.ts`** — Deluge registered and instantiated
- **`shared/downloader-types.ts`** — `"deluge"` added to the allowed downloader type enum
- **57 tests** across two test files (`downloaders_deluge.test.ts`, `downloaders_deluge_remaining.test.ts`)

## Differences from #657

This branch is a clean rebase onto the current tip of `release/1.4.0`, resolving the conflicts that made #657 unmergeable. All review feedback from #657 was already addressed in the original commits:

- Progress percentage not double-multiplied (`mapDelugeStatus` uses `Math.round(progress)` directly)
- `file_priorities` / `file_progress` default to `[]` when missing
- Cookie extraction prioritises `_session_id` before falling back to the first cookie
- API responses validated with Zod

Closes #568

---

_Generated by [Claude Code](https://claude.ai/code/session_01HodxCHeDrnWTn47mQzCA64)_