### PR TITLE
Validate slash-command deploy args before dispatching workflow

### DIFF
--- a/.github/workflows/slash-command-listener.yml
+++ b/.github/workflows/slash-command-listener.yml
@@ -46,11 +46,36 @@ jobs:
             });
 
             // Parse named args: /deploy environment=production tag=v1.0 build_arm64=true
-            const args = {};
+            const rawArgs = {};
             body.split(/\s+/).slice(1).forEach(part => {
               const [k, ...rest] = part.split('=');
-              if (k && rest.length) args[k] = rest.join('=');
+              if (k && rest.length) rawArgs[k] = rest.join('=');
             });
+
+            // Validate and sanitize the comment-supplied args before they are
+            // forwarded to deploy.yml. Even though the commenter has already
+            // been verified as an admin, untrusted comment text must not be
+            // passed through unvalidated into the deployment pipeline.
+            const ALLOWED_ENVIRONMENTS = ['production', 'dev', 'test'];
+            const TAG_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$/;
+
+            const environment = rawArgs.environment || 'test';
+            if (!ALLOWED_ENVIRONMENTS.includes(environment)) {
+              console.log(`Rejected /deploy: invalid environment "${environment}"`);
+              return;
+            }
+
+            const tag = rawArgs.tag || '';
+            if (tag !== '' && !TAG_PATTERN.test(tag)) {
+              console.log(`Rejected /deploy: invalid tag "${tag}"`);
+              return;
+            }
+
+            const buildArm64Raw = rawArgs.build_arm64 || 'false';
+            if (buildArm64Raw !== 'true' && buildArm64Raw !== 'false') {
+              console.log(`Rejected /deploy: invalid build_arm64 "${buildArm64Raw}"`);
+              return;
+            }
 
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
@@ -58,9 +83,9 @@ jobs:
               workflow_id: 'deploy.yml',
               ref: pr.head.ref,
               inputs: {
-                environment: args.environment || 'test',
-                tag: args.tag || '',
-                build_arm64: args.build_arm64 || 'false',
+                environment,
+                tag,
+                build_arm64: buildArm64Raw,
                 'comment-id': String(context.payload.comment.id),
                 repository: `${context.repo.owner}/${context.repo.repo}`,
               },

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,6 +7,7 @@
 
 **Learning:** List components (like GameCard/CompactGameCard) were using generic aria-labels (e.g., "View details") or no labels for icon-only buttons. This makes screen reader navigation confusing as users hear "View details" repeatedly without knowing which item it refers to.
 **Action:** Always include the item's unique identifier (e.g., title) in the aria-label for actions within a list item (e.g., `aria-label={\`View details for ${game.title}\`}`).
+
 ## 2025-02-22 - [Redundant text in parent components]
 
 **Learning:** When adding context-rich ARIA labels to parent interactive elements (like a button or anchor tag), the ARIA label completely overrides the text content of its children for screen readers. However, marking all children (including visual text) as hidden from ARIA is an anti-pattern that can cause some screen readers to treat the element as empty or skip it.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -15,7 +15,9 @@
 **Vulnerability:** The RSS feed creation and update endpoints (`POST /api/rss/feeds` and `PUT /api/rss/feeds/:id`) lacked `isSafeUrl` validation, allowing attackers to force the server to fetch arbitrary URLs, including cloud metadata services (`169.254.169.254`).
 **Learning:** Even if `isSafeUrl` exists, it must be applied to _all_ inputs that trigger server-side requests. RSS feeds are a common vector for SSRF because they inherently involve fetching remote content.
 **Prevention:** Apply `isSafeUrl` validation to all URL inputs in API routes. Implement defense-in-depth by also validating the URL at the point of use (in `rssService.refreshFeed`).
+
 ## 2024-05-24 - SSRF Bypass via URL Userinfo
+
 **Vulnerability:** The `/api/stats/discord-share` endpoint was vulnerable to Server-Side Request Forgery (SSRF) because it validated webhook URLs using `startsWith("https://discord.com/api/webhooks/")` and then fetched them using the standard `fetch` API.
 **Learning:** Checking for string prefixes on URLs is insufficient for security because the userinfo component (e.g. `https://discord.com/api/webhooks/@127.0.0.1`) can be used to bypass the check. The `fetch` API and URL parsers will interpret `127.0.0.1` as the hostname and `discord.com` as the credentials.
 **Prevention:** Never rely on string prefix matching for URL validation. Always use the project's `safeFetch` utility which properly resolves and validates the target IP address to prevent SSRF and DNS rebinding attacks.

--- a/client/src/components/CompactRssFeedItem.tsx
+++ b/client/src/components/CompactRssFeedItem.tsx
@@ -72,9 +72,7 @@ const CompactRssFeedItem = ({ item }: CompactRssFeedItemProps) => {
             aria-label={`View original article for ${item.title}`}
           >
             <ExternalLink className="w-4 h-4" aria-hidden="true" />
-            <span className="hidden sm:inline">
-              View
-            </span>
+            <span className="hidden sm:inline">View</span>
           </a>
         </Button>
       </div>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3256,7 +3256,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (message) formData.append("content", message);
       formData.append("file", new Blob([imageBuffer], { type: "image/png" }), "questarr-stats.png");
 
-      const discordRes = await safeFetch(webhookUrl, { method: "POST", body: formData, allowPrivate: false });
+      const discordRes = await safeFetch(webhookUrl, {
+        method: "POST",
+        body: formData,
+        allowPrivate: false,
+      });
       if (!discordRes.ok) {
         const errorText = await discordRes.text().catch(() => "Unknown Discord error");
         routesLogger.error(


### PR DESCRIPTION
## Description

`.github/workflows/slash-command-listener.yml` parses `/deploy environment=... tag=... build_arm64=...` from PR comment bodies and forwards those values directly into `deploy.yml`'s `workflow_dispatch` inputs. Although the caller is already required to have admin permission, the comment text itself was never validated before being used to trigger the deployment pipeline (which controls the GitHub Environment, the image tag, and whether an ARM64 build runs).

This adds validation before the dispatch call:

- `environment` must be one of `production`, `dev`, `test`
- `tag` must match a safe Docker-tag pattern (alphanumeric plus `._-`, max 128 chars) or be empty
- `build_arm64` must be the literal string `true` or `false`

If any value fails validation, the dispatch is skipped and the reason is logged instead of forwarding unchecked input into the deploy workflow.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (no test suite covers GitHub Actions workflow scripts)

---

_Generated by [Claude Code](https://claude.ai/code/session_01RzYi4LGf4uebzpXyGXJ7qY)_