### PR TITLE
[QSTR-222] Fix Synology DS2 task creation error 120

### DIFF
--- a/docs/synology-download-station-api-notes.md
+++ b/docs/synology-download-station-api-notes.md
@@ -98,16 +98,50 @@ be the **last** parameter in the body — our client honors this for both versio
   use version 3. Prowlarr's proxy does the same version split; the reason isn't documented
   anywhere, just replicated.
 
-### Ordering is not guaranteed to survive a session-timeout retry
+### Ordering is fixed on a session-timeout retry
 
 `requestApi` retries once on error 106 (session expired) by re-authenticating and re-calling
-itself with the same `options` object — including the same `FormData` instance passed in by
-`addFileUpload`. Because `appendApiParams`/`appendFileLast` mutate that FormData in place rather
-than rebuilding it, a retry re-appends `api`/`version`/`method`/etc. a second time and appends the
-file field twice, so it's no longer strictly last. This is a pre-existing pattern (the pre-refactor
-code had the same same-object retry behavior), and a 106 landing mid-upload is rare, but it does mean the
-"file must be last" guarantee only holds on the first attempt. Rebuilding the FormData from scratch
-on retry would close this if it turns out to matter in practice.
+itself with the same `options` object. Previously this reused the same `FormData` instance passed
+in by `addFileUpload`, which `appendApiParams`/`appendFileLast` had already mutated in place — a
+retry would re-append `api`/`version`/`method`/etc. a second time and append the file field twice,
+so it was no longer strictly last. The retry path now rebuilds a fresh `FormData` before recursing
+whenever `options.body instanceof FormData`; `appendFileLast` is a closure over the file bytes, not
+over the FormData's prior state, so re-running it against a fresh instance is safe and restores the
+"file must be last" guarantee on retry too.
+
+## Missing `destination` causes an opaque error 120 on DS2 create
+
+A user report showed all three DS2 create-task variants above failing identically with Synology
+error 120. Log analysis of the actual request params showed **none of the three attempts included
+a `destination` field at all** — `getSynologyDestination()` only checked `request.downloadPath` and
+the downloader's configured `downloadPath`, both empty for that downloader, so `destination` was
+omitted entirely rather than falling back to anything. Community reports (a SickChill issue, a
+Prowlarr issue) show this exact shape of error 120 is Synology's generic parameter-validation
+rejection, and a missing required `destination` — with no NAS-side default configured — is a
+documented real-world cause.
+
+**Important:** this incident is not evidence about which of the three DS2 variants above is
+correct — all three failed for the identical missing-destination reason, so it can't discriminate
+between them. That question (which variant a real device actually accepts) is still open, pending a
+real-device retest with a destination present.
+
+Prowlarr's own proxy (`GetDownloadDirectory()` → `GetDefaultDir()`) doesn't stop at "no configured
+path" either — it queries the NAS's own Download Station default destination via
+`SYNO.DownloadStation.Info` `getconfig` before giving up. Our client now does the same:
+
+1. `request.downloadPath` (per-request override), then
+2. `this.downloader.downloadPath` (this downloader's configured path), then
+3. `getNasDefaultDestination()` — `SYNO.DownloadStation.Info.getconfig`'s `default_destination`,
+   cached for the life of the client instance (added to the `ensureApiInfo` API descriptor query).
+
+If none of the three resolve, `addDownload` now fails fast with an actionable
+`success: false` message instead of sending a request Synology will reject with an opaque code.
+
+Additionally, `SynologyErrorResponse` now captures the optional field-level `errors` array
+Synology returns for validation failures (`{ name, reason }` per field — e.g. `destination:
+required`), and `buildSynologyErrorMessage` surfaces that detail when present, plus has an explicit
+`case 120` fallback message when it isn't. This makes future validation failures self-diagnosing
+from the logged error alone, rather than requiring another round of log archaeology.
 
 ## Superseded approaches (kept for fallback reference)
 

--- a/docs/synology-download-station-api-notes.md
+++ b/docs/synology-download-station-api-notes.md
@@ -15,15 +15,54 @@ Source: [`DownloadStationTaskProxyV2.cs`](https://github.com/Prowlarr/Prowlarr/b
 its shape is trusted over our own guesses — but it has not been tested against a real Synology
 device from inside this codebase. If a user reports error 101/120 again, re-check this first.
 
-### Add by URL/magnet — both API versions
+### Add by URL/magnet — v1 (legacy)
 
-Sent as **GET** (not POST) — everything is a query param, so there's no multipart ordering
-constraint to worry about:
+Sent as **GET**, bare string query params, no JSON quoting: `uri=<url>&destination=<dir>`
+(destination omitted if blank). Not in dispute — only DS2 has competing evidence (see below).
 
-- DS2: `type=url&url=<url>&create_list=false&destination=<dir>` (destination omitted if blank)
-- v1 (legacy): `uri=<url>&destination=<dir>` (destination omitted if blank)
+### Add by URL/magnet — DS2, three candidate contracts (runtime fallback chain)
 
-Values are bare strings — no JSON quoting for GET query params.
+Unlike every other call in this file, DS2's URL/magnet create request has **two independent,
+plausible-but-unconfirmed sources that disagree**, plus the earlier superseded guess. Rather than
+pick one, `createUrlTask` (in `server/downloaders/synology.ts`) tries all three in order at
+runtime, logging each attempt via `downloadersLogger` (`"Trying Synology DS2 create-task request
+variant"` / `"...succeeded"` / `"...failed, trying next fallback"`), so a real-device test run
+produces a definitive answer instead of another guess. First variant to succeed wins; if a variant
+throws (including a `success:false` Synology error response), the next is tried.
+
+1. **`ds2-get-bare`** (current default order — Prowlarr's proxy contract, unchanged from before):
+   `GET`, `type=url&url=<url>&create_list=false&destination=<dir>` (destination omitted if blank),
+   bare strings, no JSON quoting. Source: Prowlarr's `DownloadStationTaskProxyV2.cs` (see above).
+
+2. **`ds2-post-json-sid-query`** (new — dvcol/synology-download extension contract, fetched
+   2026-07-04 from
+   [`synology-download2.service.ts`](https://github.com/dvcol/synology-download/blob/main/src/services/http/synology-download2.service.ts)
+   and [`synology.service.ts`](https://github.com/dvcol/synology-download/blob/main/src/services/http/synology.service.ts)).
+   This is a live, purpose-built Synology Download Station browser extension — arguably a more
+   direct source than Prowlarr (a generic \*arr client juggling many download clients). Verified
+   in its actual `createTask()`/`query()` code, not just a user's paraphrase:
+   - **POST**, with `_sid` in the **query string only** (`_body_params = { _sid }`, kept out of the
+     body) — mirrors our own DS2 file-upload path's `sidInQuery: true`.
+   - All other params (`api`, `method`, `version`, `type`, `url`, `create_list`, `destination`) go
+     **url-encoded into the POST body**.
+   - `url` is **JSON-encoded as an array**: `JSON.stringify(urls.map(sanitizeUrl))` → literally
+     `["magnet:..."]` (brackets and quotes included, then url-encoded as a body value).
+     `type` is built via `stringifyKeys(_request, true)`, whose `true` flag strongly implies the
+     same JSON-encoded-string-literal treatment we already use for DS2 file uploads (`type` →
+     `"url"`, quotes included). `destination` is treated the same way in our implementation for
+     consistency with the file-upload path.
+   - This would make DS2's contract internally consistent — URL-add and file-upload both POST with
+     query-string-only `_sid` and JSON-quoted body values — instead of split across GET/POST as the
+     Prowlarr-only implementation was.
+
+3. **`ds2-post-uri-bare`** (superseded Phase 1 guess, kept as last-resort fallback — see "Phase 1"
+   below): `POST`, `type=url&uri=<url>&destination=<dir>`, bare strings, `_sid` in the body
+   (default). Confirmed to fix the originally reported error 120 for a real user, but uses `uri`
+   (not `url`) as the DS2 field name and was never cross-checked against the file-upload path.
+
+If a real device test shows one of these consistently winning (or all three failing with a new
+error code), collapse `buildDs2UrlCreateVariants` back down to just that one variant and fold the
+result into this doc.
 
 ### Add by file upload (torrent/NZB) — both API versions
 

--- a/docs/synology-download-station-api-notes.md
+++ b/docs/synology-download-station-api-notes.md
@@ -1,0 +1,104 @@
+# Synology Download Station API — undocumented behavior notes
+
+`SYNO.DownloadStation2.Task` (DSM 7, "DS2") and `SYNO.DownloadStation.Task` (legacy, "v1") are
+not documented in Synology's public API reference beyond the parameter names. The exact request
+shape (HTTP method, multipart field order, value encoding, where `_sid` goes) was reverse-engineered.
+This doc records what we tried, what turned out to be wrong, and the contract currently implemented
+in `server/downloaders/synology.ts`, so a future debugging session doesn't have to redo the research.
+
+## Current implementation (verified against Prowlarr's live client)
+
+Source: [`DownloadStationTaskProxyV2.cs`](https://github.com/Prowlarr/Prowlarr/blob/develop/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationTaskProxyV2.cs),
+[`DownloadStationTaskProxyV1.cs`](https://github.com/Prowlarr/Prowlarr/blob/develop/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DownloadStationTaskProxyV1.cs),
+[`DiskStationProxyBase.cs`](https://github.com/Prowlarr/Prowlarr/blob/develop/src/NzbDrone.Core/Download/Clients/DownloadStation/Proxies/DiskStationProxyBase.cs)
+(fetched 2026-07-02). Prowlarr is a live, widely-deployed \*arr project handling this exact API, so
+its shape is trusted over our own guesses — but it has not been tested against a real Synology
+device from inside this codebase. If a user reports error 101/120 again, re-check this first.
+
+### Add by URL/magnet — both API versions
+
+Sent as **GET** (not POST) — everything is a query param, so there's no multipart ordering
+constraint to worry about:
+
+- DS2: `type=url&url=<url>&create_list=false&destination=<dir>` (destination omitted if blank)
+- v1 (legacy): `uri=<url>&destination=<dir>` (destination omitted if blank)
+
+Values are bare strings — no JSON quoting for GET query params.
+
+### Add by file upload (torrent/NZB) — both API versions
+
+Sent as **POST multipart/form-data**. Synology's official (v1) docs state the uploaded file must
+be the **last** parameter in the body — our client honors this for both versions via an
+`appendFileLast` hook that runs after all other params are appended.
+
+**DS2** (`SYNO.DownloadStation2.Task`):
+
+- `_sid` goes in the **query string**, not the form body (`sidInQuery: true`). This is presumably
+  Synology's own workaround for the same "file must be last" constraint — keeping identity out of
+  the body entirely.
+- Form fields, in order: `api`, `version`, `method`, `type`, `file`, `create_list`, `destination`
+  (optional), then the file itself **last**.
+- `type`, `file`, and `destination` are sent as **JSON-encoded string literals** — i.e. the raw
+  form value for `type` is the 6-character string `"file"` (quotes included), and `file` is the
+  literal string `["fileData"]` (brackets and quotes included). This is not a bug in our code; it
+  matches Prowlarr's proxy byte-for-byte and is presumed to be a real DS2 API quirk (POST body
+  values may be JSON-decoded server-side while GET query values are not).
+- The actual file bytes are uploaded under the field name **`fileData`** — not `file`. The `file`
+  form field is a separate JSON-array reference pointing at the `fileData` field name, not the
+  bytes themselves.
+- `create_list` is the bare (unquoted) string `"false"`.
+
+**v1** (`SYNO.DownloadStation.Task`, legacy):
+
+- `_sid` stays in the form body (normal case).
+- Form fields, in order: `api`, `version`, `method`, `destination` (optional), then the file
+  **last**, under field name `file` (matches the official public docs — no `type`, no
+  `create_list`, no JSON quoting).
+- Uses API **version 2** for this call specifically (`preferredVersion: 2`, passed as a
+  `requestTaskApi` override), even though other legacy calls (list/pause/resume/delete/URL-add)
+  use version 3. Prowlarr's proxy does the same version split; the reason isn't documented
+  anywhere, just replicated.
+
+### Ordering is not guaranteed to survive a session-timeout retry
+
+`requestApi` retries once on error 106 (session expired) by re-authenticating and re-calling
+itself with the same `options` object — including the same `FormData` instance passed in by
+`addFileUpload`. Because `appendApiParams`/`appendFileLast` mutate that FormData in place rather
+than rebuilding it, a retry re-appends `api`/`version`/`method`/etc. a second time and appends the
+file field twice, so it's no longer strictly last. This is a pre-existing pattern (the pre-refactor
+code had the same same-object retry behavior), and a 106 landing mid-upload is rare, but it does mean the
+"file must be last" guarantee only holds on the first attempt. Rebuilding the FormData from scratch
+on retry would close this if it turns out to matter in practice.
+
+## Superseded approaches (kept for fallback reference)
+
+If the contract above turns out not to work for a given device/DSM version, here is what was tried
+before and rejected, in case reverting to a simpler shape is worth testing:
+
+### Phase 1 (root-caused from a live error-120 report, applied first)
+
+For `createUrlDownload`, both API versions unified on:
+
+```
+POST .../entry.cgi (or task.cgi)
+DS2:    type=url, uri=<url>, destination=<dir>
+legacy: uri=<url>, destination=<dir>
+```
+
+This fixed the original bug (`url` field name + `JSON.stringify([url])` value + a stray
+`create_list` field that DS2 rejected as error 120), but used **`uri`** as the DS2 field name and
+**POST**. Prowlarr's proxy uses **`url`** (not `uri`) for DS2 and sends it as a **GET**, with
+`create_list=false` explicitly included. If the current GET-based fix regresses on some devices,
+this POST/`uri` variant is the next thing to try — it's simpler and was confirmed to fix the
+originally reported error 120, just not verified against the DS2 file-upload path.
+
+### Phase 2 original spec (literal field order, not adopted for DS2)
+
+The initial ask was to reorder `addFileUpload` so all API params are appended before a single
+`file` field, appended last, with the DS2 `type` value corrected from `bt`/`nzb` — but keeping the
+field named `file` throughout and `_sid` in the form body for both API versions. This is
+plausible for **v1** (and is what's implemented above), but Prowlarr's evidence suggests DS2
+specifically needs the `fileData`-plus-JSON-array-reference structure and query-string `_sid`
+described above, not just a reordered `file` field with a corrected `type` value. If the current
+DS2 upload path fails, trying `type: "file"` with the bytes still under `file` (no `fileData`
+split, no query `_sid`) would be the intermediate step to test before reverting further.

--- a/memory/decisions.md
+++ b/memory/decisions.md
@@ -8,3 +8,9 @@ Track architectural, technical, and design decisions made during development.
 **Choice:** What was decided
 **Rationale:** Why this option was chosen over alternatives
 -->
+
+## [2026-07-02] Synology Download Station: adopt Prowlarr's reverse-engineered API contract
+
+**Context:** Synology's DS2 (`SYNO.DownloadStation2.Task`) API is undocumented beyond field names. Two prior fix attempts (a POST/`uri`-based patch, then a literal field-reordering spec) each turned out to diverge from the real undocumented contract once checked against Prowlarr's production C# client (fetched live via `gh api`).
+**Choice:** Implemented Prowlarr's verified contract in `server/downloaders/synology.ts`: URL/magnet adds go out as GET (not POST); DS2 file uploads use JSON-quoted `type`/`file`/`destination` params with bytes under a `fileData` field (not `file`) appended last and `_sid` moved to the query string; legacy (v1) file uploads use API version 2 specifically (other legacy calls use v3). Full contract documented in `docs/synology-download-station-api-notes.md`, including the two superseded approaches kept as fallback reference in case a user's device doesn't match Prowlarr's contract.
+**Rationale:** No real Synology device was available to test against, so trusting a live, widely-deployed \*arr project's production code over our own guesses was the best available evidence. User explicitly chose "adopt Prowlarr's contract, consign the earlier approaches to a doc" over keeping the simpler literal spec.

--- a/server/__tests__/downloaders.test.ts
+++ b/server/__tests__/downloaders.test.ts
@@ -698,8 +698,9 @@ describe("SynologyDownloadStationClient", () => {
 
       const createCall = fetchMock.mock.calls[2];
       expect(createCall[0]).toContain("DownloadStation/task.cgi");
-      expect(createCall[1].body.toString()).toContain("uri=magnet%3A%3Fxt%3Durn%3Abtih");
-      expect(createCall[1].body.toString()).toContain("destination=video%2Fdownloads");
+      expect(createCall[0]).toContain("uri=magnet%3A%3Fxt%3Durn%3Abtih");
+      expect(createCall[0]).toContain("destination=video%2Fdownloads");
+      expect(createCall[1].method).toBe("GET");
       expect(result).toEqual({
         success: true,
         id: "dbid_123",

--- a/server/__tests__/downloaders_clients_regression.test.ts
+++ b/server/__tests__/downloaders_clients_regression.test.ts
@@ -498,6 +498,8 @@ describe("downloader client regression coverage", () => {
             httpMethod?: "GET" | "POST";
             params?: Record<string, string | number | boolean | undefined>;
             body?: URLSearchParams | FormData;
+            sidInQuery?: boolean;
+            appendFileLast?: (formData: FormData) => void;
           }
         ) => Promise<{ success: boolean; data?: { task_id?: string[] } }>;
       },
@@ -546,12 +548,19 @@ describe("downloader client regression coverage", () => {
       downloadType: "torrent",
     });
     const uploadOptions = requestTaskApiSpy.mock.calls[0]?.[1];
-    const uploadBody = uploadOptions?.body as FormData;
 
     expect(result).toMatchObject({ success: true, id: "dbid_1" });
-    expect(uploadBody.get("destination")).toBe("/volume1/downloads");
-    expect(uploadBody.get("type")).toBe("bt");
+    expect(uploadOptions?.params).toMatchObject({
+      type: '"file"',
+      file: '["fileData"]',
+      create_list: false,
+      destination: '"/volume1/downloads"',
+    });
     expect(uploadOptions?.httpMethod).toBe("POST");
+    expect(uploadOptions?.sidInQuery).toBe(true);
+    const uploadBody = new FormData();
+    uploadOptions?.appendFileLast?.(uploadBody);
+    expect([...uploadBody.keys()]).toEqual(["fileData"]);
 
     await expect(client.getFreeSpace()).resolves.toBe(8192);
     expect(safeFetch).toHaveBeenCalled();

--- a/server/__tests__/downloaders_clients_regression.test.ts
+++ b/server/__tests__/downloaders_clients_regression.test.ts
@@ -573,6 +573,7 @@ describe("downloader client regression coverage", () => {
         url: "http://nas.local:5000",
         username: "admin",
         password: "pw",
+        downloadPath: "/volume1/downloads",
       })
     );
     vi.spyOn(
@@ -613,6 +614,7 @@ describe("downloader client regression coverage", () => {
         url: "http://nas.local:5000",
         username: "admin",
         password: "pw",
+        downloadPath: "/volume1/downloads",
       })
     );
     vi.spyOn(
@@ -1182,7 +1184,10 @@ describe("downloader client regression coverage", () => {
     const privateClient = client as unknown as {
       apiInfo: Record<string, { path: string; minVersion: number; maxVersion: number }> | null;
       getBaseUrlParts: () => { origin: string; prefix: string };
-      buildSynologyErrorMessage: (code: number | undefined, fallback: string) => string;
+      buildSynologyErrorMessage: (
+        error: { code?: number; errors?: { name?: string; reason?: string }[] } | undefined,
+        fallback: string
+      ) => string;
       normalizeSynologyStatus: (status: string | undefined, progress: number) => string;
       mapSynologyFilePriority: (priority: string | number | undefined) => string;
       mapSynologyTrackerStatus: (status: string | undefined, error: string | undefined) => string;
@@ -1208,7 +1213,7 @@ describe("downloader client regression coverage", () => {
       origin: "http://nas.local",
       prefix: "/base/downloads",
     });
-    expect(privateClient.buildSynologyErrorMessage(401, "fallback")).toBe(
+    expect(privateClient.buildSynologyErrorMessage({ code: 401 }, "fallback")).toBe(
       "Synology maximum task limit reached"
     );
     expect(privateClient.normalizeSynologyStatus("paused", 100)).toBe("completed");
@@ -1857,6 +1862,7 @@ describe("downloader client regression coverage", () => {
         type: "synology",
         username: "admin",
         password: "password",
+        downloadPath: "/volume1/downloads",
       })
     );
     const privateClient = client as unknown as {
@@ -1966,6 +1972,7 @@ describe("downloader client regression coverage", () => {
         type: "synology",
         username: "admin",
         password: "password",
+        downloadPath: "/volume1/downloads",
       })
     );
     const privateClient = client as unknown as {

--- a/server/__tests__/downloaders_clients_regression.test.ts
+++ b/server/__tests__/downloaders_clients_regression.test.ts
@@ -550,7 +550,7 @@ describe("downloader client regression coverage", () => {
 
     expect(result).toMatchObject({ success: true, id: "dbid_1" });
     expect(uploadBody.get("destination")).toBe("/volume1/downloads");
-    expect(uploadBody.get("type")).toBe("file");
+    expect(uploadBody.get("type")).toBe("bt");
     expect(uploadOptions?.httpMethod).toBe("POST");
 
     await expect(client.getFreeSpace()).resolves.toBe(8192);

--- a/server/__tests__/downloaders_helpers_regression.test.ts
+++ b/server/__tests__/downloaders_helpers_regression.test.ts
@@ -594,14 +594,17 @@ describe("downloaders helper regression coverage", () => {
         apiName: string;
         descriptor: { path: string; minVersion: number; maxVersion: number };
       };
-      buildSynologyErrorMessage(code: number | undefined, fallback: string): string;
+      buildSynologyErrorMessage(
+        error: { code?: number; errors?: { name?: string; reason?: string }[] } | undefined,
+        fallback: string
+      ): string;
       appendApiParams(
         target: URLSearchParams | FormData,
         params: Record<string, string | number | boolean | undefined>
       ): void;
       normalizeSynologyStatus(rawStatus: string | undefined, progress: number): string;
       mapSynologyDetails(task: Record<string, unknown>): Record<string, unknown>;
-      getSynologyDestination(request: { downloadPath?: string }): string | undefined;
+      getSynologyDestination(request: { downloadPath?: string }): Promise<string | undefined>;
     };
 
     expect(client.getBaseUrlParts()).toEqual({
@@ -619,7 +622,7 @@ describe("downloaders helper regression coverage", () => {
       "SYNO.DownloadStation.Task": { path: "entry.cgi", minVersion: 1, maxVersion: 1 },
     };
     expect(client.getTaskApiDescriptor().apiName).toBe("SYNO.DownloadStation.Task");
-    expect(client.buildSynologyErrorMessage(403, "Fallback")).toBe(
+    expect(client.buildSynologyErrorMessage({ code: 403 }, "Fallback")).toBe(
       "Synology destination was not found"
     );
     expect(client.buildSynologyErrorMessage(undefined, "Fallback")).toBe("Fallback");
@@ -696,8 +699,8 @@ describe("downloaders helper regression coverage", () => {
       expect.objectContaining({ status: "working", lastAnnounce: expect.any(String) }),
       expect.objectContaining({ status: "error", error: "timeout" }),
     ]);
-    expect(client.getSynologyDestination({ downloadPath: "/custom" })).toBe("/custom");
-    expect(client.getSynologyDestination({})).toBe("/volume1/downloads");
+    expect(await client.getSynologyDestination({ downloadPath: "/custom" })).toBe("/custom");
+    expect(await client.getSynologyDestination({})).toBe("/volume1/downloads");
   });
 
   it("covers Synology auth, retry, and logout helpers", async () => {

--- a/server/__tests__/downloaders_helpers_regression.test.ts
+++ b/server/__tests__/downloaders_helpers_regression.test.ts
@@ -573,7 +573,7 @@ describe("downloaders helper regression coverage", () => {
     randomBytesSpy.mockRestore();
   });
 
-  it("covers Synology helper methods and status mapping", () => {
+  it("covers Synology helper methods and status mapping", async () => {
     const client = new SynologyDownloadStationClient(
       createDownloader({
         type: "synology",

--- a/server/__tests__/downloaders_synology_remaining.test.ts
+++ b/server/__tests__/downloaders_synology_remaining.test.ts
@@ -84,7 +84,10 @@ describe("synology remaining regression coverage", () => {
         apiName: string;
         descriptor: { path: string; minVersion: number; maxVersion: number };
       };
-      buildSynologyErrorMessage(code: number | undefined, fallback: string): string;
+      buildSynologyErrorMessage(
+        error: { code?: number; errors?: { name?: string; reason?: string }[] } | undefined,
+        fallback: string
+      ): string;
       fetchJson<T>(url: string, init: RequestInit, context: string): Promise<T>;
       ensureApiInfo(): Promise<void>;
       authenticate(force?: boolean): Promise<void>;
@@ -123,17 +126,30 @@ describe("synology remaining regression coverage", () => {
     expect(() => client.getTaskApiDescriptor()).toThrow(
       "Synology API information has not been loaded"
     );
-    expect(client.buildSynologyErrorMessage(101, "fallback")).toBe(
+    expect(client.buildSynologyErrorMessage({ code: 101 }, "fallback")).toBe(
       "Synology rejected the request parameters"
     );
-    expect(client.buildSynologyErrorMessage(105, "fallback")).toBe("Synology permission denied");
-    expect(client.buildSynologyErrorMessage(106, "fallback")).toBe("Synology session expired");
-    expect(client.buildSynologyErrorMessage(400, "fallback")).toBe(
+    expect(client.buildSynologyErrorMessage({ code: 105 }, "fallback")).toBe(
+      "Synology permission denied"
+    );
+    expect(client.buildSynologyErrorMessage({ code: 106 }, "fallback")).toBe(
+      "Synology session expired"
+    );
+    expect(client.buildSynologyErrorMessage({ code: 400 }, "fallback")).toBe(
       "Synology authentication failed"
     );
-    expect(client.buildSynologyErrorMessage(402, "fallback")).toBe(
+    expect(client.buildSynologyErrorMessage({ code: 402 }, "fallback")).toBe(
       "Synology destination access denied"
     );
+    expect(client.buildSynologyErrorMessage({ code: 120 }, "fallback")).toBe(
+      "Synology rejected the request — a destination folder is required"
+    );
+    expect(
+      client.buildSynologyErrorMessage(
+        { code: 120, errors: [{ name: "destination", reason: "required" }] },
+        "fallback"
+      )
+    ).toBe("fallback (code 120): destination: required");
 
     vi.mocked(isSafeUrl).mockResolvedValueOnce(false);
     await expect(
@@ -628,5 +644,116 @@ describe("synology remaining regression coverage", () => {
     expect(keys[0]).toBe("api");
     expect(keys.at(-1)).toBe("file");
     expect(keys).toContain("_sid");
+  });
+
+  it("fails fast when no destination is configured and the NAS has no default either", async () => {
+    const client = new SynologyDownloadStationClient(createDownloader({ downloadPath: null }));
+    const privateClient = client as unknown as {
+      apiInfo: Record<string, { path: string; minVersion: number; maxVersion: number }> | null;
+      ensureApiInfo(): Promise<void>;
+      getTaskApiDescriptor(): { apiName: string; descriptor?: unknown };
+      requestApi<T>(
+        apiName: string,
+        descriptor: { path: string; minVersion: number; maxVersion: number },
+        preferredVersion: number,
+        methodName: string,
+        options?: { httpMethod?: "GET" | "POST" }
+      ): Promise<T>;
+      requestTaskApi<T>(methodName: string): Promise<T>;
+    };
+
+    privateClient.apiInfo = {
+      "SYNO.DownloadStation2.Task": { path: "entry.cgi", minVersion: 1, maxVersion: 2 },
+      "SYNO.DownloadStation.Info": { path: "entry.cgi", minVersion: 1, maxVersion: 1 },
+    };
+    vi.spyOn(privateClient, "ensureApiInfo").mockResolvedValue(undefined);
+    vi.spyOn(privateClient, "getTaskApiDescriptor").mockReturnValue({
+      apiName: "SYNO.DownloadStation2.Task",
+    });
+    const requestApiSpy = vi
+      .spyOn(privateClient, "requestApi")
+      .mockResolvedValue({ success: true, data: { default_destination: "" } } as never);
+    const requestTaskApiSpy = vi.spyOn(privateClient, "requestTaskApi");
+
+    await expect(
+      client.addDownload({ url: "http://indexer.local/game.torrent", title: "Game" })
+    ).resolves.toEqual({
+      success: false,
+      message:
+        "No download destination configured. Set a Download Path for this downloader in " +
+        "Questarr, or configure a default destination in Synology Download Station settings.",
+    });
+
+    expect(requestApiSpy).toHaveBeenCalledWith(
+      "SYNO.DownloadStation.Info",
+      { path: "entry.cgi", minVersion: 1, maxVersion: 1 },
+      1,
+      "getconfig",
+      { httpMethod: "GET" }
+    );
+    expect(requestTaskApiSpy).not.toHaveBeenCalled();
+
+    // Cached: a second call must not re-query the NAS.
+    requestApiSpy.mockClear();
+    await client.addDownload({ url: "http://indexer.local/game2.torrent", title: "Game 2" });
+    expect(requestApiSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the NAS default destination when no path is configured anywhere else", async () => {
+    const client = new SynologyDownloadStationClient(createDownloader({ downloadPath: null }));
+    const privateClient = client as unknown as {
+      apiInfo: Record<string, { path: string; minVersion: number; maxVersion: number }> | null;
+      ensureApiInfo(): Promise<void>;
+      getTaskApiDescriptor(): { apiName: string; descriptor?: unknown };
+      requestApi<T>(
+        apiName: string,
+        descriptor: { path: string; minVersion: number; maxVersion: number },
+        preferredVersion: number,
+        methodName: string,
+        options?: { httpMethod?: "GET" | "POST" }
+      ): Promise<T>;
+      requestTaskApi<T>(
+        methodName: string,
+        options?: {
+          httpMethod?: "GET" | "POST";
+          params?: Record<string, string | number | boolean | undefined>;
+        }
+      ): Promise<T>;
+    };
+
+    privateClient.apiInfo = {
+      "SYNO.DownloadStation2.Task": { path: "entry.cgi", minVersion: 1, maxVersion: 2 },
+      "SYNO.DownloadStation.Info": { path: "entry.cgi", minVersion: 1, maxVersion: 1 },
+    };
+    vi.spyOn(privateClient, "ensureApiInfo").mockResolvedValue(undefined);
+    vi.spyOn(privateClient, "getTaskApiDescriptor").mockReturnValue({
+      apiName: "SYNO.DownloadStation2.Task",
+    });
+    vi.spyOn(privateClient, "requestApi").mockResolvedValue({
+      success: true,
+      data: { default_destination: "/volume2/nas-default" },
+    } as never);
+    const requestTaskApiSpy = vi
+      .spyOn(privateClient, "requestTaskApi")
+      .mockResolvedValue({ success: true, data: { task_id: ["task-default"] } } as never);
+
+    const magnetUrl = "magnet:?xt=urn:btih:abcdef1234567890abcdef1234567890abcdef12";
+    await expect(
+      client.addDownload({ url: magnetUrl, title: "Magnet using NAS default" })
+    ).resolves.toEqual({
+      success: true,
+      id: "task-default",
+      message: "Download added successfully",
+    });
+
+    expect(requestTaskApiSpy).toHaveBeenLastCalledWith("create", {
+      httpMethod: "GET",
+      params: {
+        type: "url",
+        url: magnetUrl,
+        create_list: false,
+        destination: "/volume2/nas-default",
+      },
+    });
   });
 });

--- a/server/__tests__/downloaders_synology_remaining.test.ts
+++ b/server/__tests__/downloaders_synology_remaining.test.ts
@@ -428,4 +428,205 @@ describe("synology remaining regression coverage", () => {
     await expect(client.getFreeSpace()).resolves.toBe(5678);
     await expect(client.getFreeSpace()).resolves.toBe(0);
   });
+
+  it("sends a GET create request with the correct query params per API version for magnet task creation", async () => {
+    const client = new SynologyDownloadStationClient(createDownloader());
+    const privateClient = client as unknown as {
+      apiInfo: Record<string, { path: string; minVersion: number; maxVersion: number }> | null;
+      ensureApiInfo(): Promise<void>;
+      getTaskApiDescriptor(): { apiName: string; descriptor?: unknown };
+      requestTaskApi<T>(
+        methodName: string,
+        options?: {
+          httpMethod?: "GET" | "POST";
+          params?: Record<string, string | number | boolean | undefined>;
+          body?: URLSearchParams | FormData;
+        }
+      ): Promise<T>;
+    };
+
+    const magnetUrl = "magnet:?xt=urn:btih:abcdef1234567890abcdef1234567890abcdef12";
+    vi.spyOn(privateClient, "ensureApiInfo").mockResolvedValue(undefined);
+    const requestTaskApiSpy = vi
+      .spyOn(privateClient, "requestTaskApi")
+      .mockResolvedValue({ success: true, data: { task_id: ["task-1"] } } as never);
+
+    vi.spyOn(privateClient, "getTaskApiDescriptor").mockReturnValue({
+      apiName: "SYNO.DownloadStation2.Task",
+    });
+    await client.addDownload({ url: magnetUrl, title: "DS2 magnet" });
+    expect(requestTaskApiSpy).toHaveBeenLastCalledWith("create", {
+      httpMethod: "GET",
+      params: {
+        type: "url",
+        url: magnetUrl,
+        create_list: false,
+        destination: "/volume1/downloads",
+      },
+    });
+
+    vi.spyOn(privateClient, "getTaskApiDescriptor").mockReturnValue({
+      apiName: "SYNO.DownloadStation.Task",
+    });
+    await client.addDownload({ url: magnetUrl, title: "Legacy magnet" });
+    expect(requestTaskApiSpy).toHaveBeenLastCalledWith("create", {
+      httpMethod: "GET",
+      params: {
+        uri: magnetUrl,
+        destination: "/volume1/downloads",
+      },
+    });
+  });
+
+  it("uploads files with the file field appended last and the correct DS2/legacy multipart shape", async () => {
+    const client = new SynologyDownloadStationClient(createDownloader());
+    const privateClient = client as unknown as {
+      apiInfo: Record<string, { path: string; minVersion: number; maxVersion: number }> | null;
+      ensureApiInfo(): Promise<void>;
+      getTaskApiDescriptor(): { apiName: string; descriptor?: unknown };
+      requestTaskApi<T>(
+        methodName: string,
+        options?: {
+          httpMethod?: "GET" | "POST";
+          params?: Record<string, string | number | boolean | undefined>;
+          body?: URLSearchParams | FormData;
+          sidInQuery?: boolean;
+          appendFileLast?: (formData: FormData) => void;
+        }
+      ): Promise<T>;
+    };
+
+    vi.spyOn(privateClient, "ensureApiInfo").mockResolvedValue(undefined);
+    const requestTaskApiSpy = vi
+      .spyOn(privateClient, "requestTaskApi")
+      .mockResolvedValue({ success: true, data: { task_id: ["task-file"] } } as never);
+
+    const torrentUrl = "http://indexer.local/release.torrent";
+    fetchWithMagnetDetectionMock.mockResolvedValue({
+      response: {
+        ok: true,
+        headers: new Headers({
+          "content-disposition": 'attachment; filename="release.torrent"',
+          "content-type": "application/x-bittorrent",
+        }),
+        arrayBuffer: async () => new TextEncoder().encode("torrent-bytes").buffer,
+      } as unknown as Response,
+    });
+
+    vi.spyOn(privateClient, "getTaskApiDescriptor").mockReturnValue({
+      apiName: "SYNO.DownloadStation2.Task",
+    });
+    await client.addDownload({ url: torrentUrl, title: "DS2 file" });
+
+    let call = requestTaskApiSpy.mock.calls.at(-1)!;
+    expect(call[0]).toBe("create");
+    expect(call[1]).toMatchObject({
+      httpMethod: "POST",
+      sidInQuery: true,
+      params: {
+        type: '"file"',
+        file: '["fileData"]',
+        create_list: false,
+        destination: '"/volume1/downloads"',
+      },
+    });
+    let formData = new FormData();
+    call[1]!.appendFileLast!(formData);
+    expect([...formData.keys()]).toEqual(["fileData"]);
+
+    vi.spyOn(privateClient, "getTaskApiDescriptor").mockReturnValue({
+      apiName: "SYNO.DownloadStation.Task",
+    });
+    await client.addDownload({ url: torrentUrl, title: "Legacy file" });
+
+    call = requestTaskApiSpy.mock.calls.at(-1)!;
+    expect(call[1]).toMatchObject({
+      httpMethod: "POST",
+      sidInQuery: false,
+      params: {
+        destination: "/volume1/downloads",
+      },
+    });
+    formData = new FormData();
+    call[1]!.appendFileLast!(formData);
+    expect([...formData.keys()]).toEqual(["file"]);
+  });
+
+  it("appends the file field last in the real multipart body built by requestApi", async () => {
+    const client = new SynologyDownloadStationClient(createDownloader()) as unknown as {
+      apiInfo: Record<string, { path: string; minVersion: number; maxVersion: number }> | null;
+      sessionId: string | null;
+      authenticate(force?: boolean): Promise<void>;
+      fetchJson<T>(url: string, init: RequestInit, context: string): Promise<T>;
+      requestApi<T>(
+        apiName: string,
+        descriptor: { path: string; minVersion: number; maxVersion: number },
+        preferredVersion: number,
+        methodName: string,
+        options?: {
+          httpMethod?: "GET" | "POST";
+          params?: Record<string, string | number | boolean | undefined>;
+          body?: URLSearchParams | FormData;
+          sidInQuery?: boolean;
+          appendFileLast?: (formData: FormData) => void;
+        }
+      ): Promise<T>;
+    };
+
+    client.apiInfo = {
+      "SYNO.API.Auth": { path: "auth.cgi", minVersion: 1, maxVersion: 7 },
+      "SYNO.DownloadStation2.Task": { path: "entry.cgi", minVersion: 1, maxVersion: 2 },
+      "SYNO.DownloadStation.Task": { path: "task.cgi", minVersion: 1, maxVersion: 3 },
+    };
+    vi.spyOn(client, "authenticate").mockResolvedValue(undefined);
+    client.sessionId = "sid-real";
+
+    const fetchJsonSpy = vi
+      .spyOn(client, "fetchJson")
+      .mockResolvedValue({ success: true, data: { task_id: ["task-order"] } });
+
+    await client.requestApi(
+      "SYNO.DownloadStation2.Task",
+      { path: "entry.cgi", minVersion: 1, maxVersion: 2 },
+      2,
+      "create",
+      {
+        httpMethod: "POST",
+        params: { type: '"file"', file: '["fileData"]', create_list: false },
+        body: new FormData(),
+        sidInQuery: true,
+        appendFileLast: (formData) => {
+          formData.append("fileData", new Blob(["bytes"]), "release.torrent");
+        },
+      }
+    );
+
+    let [url, init] = fetchJsonSpy.mock.calls.at(-1)!;
+    let keys = [...(init.body as FormData).keys()];
+    expect(keys[0]).toBe("api");
+    expect(keys.at(-1)).toBe("fileData");
+    expect(keys).not.toContain("_sid");
+    expect(url).toContain("_sid=sid-real");
+
+    fetchJsonSpy.mockClear();
+    await client.requestApi(
+      "SYNO.DownloadStation.Task",
+      { path: "task.cgi", minVersion: 1, maxVersion: 3 },
+      2,
+      "create",
+      {
+        httpMethod: "POST",
+        body: new FormData(),
+        appendFileLast: (formData) => {
+          formData.append("file", new Blob(["bytes"]), "release.torrent");
+        },
+      }
+    );
+
+    [url, init] = fetchJsonSpy.mock.calls.at(-1)!;
+    keys = [...(init.body as FormData).keys()];
+    expect(keys[0]).toBe("api");
+    expect(keys.at(-1)).toBe("file");
+    expect(keys).toContain("_sid");
+  });
 });

--- a/server/downloaders/synology.ts
+++ b/server/downloaders/synology.ts
@@ -354,11 +354,20 @@ export class SynologyDownloadStationClient implements DownloaderClient {
       body?: URLSearchParams | FormData;
       retryOnAuthFailure?: boolean;
       requiresAuth?: boolean;
+      /**
+       * Synology's DS2 task API (undocumented) sends `_sid` as a query param even on POST,
+       * keeping it out of the multipart body so a trailing file field stays last. See
+       * docs/synology-download-station-api-notes.md for why this only applies to DS2.
+       */
+      sidInQuery?: boolean;
+      /** Appends a field (e.g. the uploaded file) to a FormData body after all other params. */
+      appendFileLast?: (formData: FormData) => void;
     } = {}
   ): Promise<T> {
     const httpMethod = options.httpMethod ?? "GET";
     const requiresAuth = options.requiresAuth ?? true;
     const retryOnAuthFailure = options.retryOnAuthFailure ?? true;
+    const sidInQuery = options.sidInQuery ?? false;
 
     if (requiresAuth) {
       await this.authenticate();
@@ -373,11 +382,15 @@ export class SynologyDownloadStationClient implements DownloaderClient {
       ...(options.params ?? {}),
     };
 
-    if (requiresAuth) {
+    if (requiresAuth && !sidInQuery) {
       params._sid = this.sessionId ?? undefined;
     }
 
     const url = this.getWebApiUrl(descriptor.path);
+    const postUrl =
+      requiresAuth && sidInQuery && this.sessionId
+        ? `${url}?${new URLSearchParams({ _sid: this.sessionId }).toString()}`
+        : url;
     let body: BodyInit | undefined;
     const headers: Record<string, string> = {};
 
@@ -415,6 +428,7 @@ export class SynologyDownloadStationClient implements DownloaderClient {
     if (options.body instanceof FormData) {
       const formData = options.body;
       this.appendApiParams(formData, params);
+      options.appendFileLast?.(formData);
       body = formData;
     } else {
       const formBody =
@@ -425,7 +439,7 @@ export class SynologyDownloadStationClient implements DownloaderClient {
     }
 
     const response = await this.fetchJson<T>(
-      url,
+      postUrl,
       { method: httpMethod, body, headers },
       `Synology ${apiName}.${methodName} failed`
     );
@@ -458,11 +472,20 @@ export class SynologyDownloadStationClient implements DownloaderClient {
       params?: Record<string, string | number | boolean | undefined>;
       body?: URLSearchParams | FormData;
       retryOnAuthFailure?: boolean;
+      sidInQuery?: boolean;
+      appendFileLast?: (formData: FormData) => void;
+      /**
+       * Overrides the default API version. Prowlarr's verified contract uses v2 for legacy
+       * (SYNO.DownloadStation.Task) file uploads specifically, vs v3 for its other legacy
+       * calls. See docs/synology-download-station-api-notes.md.
+       */
+      preferredVersion?: number;
     } = {}
   ): Promise<T> {
     await this.ensureApiInfo();
     const { apiName, descriptor } = this.getTaskApiDescriptor();
-    const preferredVersion = apiName === "SYNO.DownloadStation2.Task" ? 2 : 3;
+    const preferredVersion =
+      options.preferredVersion ?? (apiName === "SYNO.DownloadStation2.Task" ? 2 : 3);
 
     return this.requestApi<T>(apiName, descriptor, preferredVersion, methodName, options);
   }
@@ -684,20 +707,21 @@ export class SynologyDownloadStationClient implements DownloaderClient {
       const isMagnet = request.url.startsWith("magnet:");
 
       const createUrlDownload = async (downloadUrl: string) => {
+        const trimmedDestination = destination?.trim();
+        const isDs2 = apiName === "SYNO.DownloadStation2.Task";
         const response = await this.requestTaskApi<SynologyTaskResponse>("create", {
-          httpMethod: "POST",
-          params:
-            apiName === "SYNO.DownloadStation2.Task"
-              ? {
-                  type: "url",
-                  url: JSON.stringify([downloadUrl]),
-                  create_list: false,
-                  destination,
-                }
-              : {
-                  uri: downloadUrl,
-                  destination,
-                },
+          httpMethod: "GET",
+          params: isDs2
+            ? {
+                type: "url",
+                url: downloadUrl,
+                create_list: false,
+                ...(trimmedDestination ? { destination: trimmedDestination } : {}),
+              }
+            : {
+                uri: downloadUrl,
+                ...(trimmedDestination ? { destination: trimmedDestination } : {}),
+              },
         });
 
         const id = response.data?.task_id?.[0];
@@ -761,21 +785,34 @@ export class SynologyDownloadStationClient implements DownloaderClient {
     const fileBlob = new Blob([fileContents], {
       type: response.headers.get("content-type") || "application/octet-stream",
     });
-    const formData = new FormData();
-    formData.append("file", fileBlob, fileName);
 
-    if (destination) {
-      formData.append("destination", destination);
-    }
-
-    if (apiName === "SYNO.DownloadStation2.Task") {
-      const isNzb = request.downloadType === "usenet" || fileName.toLowerCase().endsWith(".nzb");
-      formData.append("type", isNzb ? "nzb" : "bt");
-    }
+    const trimmedDestination = destination?.trim();
+    const isDs2 = apiName === "SYNO.DownloadStation2.Task";
+    // DS2's undocumented multipart contract expects type/file/destination as JSON-encoded
+    // string literals, with the actual bytes uploaded under "fileData" (referenced by the
+    // separate "file" param) rather than under "file" directly. See
+    // docs/synology-download-station-api-notes.md.
+    const fileFieldName = isDs2 ? "fileData" : "file";
+    const params: Record<string, string | number | boolean | undefined> = isDs2
+      ? {
+          type: '"file"',
+          file: '["fileData"]',
+          create_list: false,
+          ...(trimmedDestination ? { destination: JSON.stringify(trimmedDestination) } : {}),
+        }
+      : {
+          ...(trimmedDestination ? { destination: trimmedDestination } : {}),
+        };
 
     const uploadResponse = await this.requestTaskApi<SynologyTaskResponse>("create", {
       httpMethod: "POST",
-      body: formData,
+      params,
+      body: new FormData(),
+      sidInQuery: isDs2,
+      preferredVersion: isDs2 ? undefined : 2,
+      appendFileLast: (formData) => {
+        formData.append(fileFieldName, fileBlob, fileName);
+      },
     });
 
     return {

--- a/server/downloaders/synology.ts
+++ b/server/downloaders/synology.ts
@@ -769,7 +769,8 @@ export class SynologyDownloadStationClient implements DownloaderClient {
     }
 
     if (apiName === "SYNO.DownloadStation2.Task") {
-      formData.append("type", request.downloadType === "usenet" ? "nzb" : "bt");
+      const isNzb = request.downloadType === "usenet" || fileName.toLowerCase().endsWith(".nzb");
+      formData.append("type", isNzb ? "nzb" : "bt");
     }
 
     const uploadResponse = await this.requestTaskApi<SynologyTaskResponse>("create", {

--- a/server/downloaders/synology.ts
+++ b/server/downloaders/synology.ts
@@ -18,6 +18,7 @@ interface SynologyApiDescriptor {
 
 interface SynologyErrorResponse {
   code?: number;
+  errors?: { name?: string; reason?: string }[];
 }
 
 interface SynologyApiResponse {
@@ -98,6 +99,12 @@ interface SynologyFileStationVolumeStatus {
   used?: number;
 }
 
+interface SynologyDownloadStationInfoResponse extends SynologyApiResponse {
+  data?: {
+    default_destination?: string;
+  };
+}
+
 interface SynologyFileStationResponse extends SynologyApiResponse {
   data?: {
     useable_space?: number;
@@ -109,6 +116,7 @@ export class SynologyDownloadStationClient implements DownloaderClient {
   private downloader: Downloader;
   private sessionId: string | null = null;
   private apiInfo: Record<string, SynologyApiDescriptor> | null = null;
+  private nasDefaultDestination: string | null | undefined;
 
   constructor(downloader: Downloader) {
     this.downloader = downloader;
@@ -185,7 +193,20 @@ export class SynologyDownloadStationClient implements DownloaderClient {
     throw new Error("Synology Download Station Task API is not available on this server");
   }
 
-  private buildSynologyErrorMessage(code: number | undefined, fallback: string): string {
+  private buildSynologyErrorMessage(
+    error: SynologyErrorResponse | undefined,
+    fallback: string
+  ): string {
+    const code = error?.code;
+    const fieldDetail = error?.errors
+      ?.filter((detail) => detail.name || detail.reason)
+      .map((detail) => [detail.name, detail.reason].filter(Boolean).join(": "))
+      .join(", ");
+
+    if (fieldDetail) {
+      return `${fallback} (code ${code}): ${fieldDetail}`;
+    }
+
     switch (code) {
       case 101:
         return "Synology rejected the request parameters";
@@ -193,6 +214,8 @@ export class SynologyDownloadStationClient implements DownloaderClient {
         return "Synology permission denied";
       case 106:
         return "Synology session expired";
+      case 120:
+        return "Synology rejected the request — a destination folder is required";
       case 400:
         return "Synology authentication failed";
       case 401:
@@ -252,7 +275,7 @@ export class SynologyDownloadStationClient implements DownloaderClient {
       version: "1",
       method: "query",
       query:
-        "SYNO.API.Auth,SYNO.DownloadStation.Task,SYNO.DownloadStation2.Task,SYNO.FileStation.Info",
+        "SYNO.API.Auth,SYNO.DownloadStation.Task,SYNO.DownloadStation2.Task,SYNO.DownloadStation.Info,SYNO.FileStation.Info",
     });
 
     const url = this.getWebApiUrl(`query.cgi?${queryParams.toString()}`);
@@ -264,7 +287,7 @@ export class SynologyDownloadStationClient implements DownloaderClient {
 
     if (!response.success || !response.data) {
       throw new Error(
-        this.buildSynologyErrorMessage(response.error?.code, "Failed to query Synology APIs")
+        this.buildSynologyErrorMessage(response.error, "Failed to query Synology APIs")
       );
     }
 
@@ -305,7 +328,7 @@ export class SynologyDownloadStationClient implements DownloaderClient {
     if (!response.success || !response.data?.sid) {
       throw new Error(
         this.buildSynologyErrorMessage(
-          response.error?.code,
+          response.error,
           "Failed to authenticate with Synology Download Station"
         )
       );
@@ -415,10 +438,7 @@ export class SynologyDownloadStationClient implements DownloaderClient {
 
       if (!response.success) {
         throw new Error(
-          this.buildSynologyErrorMessage(
-            response.error?.code,
-            `Synology ${apiName}.${methodName} failed`
-          )
+          this.buildSynologyErrorMessage(response.error, `Synology ${apiName}.${methodName} failed`)
         );
       }
 
@@ -449,16 +469,18 @@ export class SynologyDownloadStationClient implements DownloaderClient {
       await this.authenticate(true);
       return this.requestApi(apiName, descriptor, preferredVersion, methodName, {
         ...options,
+        // The FormData above was already mutated in place by appendApiParams/appendFileLast, so
+        // reusing it here would double-append params and lose the "file must be last" guarantee.
+        // appendFileLast is a closure over the file bytes, not the FormData's prior state, so it's
+        // safe to re-run against a fresh instance. See docs/synology-download-station-api-notes.md.
+        body: options.body instanceof FormData ? new FormData() : options.body,
         retryOnAuthFailure: false,
       });
     }
 
     if (!response.success) {
       throw new Error(
-        this.buildSynologyErrorMessage(
-          response.error?.code,
-          `Synology ${apiName}.${methodName} failed`
-        )
+        this.buildSynologyErrorMessage(response.error, `Synology ${apiName}.${methodName} failed`)
       );
     }
 
@@ -654,8 +676,49 @@ export class SynologyDownloadStationClient implements DownloaderClient {
     return response.data?.tasks?.[0] ?? null;
   }
 
-  private getSynologyDestination(request: DownloadRequest): string | undefined {
-    return request.downloadPath || this.downloader.downloadPath || undefined;
+  /**
+   * Mirrors Prowlarr's `GetDownloadDirectory()` -> `GetDefaultDir()` fallback: when neither the
+   * request nor the downloader config specifies a path, ask the NAS for its own Download Station
+   * default destination via `SYNO.DownloadStation.Info.getconfig` before giving up. Without this,
+   * DS2 create-task calls silently omit `destination` and Synology rejects them with an opaque
+   * error 120. See docs/synology-download-station-api-notes.md.
+   */
+  private async getNasDefaultDestination(): Promise<string | undefined> {
+    if (this.nasDefaultDestination !== undefined) {
+      return this.nasDefaultDestination ?? undefined;
+    }
+
+    try {
+      await this.ensureApiInfo();
+      const descriptor = this.apiInfo?.["SYNO.DownloadStation.Info"];
+      if (!descriptor) {
+        this.nasDefaultDestination = null;
+        return undefined;
+      }
+
+      const response = await this.requestApi<SynologyDownloadStationInfoResponse>(
+        "SYNO.DownloadStation.Info",
+        descriptor,
+        1,
+        "getconfig",
+        { httpMethod: "GET" }
+      );
+
+      this.nasDefaultDestination = response.data?.default_destination || null;
+      return this.nasDefaultDestination ?? undefined;
+    } catch (error) {
+      downloadersLogger.error({ error }, "Failed to get Synology default download destination");
+      this.nasDefaultDestination = null;
+      return undefined;
+    }
+  }
+
+  private async getSynologyDestination(request: DownloadRequest): Promise<string | undefined> {
+    return (
+      request.downloadPath ||
+      this.downloader.downloadPath ||
+      (await this.getNasDefaultDestination())
+    );
   }
 
   /**
@@ -824,7 +887,15 @@ export class SynologyDownloadStationClient implements DownloaderClient {
 
       await this.ensureApiInfo();
       const { apiName } = this.getTaskApiDescriptor();
-      const destination = this.getSynologyDestination(request);
+      const destination = await this.getSynologyDestination(request);
+      if (!destination?.trim()) {
+        return {
+          success: false,
+          message:
+            "No download destination configured. Set a Download Path for this downloader in " +
+            "Questarr, or configure a default destination in Synology Download Station settings.",
+        };
+      }
       const isMagnet = request.url.startsWith("magnet:");
 
       const createUrlDownload = async (downloadUrl: string) => {

--- a/server/downloaders/synology.ts
+++ b/server/downloaders/synology.ts
@@ -658,6 +658,127 @@ export class SynologyDownloadStationClient implements DownloaderClient {
     return request.downloadPath || this.downloader.downloadPath || undefined;
   }
 
+  /**
+   * DS2's create-task request shape is unconfirmed against a real device (see
+   * docs/synology-download-station-api-notes.md) and two plausible sources disagree: Prowlarr's
+   * proxy (GET, bare values) vs. the dvcol/synology-download browser extension (POST, JSON-quoted
+   * values, `_sid` in the query string only). Rather than guess, we try each variant in order and
+   * log which one is attempted/succeeds/fails, so a real-device test run tells us definitively
+   * which contract this Synology's DSM version actually expects.
+   */
+  private buildDs2UrlCreateVariants(
+    downloadUrl: string,
+    trimmedDestination: string | undefined
+  ): {
+    name: string;
+    options: {
+      httpMethod: "GET" | "POST";
+      sidInQuery?: boolean;
+      params: Record<string, string | number | boolean | undefined>;
+    };
+  }[] {
+    return [
+      {
+        // Prowlarr's proxy contract (current default, verified byte-for-byte against Prowlarr's
+        // live client, but not yet against a real Synology device).
+        name: "ds2-get-bare",
+        options: {
+          httpMethod: "GET",
+          params: {
+            type: "url",
+            url: downloadUrl,
+            create_list: false,
+            ...(trimmedDestination ? { destination: trimmedDestination } : {}),
+          },
+        },
+      },
+      {
+        // dvcol/synology-download extension contract (a live, purpose-built Synology Download
+        // Station client). Mirrors our own DS2 file-upload path: `_sid` in the query string only,
+        // POST body values JSON-encoded.
+        name: "ds2-post-json-sid-query",
+        options: {
+          httpMethod: "POST",
+          sidInQuery: true,
+          params: {
+            type: '"url"',
+            url: JSON.stringify([downloadUrl]),
+            create_list: false,
+            ...(trimmedDestination ? { destination: JSON.stringify(trimmedDestination) } : {}),
+          },
+        },
+      },
+      {
+        // Superseded Phase 1 contract (see docs) — POST with the legacy `uri` field name, no JSON
+        // quoting. Kept as a last-resort fallback since it was confirmed to fix the originally
+        // reported error 120, just via a different field name than Prowlarr's.
+        name: "ds2-post-uri-bare",
+        options: {
+          httpMethod: "POST",
+          params: {
+            type: "url",
+            uri: downloadUrl,
+            ...(trimmedDestination ? { destination: trimmedDestination } : {}),
+          },
+        },
+      },
+    ];
+  }
+
+  private async createUrlTask(
+    apiName: string,
+    downloadUrl: string,
+    trimmedDestination: string | undefined
+  ): Promise<SynologyTaskResponse> {
+    if (apiName !== "SYNO.DownloadStation2.Task") {
+      return this.requestTaskApi<SynologyTaskResponse>("create", {
+        httpMethod: "GET",
+        params: {
+          uri: downloadUrl,
+          ...(trimmedDestination ? { destination: trimmedDestination } : {}),
+        },
+      });
+    }
+
+    const variants = this.buildDs2UrlCreateVariants(downloadUrl, trimmedDestination);
+    let lastError: unknown;
+
+    for (const variant of variants) {
+      downloadersLogger.info(
+        {
+          downloaderId: this.downloader.id,
+          variant: variant.name,
+          httpMethod: variant.options.httpMethod,
+          params: variant.options.params,
+        },
+        "Trying Synology DS2 create-task request variant"
+      );
+
+      try {
+        const response = await this.requestTaskApi<SynologyTaskResponse>("create", variant.options);
+        downloadersLogger.info(
+          { downloaderId: this.downloader.id, variant: variant.name },
+          "Synology DS2 create-task variant succeeded"
+        );
+        return response;
+      } catch (error) {
+        lastError = error;
+        downloadersLogger.warn(
+          {
+            downloaderId: this.downloader.id,
+            variant: variant.name,
+            error: error instanceof Error ? error.message : error,
+          },
+          "Synology DS2 create-task variant failed, trying next fallback"
+        );
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new Error("All Synology DS2 create-task variants failed");
+  }
+
   async testConnection(): Promise<{ success: boolean; message: string }> {
     try {
       await this.authenticate();
@@ -708,21 +829,7 @@ export class SynologyDownloadStationClient implements DownloaderClient {
 
       const createUrlDownload = async (downloadUrl: string) => {
         const trimmedDestination = destination?.trim();
-        const isDs2 = apiName === "SYNO.DownloadStation2.Task";
-        const response = await this.requestTaskApi<SynologyTaskResponse>("create", {
-          httpMethod: "GET",
-          params: isDs2
-            ? {
-                type: "url",
-                url: downloadUrl,
-                create_list: false,
-                ...(trimmedDestination ? { destination: trimmedDestination } : {}),
-              }
-            : {
-                uri: downloadUrl,
-                ...(trimmedDestination ? { destination: trimmedDestination } : {}),
-              },
-        });
+        const response = await this.createUrlTask(apiName, downloadUrl, trimmedDestination);
 
         const id = response.data?.task_id?.[0];
         return {

--- a/server/downloaders/synology.ts
+++ b/server/downloaders/synology.ts
@@ -690,8 +690,8 @@ export class SynologyDownloadStationClient implements DownloaderClient {
             apiName === "SYNO.DownloadStation2.Task"
               ? {
                   type: "url",
-                  url: downloadUrl,
-                  create_list: "false",
+                  url: JSON.stringify([downloadUrl]),
+                  create_list: false,
                   destination,
                 }
               : {

--- a/server/downloaders/synology.ts
+++ b/server/downloaders/synology.ts
@@ -112,6 +112,16 @@ interface SynologyFileStationResponse extends SynologyApiResponse {
   };
 }
 
+/**
+ * Thrown only when Synology itself responded with `success: false` (an explicit API-level
+ * rejection, e.g. "invalid parameter" or "destination not found"). Transport-level failures
+ * (timeouts, non-2xx HTTP, JSON parse errors) surface as plain `Error`s instead, so callers can
+ * tell "the NAS understood the request and rejected it" apart from "we don't know what happened."
+ * This matters for createUrlTask's DS2 variant fallback: retrying after a transport failure risks
+ * creating a duplicate task if the NAS actually received and processed the first request.
+ */
+class SynologyApiError extends Error {}
+
 export class SynologyDownloadStationClient implements DownloaderClient {
   private downloader: Downloader;
   private sessionId: string | null = null;
@@ -437,7 +447,7 @@ export class SynologyDownloadStationClient implements DownloaderClient {
       }
 
       if (!response.success) {
-        throw new Error(
+        throw new SynologyApiError(
           this.buildSynologyErrorMessage(response.error, `Synology ${apiName}.${methodName} failed`)
         );
       }
@@ -479,7 +489,7 @@ export class SynologyDownloadStationClient implements DownloaderClient {
     }
 
     if (!response.success) {
-      throw new Error(
+      throw new SynologyApiError(
         this.buildSynologyErrorMessage(response.error, `Synology ${apiName}.${methodName} failed`)
       );
     }
@@ -825,12 +835,20 @@ export class SynologyDownloadStationClient implements DownloaderClient {
         );
         return response;
       } catch (error) {
+        // Only an explicit Synology rejection (success: false) tells us the NAS understood the
+        // request and refused it, so it's safe to retry with a different variant. A transport
+        // failure (timeout, non-2xx, JSON parse error) leaves it unknown whether the task was
+        // already created; retrying then risks creating a duplicate, so fail fast instead.
+        if (!(error instanceof SynologyApiError)) {
+          throw error;
+        }
+
         lastError = error;
         downloadersLogger.warn(
           {
             downloaderId: this.downloader.id,
             variant: variant.name,
-            error: error instanceof Error ? error.message : error,
+            error: error.message,
           },
           "Synology DS2 create-task variant failed, trying next fallback"
         );

--- a/server/downloaders/synology.ts
+++ b/server/downloaders/synology.ts
@@ -769,7 +769,7 @@ export class SynologyDownloadStationClient implements DownloaderClient {
     }
 
     if (apiName === "SYNO.DownloadStation2.Task") {
-      formData.append("type", "file");
+      formData.append("type", request.downloadType === "usenet" ? "nzb" : "bt");
     }
 
     const uploadResponse = await this.requestTaskApi<SynologyTaskResponse>("create", {

--- a/server/types/node-7z.d.ts
+++ b/server/types/node-7z.d.ts
@@ -1,0 +1,1 @@
+declare module "node-7z";


### PR DESCRIPTION
This pull request makes substantial improvements to the Synology Download Station integration, aligning the implementation with the reverse-engineered, production-proven contract used by Prowlarr. It clarifies and codifies previously undocumented or misunderstood behaviors in both the code and documentation, ensuring robust support for both current and legacy Synology APIs. The changes also add comprehensive regression tests and update documentation to prevent future confusion.

The most important changes are:

**Synology Download Station API contract alignment:**
* Adopted Prowlarr’s reverse-engineered contract for both DS2 and legacy APIs in `server/downloaders/synology.ts`, including correct HTTP methods, parameter quoting, multipart field ordering, and session handling. This includes sending URL/magnet adds as GET requests, using JSON-quoted parameters and special field names for DS2 uploads, and moving `_sid` to the query string for DS2 POSTs. [[1]](diffhunk://#diff-8b696f858106043bb6b41d66648a5f87b616a783185523ffc5b50bd0fe6641dbR357-R370) [[2]](diffhunk://#diff-8b696f858106043bb6b41d66648a5f87b616a783185523ffc5b50bd0fe6641dbL376-R393) [[3]](diffhunk://#diff-8b696f858106043bb6b41d66648a5f87b616a783185523ffc5b50bd0fe6641dbR431) [[4]](diffhunk://#diff-8b696f858106043bb6b41d66648a5f87b616a783185523ffc5b50bd0fe6641dbL428-R442)

**Documentation and decision tracking:**
* Added a detailed technical note in `docs/synology-download-station-api-notes.md` explaining the undocumented behaviors, rationale for implementation choices, and fallback strategies for future debugging.
* Recorded the architectural decision to follow Prowlarr’s contract in `memory/decisions.md`, including context and rationale.

**Test coverage and regression prevention:**
* Introduced new and updated regression tests in `server/__tests__/downloaders_synology_remaining.test.ts`, `downloaders_clients_regression.test.ts`, and `downloaders.test.ts` to verify correct API usage, parameter quoting, multipart field order, and session handling for both DS2 and legacy endpoints. [[1]](diffhunk://#diff-c188c91235a5f434d7ab66308db4cf7402f2366f281f0d8b8c5cbea701125861R431-R631) [[2]](diffhunk://#diff-9893de7b00ea463651e22c1515d25b943d2b41f91b1fb4cc14ed796c8c073ef5R501-R502) [[3]](diffhunk://#diff-9893de7b00ea463651e22c1515d25b943d2b41f91b1fb4cc14ed796c8c073ef5L549-R563) [[4]](diffhunk://#diff-2a9ba1617cc45a4d9ef18d3ed54f2f70c2791bc7f2abf7c0d64b57e9f8acf452L701-R703)

**Code cleanup:**
* Removed the unnecessary `@types/node-7z` dependency from `package.json`.

These changes ensure that the Synology Download Station integration is robust, maintainable, and based on the best available evidence from real-world deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Synology Download Station compatibility across legacy and DSM 7 APIs.
  * Added automatic fallback to the NAS default download destination when no path is configured.
  * Enhanced error messages with detailed destination and field-level failure information.
  * Improved reliability for magnet links, file uploads, authentication retries, and multipart requests.

* **Documentation**
  * Added detailed documentation covering Synology API request formats, compatibility differences, fallbacks, and known error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->