### PR TITLE
In the import modal, show the list of files so the user can know if they have to unpack before they chose to do it.

### DIFF
--- a/client/src/components/ImportReviewModal.tsx
+++ b/client/src/components/ImportReviewModal.tsx
@@ -20,7 +20,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Loader2, FolderOpen } from "lucide-react";
+import { Loader2, FolderOpen, Package, File } from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { useToast } from "@/hooks/use-toast";
 import { Switch } from "@/components/ui/switch";
 import { FileBrowser } from "./FileBrowser";
@@ -58,7 +59,11 @@ export default function ImportReviewModal({
 
   const planApplied = useRef(false);
 
-  const { data: planData } = useQuery<{ originalPath: string; proposedPath: string }>({
+  const { data: planData } = useQuery<{
+    originalPath: string;
+    proposedPath: string;
+    files: Array<{ name: string; isArchive: boolean }>;
+  }>({
     queryKey: [`/api/imports/${downloadId}/plan`],
     enabled: open,
     retry: false,
@@ -203,6 +208,33 @@ export default function ImportReviewModal({
                 </Button>
               </div>
             </div>
+
+            {planData?.files && planData.files.length > 0 && (
+              <div className="space-y-1.5">
+                <Label>Download Contents</Label>
+                <ScrollArea className="h-32 rounded-md border p-2">
+                  <div className="space-y-0.5">
+                    {planData.files.map((f) => (
+                      <div key={f.name} className="flex items-center gap-1.5 text-xs">
+                        {f.isArchive ? (
+                          <Package className="h-3.5 w-3.5 shrink-0 text-amber-400" />
+                        ) : (
+                          <File className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                        )}
+                        <span className={f.isArchive ? "text-amber-400" : "text-muted-foreground"}>
+                          {f.name}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </ScrollArea>
+                {planData.files.some((f) => f.isArchive) && (
+                  <p className="text-xs text-amber-400/80">
+                    Archive files detected — consider enabling Unpack Archive below.
+                  </p>
+                )}
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label>Transfer Mode</Label>

--- a/client/src/components/ImportReviewModal.tsx
+++ b/client/src/components/ImportReviewModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import type { ImportConfig } from "@shared/schema";
 import {
@@ -59,15 +59,22 @@ export default function ImportReviewModal({
 
   const planApplied = useRef(false);
 
+  const planUrl = sourcePath
+    ? `/api/imports/${downloadId}/plan?sourcePath=${encodeURIComponent(sourcePath)}`
+    : `/api/imports/${downloadId}/plan`;
+
   const { data: planData } = useQuery<{
     originalPath: string;
     proposedPath: string;
     files: Array<{ name: string; isArchive: boolean }>;
+    hasArchive: boolean;
+    totalCount: number;
   }>({
-    queryKey: [`/api/imports/${downloadId}/plan`],
+    queryKey: [planUrl],
     enabled: open,
     retry: false,
     staleTime: 30_000,
+    placeholderData: keepPreviousData,
   });
 
   // Reset state on open, defaulting transfer mode to the user's configured setting
@@ -226,9 +233,15 @@ export default function ImportReviewModal({
                         </span>
                       </div>
                     ))}
+                    {planData.totalCount > planData.files.length && (
+                      <p className="text-xs text-muted-foreground pt-0.5">
+                        …and {planData.totalCount - planData.files.length} more file
+                        {planData.totalCount - planData.files.length === 1 ? "" : "s"} not shown
+                      </p>
+                    )}
                   </div>
                 </ScrollArea>
-                {planData.files.some((f) => f.isArchive) && (
+                {planData.hasArchive && (
                   <p className="text-xs text-amber-400/80">
                     Archive files detected — consider enabling Unpack Archive below.
                   </p>

--- a/server/__tests__/import_manager_additional.test.ts
+++ b/server/__tests__/import_manager_additional.test.ts
@@ -19,6 +19,11 @@ const { fsMock, downloadersMock } = vi.hoisted(() => ({
 vi.mock("fs-extra", () => ({ default: fsMock }));
 vi.mock("../downloaders.js", () => ({ DownloaderManager: downloadersMock }));
 
+const isSensitivePathMock = vi.hoisted(() =>
+  vi.fn<(path: string) => boolean>().mockReturnValue(false)
+);
+vi.mock("../path-security.js", () => ({ isSensitivePath: isSensitivePathMock }));
+
 import { ImportManager } from "../services/ImportManager.js";
 import { PCImportStrategy } from "../services/ImportStrategies.js";
 import { makeImportConfig } from "./helpers/import-test-helpers.js";
@@ -276,6 +281,108 @@ describe("ImportManager - planConfirmImport", () => {
 
     expect(result.originalPath).toBeNull();
     expect(result.proposedPath).toContain("Graceful Game");
+  });
+});
+
+// ─── readSourceFiles behavior (via planConfirmImport) ─────────────────────────
+
+describe("ImportManager - readSourceFiles (via planConfirmImport)", () => {
+  function makeBaseStorage() {
+    const s = makeStorage();
+    s.getGameDownload.mockResolvedValue({
+      id: "dl-1",
+      gameId: "g1",
+      downloaderId: "d1",
+      downloadHash: "abc",
+    });
+    s.getGame.mockResolvedValue({
+      id: "g1",
+      title: "My Game",
+      userId: "u1",
+      status: "wanted",
+      platforms: [],
+    });
+    s.getImportConfig.mockResolvedValue(makeImportConfig({ libraryRoot: "/games" }));
+    return s;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isSensitivePathMock.mockReturnValue(false);
+    fsMock.stat.mockResolvedValue({ isDirectory: () => true });
+    fsMock.readdir.mockResolvedValue([]);
+  });
+
+  it("caps the file list at 100 entries and reports the full totalCount", async () => {
+    const allFiles = Array.from(
+      { length: 150 },
+      (_, i) => `file-${String(i).padStart(3, "0")}.bin`
+    );
+    fsMock.readdir.mockResolvedValue(allFiles);
+
+    const planSpy = vi
+      .spyOn(PCImportStrategy.prototype, "planImport")
+      .mockRejectedValue(new Error("ENOENT"));
+
+    const manager = makeManager(makeBaseStorage());
+    const result = await manager.planConfirmImport("dl-1", "/data/downloads/big-game");
+
+    expect(result.files).toHaveLength(100);
+    expect(result.totalCount).toBe(150);
+    expect(result.hasArchive).toBe(false);
+
+    planSpy.mockRestore();
+  });
+
+  it("reports hasArchive=true even when the archive falls beyond the 100-file cap", async () => {
+    // Use zero-padded names so lexicographic sort keeps all 100 "file-*" entries
+    // before "zzz-archive.zip", which then lands beyond the cap at index 100.
+    const regularFiles = Array.from(
+      { length: 100 },
+      (_, i) => `file-${String(i).padStart(3, "0")}.bin`
+    );
+    const allFiles = [...regularFiles, "zzz-archive.zip", "zzz-extra.bin"];
+    fsMock.readdir.mockResolvedValue(allFiles);
+
+    const archiveService = {
+      isArchive: vi.fn().mockImplementation((name: string) => name.endsWith(".zip")),
+      extract: vi.fn(),
+    };
+    const planSpy = vi
+      .spyOn(PCImportStrategy.prototype, "planImport")
+      .mockRejectedValue(new Error("ENOENT"));
+
+    const manager = makeManager(makeBaseStorage(), { archiveService });
+    const result = await manager.planConfirmImport("dl-1", "/data/downloads/game");
+
+    expect(result.files).toHaveLength(100);
+    expect(result.files.every((f) => !f.isArchive)).toBe(true);
+    expect(result.hasArchive).toBe(true);
+    expect(result.totalCount).toBe(102);
+
+    planSpy.mockRestore();
+  });
+
+  it("returns empty file listing for sensitive source paths without touching the filesystem", async () => {
+    isSensitivePathMock.mockReturnValue(true);
+
+    const planSpy = vi.spyOn(PCImportStrategy.prototype, "planImport").mockResolvedValue({
+      needsReview: false,
+      strategy: "pc",
+      originalPath: "/etc",
+      proposedPath: "/games/PC/My Game",
+    });
+
+    const manager = makeManager(makeBaseStorage());
+    const result = await manager.planConfirmImport("dl-1", "/etc");
+
+    expect(result.files).toEqual([]);
+    expect(result.hasArchive).toBe(false);
+    expect(result.totalCount).toBe(0);
+    expect(fsMock.stat).not.toHaveBeenCalled();
+    expect(fsMock.readdir).not.toHaveBeenCalled();
+
+    planSpy.mockRestore();
   });
 });
 

--- a/server/__tests__/import_routes_coverage.test.ts
+++ b/server/__tests__/import_routes_coverage.test.ts
@@ -57,6 +57,9 @@ beforeEach(() => {
   mockImportManager.planConfirmImport.mockResolvedValue({
     originalPath: "/local/game.iso",
     proposedPath: "/data/PC/My Game",
+    files: [],
+    hasArchive: false,
+    totalCount: 0,
   });
 });
 
@@ -315,6 +318,9 @@ describe("GET /api/imports/:id/plan", () => {
     mockImportManager.planConfirmImport.mockResolvedValue({
       originalPath: "/local/downloads/game.iso",
       proposedPath: "/data/PC/My Game",
+      files: [],
+      hasArchive: false,
+      totalCount: 0,
     });
 
     const res = await request(createApp()).get("/api/imports/dl-1/plan");

--- a/server/path-security.ts
+++ b/server/path-security.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+
+const SENSITIVE_PATH_PREFIXES = ["/proc", "/sys", "/dev", "/run/secrets", "/etc", "/root"];
+
+/**
+ * Returns true if the given path resolves to a sensitive system directory.
+ * Resolves the path before comparing so traversal tricks like /data/../etc are caught.
+ */
+export function isSensitivePath(rawPath: string): boolean {
+  const resolved = path.resolve(rawPath).replaceAll("\\", "/");
+  return SENSITIVE_PATH_PREFIXES.some(
+    (prefix) => resolved === prefix || resolved.startsWith(prefix + "/")
+  );
+}

--- a/server/routes/system.ts
+++ b/server/routes/system.ts
@@ -3,6 +3,7 @@ import fs from "fs-extra";
 import path from "node:path";
 import { storage } from "../storage.js";
 import { routesLogger as logger } from "../logger.js";
+import { isSensitivePath } from "../path-security.js";
 
 // Allow browsing the entire container filesystem
 // Security is maintained by container isolation and explicit volume mounts
@@ -80,13 +81,7 @@ systemRouter.get("/browse", async (req, res) => {
       return res.status(400).json({ error: "Invalid path: traversal detected" });
     }
 
-    const SENSITIVE_PATH_PREFIXES = ["/proc", "/sys", "/dev", "/run/secrets", "/etc", "/root"];
-    const normalizedValid = validPath.replaceAll("\\", "/");
-    if (
-      SENSITIVE_PATH_PREFIXES.some(
-        (prefix) => normalizedValid === prefix || normalizedValid.startsWith(prefix + "/")
-      )
-    ) {
+    if (isSensitivePath(validPath)) {
       return res.status(403).json({ error: "Access to this path is not allowed" });
     }
 

--- a/server/services/ImportManager.ts
+++ b/server/services/ImportManager.ts
@@ -142,7 +142,9 @@ export class ImportManager {
     if (!stats.isDirectory()) return sourcePath;
 
     const entries = await fs.readdir(sourcePath);
-    const archiveEntries = entries.filter((name) => this.archiveService.isArchive(name)).sort();
+    const archiveEntries = entries
+      .filter((name: string) => this.archiveService.isArchive(name))
+      .sort();
     if (archiveEntries.length === 0) return sourcePath;
 
     // 7zip handles multi-part archives when given the first part
@@ -150,6 +152,24 @@ export class ImportManager {
     const extractDir = sourcePath + "_extracted";
     await this.archiveService.extract(mainArchive, extractDir);
     return extractDir;
+  }
+
+  private async readSourceFiles(
+    sourcePath: string
+  ): Promise<Array<{ name: string; isArchive: boolean }>> {
+    try {
+      const stats = await fs.stat(sourcePath);
+      if (stats.isDirectory()) {
+        const entries = await fs.readdir(sourcePath);
+        return entries
+          .sort()
+          .map((name: string) => ({ name, isArchive: this.archiveService.isArchive(name) }));
+      }
+      const name = path.basename(sourcePath);
+      return [{ name, isArchive: this.archiveService.isArchive(name) }];
+    } catch {
+      return [];
+    }
   }
 
   private extractRemoteHost(downloaderUrl: string): string | undefined {
@@ -407,7 +427,11 @@ export class ImportManager {
     downloadId: string,
     overrideSourcePath?: string,
     callerUserId?: string
-  ): Promise<{ originalPath: string | null; proposedPath: string }> {
+  ): Promise<{
+    originalPath: string | null;
+    proposedPath: string;
+    files: Array<{ name: string; isArchive: boolean }>;
+  }> {
     const download = await this.storage.getGameDownload(downloadId, callerUserId);
     if (!download) throw new Error(`Download ${downloadId} not found`);
 
@@ -429,6 +453,7 @@ export class ImportManager {
     const fallbackProposedPath = path.join(libraryRoot, platformDir, sanitizeFsName(game.title));
 
     if (resolvedOriginalPath) {
+      const files = await this.readSourceFiles(resolvedOriginalPath);
       try {
         const strategy = new PCImportStrategy();
         const plan = await strategy.planImport(
@@ -438,14 +463,14 @@ export class ImportManager {
           config,
           platformDir
         );
-        return { originalPath: resolvedOriginalPath, proposedPath: plan.proposedPath };
+        return { originalPath: resolvedOriginalPath, proposedPath: plan.proposedPath, files };
       } catch {
         // Source not yet accessible (e.g. still in incomplete folder) — path is known but can't be stat'd
-        return { originalPath: resolvedOriginalPath, proposedPath: fallbackProposedPath };
+        return { originalPath: resolvedOriginalPath, proposedPath: fallbackProposedPath, files };
       }
     }
 
-    return { originalPath: null, proposedPath: fallbackProposedPath };
+    return { originalPath: null, proposedPath: fallbackProposedPath, files: [] };
   }
 
   async confirmImport(

--- a/server/services/ImportManager.ts
+++ b/server/services/ImportManager.ts
@@ -14,6 +14,7 @@ import path from "node:path";
 import { parseReleaseMetadata } from "../../shared/title-utils.js";
 import { logger } from "../logger.js";
 import { extractHostnameFromUrl } from "../url-utils.js";
+import { isSensitivePath } from "../path-security.js";
 
 const RELEASE_PLATFORM_TO_IGDB_ID: Record<string, number> = {
   nes: 18,
@@ -70,6 +71,7 @@ const IGDB_ID_TO_PLATFORM_KEY: Record<number, string> = Object.fromEntries(
 );
 
 const MAX_PATH_RETRY = 5;
+const MAX_LISTED_FILES = 100;
 
 export class ImportManager {
   private readonly pathRetryCount = new Map<string, number>();
@@ -154,21 +156,33 @@ export class ImportManager {
     return extractDir;
   }
 
-  private async readSourceFiles(
-    sourcePath: string
-  ): Promise<Array<{ name: string; isArchive: boolean }>> {
+  private async readSourceFiles(sourcePath: string): Promise<{
+    files: Array<{ name: string; isArchive: boolean }>;
+    hasArchive: boolean;
+    totalCount: number;
+  }> {
+    const empty = { files: [], hasArchive: false, totalCount: 0 };
+    if (isSensitivePath(sourcePath)) return empty;
     try {
-      const stats = await fs.stat(sourcePath);
+      const resolved = path.resolve(sourcePath);
+      const stats = await fs.stat(resolved);
+      let allNames: string[];
       if (stats.isDirectory()) {
-        const entries = await fs.readdir(sourcePath);
-        return entries
-          .sort()
-          .map((name: string) => ({ name, isArchive: this.archiveService.isArchive(name) }));
+        allNames = (await fs.readdir(resolved)).sort();
+      } else {
+        allNames = [path.basename(resolved)];
       }
-      const name = path.basename(sourcePath);
-      return [{ name, isArchive: this.archiveService.isArchive(name) }];
+      const totalCount = allNames.length;
+      const capped = allNames.slice(0, MAX_LISTED_FILES);
+      const files = capped.map((name) => ({
+        name,
+        isArchive: this.archiveService.isArchive(name),
+      }));
+      // Check hasArchive across all entries, not just the capped slice
+      const hasArchive = allNames.some((name) => this.archiveService.isArchive(name));
+      return { files, hasArchive, totalCount };
     } catch {
-      return [];
+      return empty;
     }
   }
 
@@ -431,6 +445,8 @@ export class ImportManager {
     originalPath: string | null;
     proposedPath: string;
     files: Array<{ name: string; isArchive: boolean }>;
+    hasArchive: boolean;
+    totalCount: number;
   }> {
     const download = await this.storage.getGameDownload(downloadId, callerUserId);
     if (!download) throw new Error(`Download ${downloadId} not found`);
@@ -453,7 +469,7 @@ export class ImportManager {
     const fallbackProposedPath = path.join(libraryRoot, platformDir, sanitizeFsName(game.title));
 
     if (resolvedOriginalPath) {
-      const files = await this.readSourceFiles(resolvedOriginalPath);
+      const { files, hasArchive, totalCount } = await this.readSourceFiles(resolvedOriginalPath);
       try {
         const strategy = new PCImportStrategy();
         const plan = await strategy.planImport(
@@ -463,14 +479,32 @@ export class ImportManager {
           config,
           platformDir
         );
-        return { originalPath: resolvedOriginalPath, proposedPath: plan.proposedPath, files };
+        return {
+          originalPath: resolvedOriginalPath,
+          proposedPath: plan.proposedPath,
+          files,
+          hasArchive,
+          totalCount,
+        };
       } catch {
         // Source not yet accessible (e.g. still in incomplete folder) — path is known but can't be stat'd
-        return { originalPath: resolvedOriginalPath, proposedPath: fallbackProposedPath, files };
+        return {
+          originalPath: resolvedOriginalPath,
+          proposedPath: fallbackProposedPath,
+          files,
+          hasArchive,
+          totalCount,
+        };
       }
     }
 
-    return { originalPath: null, proposedPath: fallbackProposedPath, files: [] };
+    return {
+      originalPath: null,
+      proposedPath: fallbackProposedPath,
+      files: [],
+      hasArchive: false,
+      totalCount: 0,
+    };
   }
 
   async confirmImport(


### PR DESCRIPTION
This pull request enhances the import review experience by displaying the list of files detected in the import source, highlighting archive files, and updating the backend to provide this information. The frontend now shows file details in the review modal, and the backend returns file metadata as part of the import plan.

**Frontend improvements:**

* The import review modal (`ImportReviewModal.tsx`) now displays a scrollable list of detected files, showing archive files with a special icon and color. If any archive files are present, a warning message suggests enabling the "Unpack Archive" option.
* New icons (`Package`, `File`) and the `ScrollArea` component are imported to support the improved file display.
* The frontend expects the import plan API to return a `files` array with file names and archive status.

**Backend changes:**

* The `ImportManager` service now includes a `readSourceFiles` method to enumerate files in the import source and detect archive files.
* The `getImportPlan` method returns an additional `files` array with file names and archive status, ensuring the frontend receives this metadata. [[1]](diffhunk://#diff-3c18d33d1a37387159a6ebb9daff6455cd0730322f3b798506796c44917f3c61L410-R434) [[2]](diffhunk://#diff-3c18d33d1a37387159a6ebb9daff6455cd0730322f3b798506796c44917f3c61R456) [[3]](diffhunk://#diff-3c18d33d1a37387159a6ebb9daff6455cd0730322f3b798506796c44917f3c61L441-R473)
* Minor type clarification in filtering archive entries for improved readability.