### PR TITLE
🎨 Palette: Enhance accessibility of RSS Feed links and controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,7 @@
 
 **Learning:** List components (like GameCard/CompactGameCard) were using generic aria-labels (e.g., "View details") or no labels for icon-only buttons. This makes screen reader navigation confusing as users hear "View details" repeatedly without knowing which item it refers to.
 **Action:** Always include the item's unique identifier (e.g., title) in the aria-label for actions within a list item (e.g., `aria-label={\`View details for ${game.title}\`}`).
+## 2025-02-22 - [Redundant text in parent components]
+
+**Learning:** When adding context-rich `aria-labels` to parent interactive elements (like a `button` or `a` tag) that already contain visually rendered text or icons inside them, screen readers may redundantly announce both the parent label AND the internal text/icons, causing confusing duplication for the user.
+**Action:** When adding a consolidated or context-rich `aria-label` to a parent interactive element, any child decorative elements, status icons, or visually rendered text (e.g., a responsive `span`) within it must be explicitly marked with `aria-hidden="true"` to prevent redundant screen reader announcements.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,5 +9,5 @@
 **Action:** Always include the item's unique identifier (e.g., title) in the aria-label for actions within a list item (e.g., `aria-label={\`View details for ${game.title}\`}`).
 ## 2025-02-22 - [Redundant text in parent components]
 
-**Learning:** When adding context-rich `aria-labels` to parent interactive elements (like a `button` or `a` tag) that already contain visually rendered text or icons inside them, screen readers may redundantly announce both the parent label AND the internal text/icons, causing confusing duplication for the user.
-**Action:** When adding a consolidated or context-rich `aria-label` to a parent interactive element, any child decorative elements, status icons, or visually rendered text (e.g., a responsive `span`) within it must be explicitly marked with `aria-hidden="true"` to prevent redundant screen reader announcements.
+**Learning:** When adding context-rich ARIA labels to parent interactive elements (like a button or anchor tag), the ARIA label completely overrides the text content of its children for screen readers. However, marking all children (including visual text) as hidden from ARIA is an anti-pattern that can cause some screen readers to treat the element as empty or skip it.
+**Action:** When adding an ARIA label to a parent interactive element, only mark purely decorative elements (like icons) as hidden. Do not apply aria-hidden to visual text spans inside the interactive element.

--- a/client/src/components/CompactRssFeedItem.tsx
+++ b/client/src/components/CompactRssFeedItem.tsx
@@ -72,7 +72,7 @@ const CompactRssFeedItem = ({ item }: CompactRssFeedItemProps) => {
             aria-label={`View original article for ${item.title}`}
           >
             <ExternalLink className="w-4 h-4" aria-hidden="true" />
-            <span className="hidden sm:inline" aria-hidden="true">
+            <span className="hidden sm:inline">
               View
             </span>
           </a>

--- a/client/src/components/CompactRssFeedItem.tsx
+++ b/client/src/components/CompactRssFeedItem.tsx
@@ -65,9 +65,16 @@ const CompactRssFeedItem = ({ item }: CompactRssFeedItemProps) => {
       {/* Actions */}
       <div className="flex items-center gap-2 self-center">
         <Button variant="outline" size="sm" className="h-8 gap-2" asChild>
-          <a href={safeUrl(item.link)} target="_blank" rel="noopener noreferrer">
-            <ExternalLink className="w-4 h-4" />
-            <span className="hidden sm:inline">View</span>
+          <a
+            href={safeUrl(item.link)}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`View original article for ${item.title}`}
+          >
+            <ExternalLink className="w-4 h-4" aria-hidden="true" />
+            <span className="hidden sm:inline" aria-hidden="true">
+              View
+            </span>
           </a>
         </Button>
       </div>

--- a/client/src/components/RssFeedList.tsx
+++ b/client/src/components/RssFeedList.tsx
@@ -69,8 +69,9 @@ export default function RssFeedList() {
             className="h-8 w-8 p-0"
             onClick={() => setViewMode("grid")}
             title="Grid View"
+            aria-label="Grid View"
           >
-            <LayoutGrid className="h-4 w-4" />
+            <LayoutGrid className="h-4 w-4" aria-hidden="true" />
           </Button>
           <Button
             variant={viewMode === "list" ? "secondary" : "ghost"}
@@ -78,8 +79,9 @@ export default function RssFeedList() {
             className="h-8 w-8 p-0"
             onClick={() => setViewMode("list")}
             title="List View"
+            aria-label="List View"
           >
-            <List className="h-4 w-4" />
+            <List className="h-4 w-4" aria-hidden="true" />
           </Button>
         </div>
 
@@ -138,9 +140,10 @@ export default function RssFeedList() {
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-xs text-primary hover:underline flex items-center gap-1 mt-2"
+                  aria-label={`View original article for ${item.title}`}
                 >
-                  <ExternalLink className="h-3 w-3" />
-                  View Original
+                  <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                  <span aria-hidden="true">View Original</span>
                 </a>
               </CardContent>
             </Card>

--- a/client/src/components/RssFeedList.tsx
+++ b/client/src/components/RssFeedList.tsx
@@ -143,7 +143,7 @@ export default function RssFeedList() {
                   aria-label={`View original article for ${item.title}`}
                 >
                   <ExternalLink className="h-3 w-3" aria-hidden="true" />
-                  <span aria-hidden="true">View Original</span>
+                  View Original
                 </a>
               </CardContent>
             </Card>


### PR DESCRIPTION
🎨 Palette: Enhance accessibility in RSS Feed lists

### 💡 What

Added context-rich `aria-labels` to icon-only buttons and external links in the RSS feed pages, and prevented redundant screen-reader announcements by hiding visual internal elements with `aria-hidden="true"`.

### 🎯 Why

- The view mode toggles (Grid/List) in the RSS Feed List were missing explicit accessible names, meaning screen readers would announce them vaguely (often just as "button").
- The external "View" links for RSS articles were previously either icon-only or generic ("View Original"). In lists with multiple items, having numerous generic "View" links makes navigation extremely confusing for screen reader users, as they lack context on what they are viewing without manually scanning adjacent content.
- When replacing visual text/icons with a parent `aria-label`, adding `aria-hidden="true"` to the children prevents screen readers from redundantly reading both.

### ♿ Accessibility

- Screen readers will now announce "Grid View" and "List View" for the toggle buttons.
- Screen readers will now announce "View original article for [Specific Article Title]" instead of a generic "View Original" or "Link" for every item in the feed list.

---

*PR created automatically by Jules for task [2552169373473404131](https://jules.google.com/task/2552169373473404131) started by @Doezer*