### PR TITLE
Add automatic SBOM generation to the Docker release pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -174,7 +174,7 @@ jobs:
 
           ### Inspect the SBOM attestation:
           \`\`\`bash
-          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:\$TAG --format '{{ json .SBOM }}'
+          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:\$TAG --format '{{ json (index .SBOM "linux/amd64").SPDX }}'
           \`\`\`
           EOF
           )

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,10 @@ jobs:
           REPO_NAME_LC=$(echo "$REPO_SHOULD_BE_NAME" | tr '[:upper:]' '[:lower:]')
           echo "REPO_NAME_LC=$REPO_NAME_LC" >> $GITHUB_ENV
 
+          # Full owner/repo, lowercased (GHCR requires lowercase image references)
+          REPO_LC=$(echo "$REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          echo "REPO_LC=$REPO_LC" >> $GITHUB_ENV
+
       - name: Set up QEMU
         if: inputs.build_arm64 == true
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
@@ -134,7 +138,7 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
+          image: ghcr.io/${{ env.REPO_LC }}@${{ steps.build.outputs.digest }}
           format: spdx-json
           output-file: sbom-questarr-${{ env.VERSION }}.spdx.json
 
@@ -157,24 +161,24 @@ jobs:
           ## Deployment Summary
 
           - **Environment:** ${{ env.ENVIRONMENT }}
-          - **Image:** ghcr.io/${{ github.repository }}
+          - **Image:** ghcr.io/${{ env.REPO_LC }}
           - **Docker Hub:** doezer/${{ env.REPO_NAME_LC }}
           - **Tags:** ${{ steps.meta.outputs.tags }}
           - **SBOM:** attached to the image as an attestation, and uploaded as the \`sbom-questarr-${{ env.VERSION }}-${{ env.ENVIRONMENT }}\` workflow artifact
 
           ### Pull and run the image:
           \`\`\`bash
-          docker pull ghcr.io/${{ github.repository }}:\$TAG
+          docker pull ghcr.io/${{ env.REPO_LC }}:\$TAG
           docker run -d -p 5000:5000 \\
             -e POSTGRES_PASSWORD=your_password \\
             -e IGDB_CLIENT_ID=your_client_id \\
             -e IGDB_CLIENT_SECRET=your_client_secret \\
-            ghcr.io/${{ github.repository }}:\$TAG
+            ghcr.io/${{ env.REPO_LC }}:\$TAG
           \`\`\`
 
           ### Inspect the SBOM attestation:
           \`\`\`bash
-          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:\$TAG --format '{{ json (index .SBOM "linux/amd64").SPDX }}'
+          docker buildx imagetools inspect ghcr.io/${{ env.REPO_LC }}:\$TAG --format '{{ json (index .SBOM "linux/amd64").SPDX }}'
           \`\`\`
           EOF
           )

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,6 +118,7 @@ jobs:
             org.opencontainers.image.vendor=Doezer
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
@@ -128,6 +129,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: production
+          sbom: true
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-questarr-${{ env.VERSION }}.spdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom-questarr-${{ env.VERSION }}-${{ env.ENVIRONMENT }}
+          path: sbom-questarr-${{ env.VERSION }}.spdx.json
+          retention-days: 90
 
       - name: Deployment summary
         id: summary
@@ -144,6 +160,7 @@ jobs:
           - **Image:** ghcr.io/${{ github.repository }}
           - **Docker Hub:** doezer/${{ env.REPO_NAME_LC }}
           - **Tags:** ${{ steps.meta.outputs.tags }}
+          - **SBOM:** attached to the image as an attestation, and uploaded as the \`sbom-questarr-${{ env.VERSION }}-${{ env.ENVIRONMENT }}\` workflow artifact
 
           ### Pull and run the image:
           \`\`\`bash
@@ -153,6 +170,11 @@ jobs:
             -e IGDB_CLIENT_ID=your_client_id \\
             -e IGDB_CLIENT_SECRET=your_client_secret \\
             ghcr.io/${{ github.repository }}:\$TAG
+          \`\`\`
+
+          ### Inspect the SBOM attestation:
+          \`\`\`bash
+          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:\$TAG --format '{{ json .SBOM }}'
           \`\`\`
           EOF
           )

--- a/README.md
+++ b/README.md
@@ -210,6 +210,16 @@ If you are upgrading from an older version that used PostgreSQL, you need to mig
 
 See [docs/MIGRATION.md](docs/MIGRATION.md) for more details.
 
+#### Software Bill of Materials (SBOM)
+
+Every published image is built with a Software Bill of Materials (SBOM), auto-generated at build time with [Syft](https://github.com/anchore/syft). The SBOM is attached to the image as an attestation and is also published as a downloadable artifact on the corresponding [Deploy Web App workflow run](https://github.com/Doezer/Questarr/actions/workflows/deploy.yml).
+
+To inspect the SBOM attached to an image directly:
+
+```bash
+docker buildx imagetools inspect ghcr.io/doezer/questarr:latest --format '{{ json .SBOM }}'
+```
+
 ## Configuration
 
 1. **First-time setup:**

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Every published image is built with a Software Bill of Materials (SBOM), auto-ge
 To inspect the SBOM attached to an image directly:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/doezer/questarr:latest --format '{{ json .SBOM }}'
+docker buildx imagetools inspect ghcr.io/doezer/questarr:latest --format '{{ json (index .SBOM "linux/amd64").SPDX }}'
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -210,15 +210,7 @@ If you are upgrading from an older version that used PostgreSQL, you need to mig
 
 See [docs/MIGRATION.md](docs/MIGRATION.md) for more details.
 
-#### Software Bill of Materials (SBOM)
-
-Every published image is built with a Software Bill of Materials (SBOM), auto-generated at build time with [Syft](https://github.com/anchore/syft). The SBOM is attached to the image as an attestation and is also published as a downloadable artifact on the corresponding [Deploy Web App workflow run](https://github.com/Doezer/Questarr/actions/workflows/deploy.yml).
-
-To inspect the SBOM attached to an image directly:
-
-```bash
-docker buildx imagetools inspect ghcr.io/doezer/questarr:latest --format '{{ json (index .SBOM "linux/amd64").SPDX }}'
-```
+Every published image ships with a Software Bill of Materials — see [docs/SBOM.md](docs/SBOM.md) for how to get it.
 
 ## Configuration
 

--- a/docs/SBOM.md
+++ b/docs/SBOM.md
@@ -1,0 +1,22 @@
+# Software Bill of Materials (SBOM)
+
+Every published Docker image is built with a Software Bill of Materials (SBOM), auto-generated at build time with [Syft](https://github.com/anchore/syft). This lets you see exactly what's inside an image — every package, library, and version — and feed that data into vulnerability scanners or SBOM catalogs like Dependency-Track.
+
+## Where to find it
+
+- **Attached to the image:** the SBOM is pushed alongside the image as an attestation, so it travels with whichever tag or digest you pull.
+- **As a downloadable file:** each [Deploy Web App workflow run](https://github.com/Doezer/Questarr/actions/workflows/deploy.yml) uploads the SBOM as an SPDX-JSON artifact you can download directly from the run summary.
+
+## Inspecting the attached SBOM
+
+Use `docker buildx imagetools inspect` to pull the SPDX JSON for a given image and tag:
+
+```bash
+docker buildx imagetools inspect ghcr.io/doezer/questarr:latest --format '{{ json (index .SBOM "linux/amd64").SPDX }}'
+```
+
+This prints the full SPDX document, which you can redirect to a file or pipe into a tool like `jq` or a vulnerability scanner:
+
+```bash
+docker buildx imagetools inspect ghcr.io/doezer/questarr:latest --format '{{ json (index .SBOM "linux/amd64").SPDX }}' > sbom.spdx.json
+```


### PR DESCRIPTION
## Summary

OSPS-QA-02.02 requires that all released compiled software assets be delivered with a Software Bill of Materials (SBOM). Questarr's only released artifact is the Docker image published by `.github/workflows/deploy.yml`, so this adds automatic, build-time SBOM generation to that pipeline using [Syft](https://github.com/anchore/syft) (via Anchore's `sbom-action`), a widely-used, vetted SBOM generator.

- Enable Docker Buildx's native `sbom: true` attestation on the "Build and push Docker image" step, so every published image (GHCR + Docker Hub) carries an attached SBOM attestation retrievable via `docker buildx imagetools inspect`.
- Add an explicit "Generate SBOM" step (`anchore/sbom-action`) that scans the just-pushed image by digest and produces a standalone SPDX-JSON SBOM file.
- Upload that SBOM file as a workflow artifact (`actions/upload-artifact`) so it can be downloaded independently of the image, e.g. for ingestion into tools like Dependency-Track.
- Update the deployment summary step to surface where the SBOM lives and how to inspect it.
- Document SBOM availability in the README's installation section.

## Test plan

- [x] Validated the updated `deploy.yml` parses as valid YAML.
- [x] Ran `npx prettier --check` on the modified workflow and README.
- [ ] Trigger the `Deploy Web App` workflow (manual dispatch) and confirm the `Generate SBOM` / `Upload SBOM artifact` steps succeed and the artifact is downloadable.

---

_Generated by [Claude Code](https://claude.ai/code/session_01Y2ifKwaVt59Z2qr1892atz)_