### PR TITLE
fix(ssrf): harden outbound fetches with DNS rebinding protection

### DIFF
--- a/server/__tests__/downloaders_helpers_regression.test.ts
+++ b/server/__tests__/downloaders_helpers_regression.test.ts
@@ -11,6 +11,12 @@ import { SABnzbdClient } from "../downloaders/sabnzbd.js";
 import { SynologyDownloadStationClient } from "../downloaders/synology.js";
 import { TransmissionClient } from "../downloaders/transmission.js";
 
+vi.mock("dns/promises", () => ({
+  default: {
+    lookup: vi.fn().mockResolvedValue([{ address: "127.0.0.1", family: 4 }]),
+  },
+}));
+
 vi.mock("../logger.js", () => ({
   downloadersLogger: {
     debug: vi.fn(),

--- a/server/__tests__/downloaders_sabnzbd_remaining.test.ts
+++ b/server/__tests__/downloaders_sabnzbd_remaining.test.ts
@@ -25,6 +25,7 @@ vi.mock("../logger.js", () => ({
 vi.mock("../ssrf.js", () => ({
   isSafeUrl: vi.fn().mockResolvedValue(true),
   safeFetch: safeFetchMock,
+  resolveSafeAddress: vi.fn().mockResolvedValue({ address: "127.0.0.1", family: 4 }),
 }));
 
 global.fetch = fetchMock as unknown as typeof fetch;

--- a/server/__tests__/downloaders_ssl_fallback.test.ts
+++ b/server/__tests__/downloaders_ssl_fallback.test.ts
@@ -1,0 +1,115 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage } from "http";
+import https, { type RequestOptions } from "https";
+import dns from "dns/promises";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Downloader } from "../../shared/schema";
+import { SABnzbdClient } from "../downloaders.js";
+import * as ssrf from "../ssrf.js";
+
+vi.mock("../logger.js", () => ({
+  downloadersLogger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("dns/promises", () => ({
+  default: {
+    lookup: vi.fn(),
+  },
+}));
+
+function createMockDownloader(overrides: Partial<Downloader> = {}): Downloader {
+  const timestamp = new Date("2024-01-01T00:00:00.000Z");
+
+  return {
+    id: "sab-ssl",
+    name: "Test SAB",
+    type: "sabnzbd",
+    url: "sab.local",
+    enabled: true,
+    priority: 1,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    port: 8080,
+    useSsl: true,
+    urlPath: null,
+    username: "api-key",
+    password: "secret",
+    category: null,
+    downloadPath: "/downloads",
+    label: "test",
+    addStopped: false,
+    removeCompleted: false,
+    postImportCategory: null,
+    settings: null,
+    ...overrides,
+  };
+}
+
+describe("SABnzbdClient SSL fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("pins the resolved IP when retrying an insecure SABnzbd request", async () => {
+    vi.spyOn(ssrf, "safeFetch").mockRejectedValueOnce(
+      Object.assign(new Error("self-signed certificate"), {
+        cause: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" },
+      })
+    );
+
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
+      { address: "127.0.0.1", family: 4 },
+    ]);
+
+    vi.spyOn(https, "request").mockImplementation(((...args: unknown[]) => {
+      const [requestUrl, requestOptions, requestCallback] = args as [
+        string,
+        RequestOptions,
+        (response: IncomingMessage) => void,
+      ];
+
+      expect(requestUrl).toBe("https://127.0.0.1:8080/api?apikey=api-key&mode=version&output=json");
+      expect(requestOptions.rejectUnauthorized).toBe(false);
+      expect(requestOptions.headers).toMatchObject({
+        host: "sab.local",
+      });
+
+      const request = new EventEmitter() as EventEmitter & {
+        destroy: () => void;
+        end: () => void;
+        on: EventEmitter["on"];
+        write: (chunk: Buffer | string) => void;
+      };
+
+      request.destroy = vi.fn();
+      request.write = vi.fn();
+      request.end = () => {
+        const response = new EventEmitter() as IncomingMessage;
+        Object.assign(response, {
+          headers: { "content-type": "application/json" },
+          statusCode: 200,
+          statusMessage: "OK",
+        });
+
+        requestCallback(response);
+        response.emit("data", Buffer.from(JSON.stringify({ version: "4.5.0" })));
+        response.emit("end");
+      };
+
+      return request as unknown as ReturnType<typeof https.request>;
+    }) as typeof https.request);
+
+    const client = new SABnzbdClient(createMockDownloader());
+    const result = await client.testConnection();
+
+    expect(result).toEqual({
+      success: true,
+      message: "Connected to SABnzbd v4.5.0",
+    });
+  });
+});

--- a/server/__tests__/downloaders_ssl_fallback.test.ts
+++ b/server/__tests__/downloaders_ssl_fallback.test.ts
@@ -76,7 +76,7 @@ describe("SABnzbdClient SSL fallback", () => {
       expect(requestUrl).toBe("https://127.0.0.1:8080/api?apikey=api-key&mode=version&output=json");
       expect(requestOptions.rejectUnauthorized).toBe(false);
       expect(requestOptions.headers).toMatchObject({
-        host: "sab.local",
+        host: "sab.local:8080",
       });
 
       const request = new EventEmitter() as EventEmitter & {

--- a/server/__tests__/ssrf.test.ts
+++ b/server/__tests__/ssrf.test.ts
@@ -242,6 +242,6 @@ describe("safeFetch", () => {
     );
 
     const calledHeaders = (fetch as Mock).mock.calls[0][1].headers as Headers;
-    expect(calledHeaders.get("Host")).toBe("[::1]");
+    expect(calledHeaders.get("Host")).toBe("[::1]:8080");
   });
 });

--- a/server/__tests__/ssrf.test.ts
+++ b/server/__tests__/ssrf.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
-import { isSafeUrl, safeFetch } from "../ssrf";
+import { isSafeUrl, safeFetch, resolveSafeAddress } from "../ssrf";
 import dns from "dns/promises";
 
 // Mock dns module
@@ -243,5 +243,54 @@ describe("safeFetch", () => {
 
     const calledHeaders = (fetch as Mock).mock.calls[0][1].headers as Headers;
     expect(calledHeaders.get("Host")).toBe("[::1]:8080");
+  });
+});
+
+describe("resolveSafeAddress", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns address and family for a safe IP", async () => {
+    const result = await resolveSafeAddress("192.168.1.1");
+    expect(result).toEqual({ address: "192.168.1.1", family: 4 });
+  });
+
+  it("strips IPv6 brackets and returns the bare address", async () => {
+    const result = await resolveSafeAddress("[::1]");
+    expect(result).toEqual({ address: "::1", family: 6 });
+  });
+
+  it("throws for an unsafe IP (link-local) passed directly", async () => {
+    await expect(resolveSafeAddress("169.254.169.254")).rejects.toThrow("Invalid or unsafe URL");
+  });
+
+  it("resolves a hostname and returns the first address", async () => {
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
+      { address: "1.2.3.4", family: 4 },
+    ]);
+    const result = await resolveSafeAddress("example.com");
+    expect(result).toEqual({ address: "1.2.3.4", family: 4 });
+  });
+
+  it("throws when DNS returns an empty address list", async () => {
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce(
+      []
+    );
+    await expect(resolveSafeAddress("empty.example.com")).rejects.toThrow("Invalid or unsafe URL");
+  });
+
+  it("throws when a resolved address is unsafe", async () => {
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
+      { address: "169.254.169.254", family: 4 },
+    ]);
+    await expect(resolveSafeAddress("evil.example.com")).rejects.toThrow("Invalid or unsafe URL");
+  });
+
+  it("throws a descriptive error when DNS resolution fails", async () => {
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockRejectedValueOnce(
+      new Error("ENOTFOUND")
+    );
+    await expect(resolveSafeAddress("no-such-host.example.com")).rejects.toThrow(
+      "Failed to resolve hostname: no-such-host.example.com"
+    );
   });
 });

--- a/server/__tests__/ssrf.test.ts
+++ b/server/__tests__/ssrf.test.ts
@@ -220,4 +220,28 @@ describe("safeFetch", () => {
     );
     await expect(safeFetch("http://empty-dns.com")).rejects.toThrow("Invalid or unsafe URL");
   });
+
+  it("should allow bracketed IPv6 literals for HTTPS", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("ok"));
+
+    await safeFetch("https://[::1]:8080/api");
+
+    expect(fetch).toHaveBeenCalledWith("https://[::1]:8080/api", expect.any(Object));
+  });
+
+  it("should allow bracketed IPv6 literals for HTTP and preserve the Host header", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("ok"));
+
+    await safeFetch("http://[::1]:8080/api");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://[::1]:8080/api",
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      })
+    );
+
+    const calledHeaders = (fetch as Mock).mock.calls[0][1].headers as Headers;
+    expect(calledHeaders.get("Host")).toBe("[::1]");
+  });
 });

--- a/server/downloaders/sabnzbd.ts
+++ b/server/downloaders/sabnzbd.ts
@@ -1,7 +1,7 @@
 import type { Downloader, DownloadStatus, DownloadDetails } from "../../shared/schema.js";
 import { downloadersLogger } from "../logger.js";
 import https from "https";
-import { isSafeUrl, safeFetch } from "../ssrf.js";
+import { isSafeUrl, resolveSafeAddress, safeFetch } from "../ssrf.js";
 import type { DownloadRequest, DownloaderClient } from "./types.js";
 import { fixNzbUrlEncoding } from "./utils.js";
 
@@ -103,7 +103,7 @@ export class SABnzbdClient implements DownloaderClient {
 
   private async fetchWithFallback(url: string, options: RequestInit = {}): Promise<Response> {
     try {
-      return await fetch(url, options);
+      return await safeFetch(url, { ...options, allowPrivate: true });
     } catch (error) {
       const isSslError =
         error instanceof Error &&
@@ -124,13 +124,21 @@ export class SABnzbdClient implements DownloaderClient {
     }
   }
 
-  private fetchInsecure(url: string, options: RequestInit): Promise<Response> {
+  private async fetchInsecure(url: string, options: RequestInit): Promise<Response> {
+    const parsedUrl = new URL(url);
+    const { address, family } = await resolveSafeAddress(parsedUrl.hostname, true);
+    const safeUrl = new URL(url);
+    safeUrl.hostname = family === 6 ? `[${address}]` : address;
+
+    const headers = new Headers(options.headers || {});
+    headers.set("Host", parsedUrl.hostname);
+
     return new Promise((resolve, reject) => {
       const req = https.request(
-        url,
+        safeUrl.toString(),
         {
           method: options.method || "GET",
-          headers: options.headers as unknown as import("http").OutgoingHttpHeaders,
+          headers: Object.fromEntries(headers.entries()) as import("http").OutgoingHttpHeaders,
           rejectUnauthorized: false,
           timeout: 30000,
         },

--- a/server/downloaders/sabnzbd.ts
+++ b/server/downloaders/sabnzbd.ts
@@ -131,7 +131,7 @@ export class SABnzbdClient implements DownloaderClient {
     safeUrl.hostname = family === 6 ? `[${address}]` : address;
 
     const headers = new Headers(options.headers || {});
-    headers.set("Host", parsedUrl.hostname);
+    headers.set("Host", parsedUrl.host);
 
     return new Promise((resolve, reject) => {
       const req = https.request(

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -5,6 +5,7 @@ import { storage } from "./storage.js";
 import { db } from "./db.js";
 import { userSettings } from "../shared/schema.js";
 import { logger } from "./logger.js";
+import { safeFetch } from "./ssrf.js";
 
 // Configuration constants for search limits
 const MAX_SEARCH_ATTEMPTS = 5;
@@ -220,7 +221,7 @@ class IGDBClient {
       throw new Error("IGDB credentials not configured");
     }
 
-    const response = await fetch(
+    const response = await safeFetch(
       `https://id.twitch.tv/oauth2/token?client_id=${clientId}&client_secret=${clientSecret}&grant_type=client_credentials`,
       {
         method: "POST",
@@ -251,7 +252,7 @@ class IGDBClient {
 
     let attempt = 0;
     while (true) {
-      const response = await fetch(`https://api.igdb.com/v4/${endpoint}`, {
+      const response = await safeFetch(`https://api.igdb.com/v4/${endpoint}`, {
         method: "POST",
         headers: {
           Accept: "application/json",

--- a/server/ssrf.ts
+++ b/server/ssrf.ts
@@ -165,8 +165,8 @@ async function fetchValidatedOnce(
   safeUrl.hostname = target.family === 6 ? `[${target.address}]` : target.address;
 
   const headers = new Headers(fetchOptions.headers ?? {});
-  // Use url.hostname (not normalized) to preserve IPv6 brackets in the Host header per RFC 7230
-  headers.set("Host", url.hostname);
+  // Use url.host (not normalized) to preserve IPv6 brackets and include non-default port per RFC 7230
+  headers.set("Host", url.host);
 
   return fetch(safeUrl.toString(), {
     ...fetchOptions,

--- a/server/ssrf.ts
+++ b/server/ssrf.ts
@@ -17,11 +17,47 @@ interface SafeFetchTarget {
   isHttps: boolean;
 }
 
-function normalizeHostname(hostname: string): string {
+export function normalizeHostname(hostname: string): string {
   if (hostname.startsWith("[") && hostname.endsWith("]")) {
     return hostname.slice(1, -1);
   }
   return hostname;
+}
+
+export async function resolveSafeAddress(
+  hostname: string,
+  allowPrivate = true
+): Promise<{ address: string; family: 4 | 6 }> {
+  const normalizedHostname = normalizeHostname(hostname);
+  const ipVersion = isIP(normalizedHostname);
+
+  if (ipVersion !== 0) {
+    if (!isSafeIp(normalizedHostname, allowPrivate)) {
+      throw new Error("Invalid or unsafe URL");
+    }
+    return { address: normalizedHostname, family: ipVersion as 4 | 6 };
+  }
+
+  try {
+    const addresses = await dns.lookup(normalizedHostname, { all: true });
+    if (!addresses || addresses.length === 0) {
+      throw new Error("Invalid or unsafe URL");
+    }
+    for (const { address } of addresses) {
+      if (!isSafeIp(address, allowPrivate)) {
+        throw new Error("Invalid or unsafe URL");
+      }
+    }
+    return {
+      address: addresses[0].address,
+      family: addresses[0].family as 4 | 6,
+    };
+  } catch (error) {
+    if (error instanceof Error && error.message === "Invalid or unsafe URL") {
+      throw error;
+    }
+    throw new Error(`Failed to resolve hostname: ${normalizedHostname}`);
+  }
 }
 
 function buildFetchSignal(
@@ -129,7 +165,8 @@ async function fetchValidatedOnce(
   safeUrl.hostname = target.family === 6 ? `[${target.address}]` : target.address;
 
   const headers = new Headers(fetchOptions.headers ?? {});
-  headers.set("Host", target.hostname);
+  // Use url.hostname (not normalized) to preserve IPv6 brackets in the Host header per RFC 7230
+  headers.set("Host", url.hostname);
 
   return fetch(safeUrl.toString(), {
     ...fetchOptions,


### PR DESCRIPTION
## Summary

Surgical backport of the network hardening from #642 — only the SSRF-related changes, none of the feature work.

- **`server/ssrf.ts`** — Export `normalizeHostname` and add `resolveSafeAddress` as a public helper so download clients can resolve and pin target IPs independently. Fix the `Host` header in `fetchValidatedOnce` to preserve IPv6 brackets (`[::1]`) per RFC 7230 (this was a bug in the existing code).
- **`server/downloaders/sabnzbd.ts`** — Route `fetchWithFallback` through `safeFetch` (with `allowPrivate: true`) instead of raw `fetch`. In `fetchInsecure`, resolve the hostname via `resolveSafeAddress` and pin the request to the resolved IP to prevent DNS rebinding on the self-signed SSL fallback path.
- **`server/igdb.ts`** — Switch the Twitch OAuth and IGDB API calls from global `fetch` to `safeFetch`, so all server-initiated outbound requests are DNS-validated.

Private IPs remain allowed throughout (`allowPrivate: true`), so local download clients (192.168.x.x, 10.x.x.x, localhost) are not affected.

## What's NOT included (vs #642)

- Synology Download Station client
- Game notes feature
- Logs streaming page
- Apprise notifications
- HLTB removal
- Mobile navigation
- UI component changes

## Test plan

- [x] `server/__tests__/ssrf.test.ts` — added IPv6 bracket tests (HTTPS and HTTP + Host header)
- [x] `server/__tests__/downloaders_ssl_fallback.test.ts` — new: verifies IP pinning in SABnzbd SSL fallback
- [x] `server/__tests__/downloaders_sabnzbd_remaining.test.ts` — updated mock to include `resolveSafeAddress`
- [x] `server/__tests__/downloaders_helpers_regression.test.ts` — added `dns/promises` mock for `safeFetch` path
- [x] Full server test suite: 76 files, 1036 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcGHAxzf32unDigPLP96TX

---

_Generated by [Claude Code](https://claude.ai/code/session_01AcGHAxzf32unDigPLP96TX)_