### PR TITLE
Add collaborator access & escalation review policy

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -74,6 +74,10 @@ npm run format
 - Open a new issue if you find a bug or have a feature request
 - Be respectful and constructive in all interactions
 
+## Collaborator Access
+
+Requests for elevated repository access (merge/write permissions, secrets, or infrastructure access) are subject to review and approval per our [Collaborator Access & Escalation Policy](./SECURITY.md#collaborator-access--escalation-policy). New contributors should start by submitting pull requests from a fork; escalated access is granted only after identity vetting and maintainer approval.
+
 ## Code of Conduct
 
 - Be respectful and inclusive

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -36,3 +36,43 @@ Update the `docker-compose.yml` or use a `.env` file to set strong passwords for
 ### 4. Authentication
 
 - The application uses a default admin setup flow. Ensure you complete the setup immediately after deployment to claim the admin account.
+
+## Collaborator Access & Escalation Policy
+
+This policy governs how contributors are granted escalated permissions to this repository and its associated infrastructure. It is enforced by repository maintainers/admins for every access request — no escalation may be granted outside this process.
+
+### Scope
+
+"Escalated permissions" covers any of the following:
+
+- Write, Maintain, or Admin roles on the GitHub repository
+- Merge/approval rights on pull requests (including bypassing branch protection)
+- Access to repository or organization **Secrets** (Actions secrets, environment secrets, deploy keys, `.env` values for shared/hosted environments)
+- Access to production or staging infrastructure (hosting provider, database, CI/CD runners)
+- Ability to modify CI/CD workflows, branch protection rules, or this policy itself
+
+### Requirement: Review Before Grant
+
+No contributor may be granted an escalated permission listed above without prior review and explicit approval by an existing repository admin/maintainer. This includes:
+
+1. **Request & record** — The requested role/access and its justification are recorded (e.g., in an issue, PR, or admin log) before being granted, not after.
+2. **Independent approval** — The grant must be approved by an admin/maintainer other than the requester. A contributor cannot self-approve their own escalation.
+3. **Least privilege** — Grant the minimum role/access needed for the contributor's actual responsibilities (e.g., prefer Write over Maintain, avoid org-wide secrets access for repo-scoped work).
+4. **Time-bound where practical** — Temporary or contract contributors should have access scoped to the duration of their engagement and reviewed/revoked on completion.
+
+### Identity Vetting
+
+Before approving escalated access, the approver should establish a justifiable lineage of identity for the contributor, using one or more of:
+
+- Confirming the contributor's association with a known, trusted organization (verified work email domain, employer/organization GitHub membership, or a signed statement from a known point of contact at that organization)
+- A documented history of reviewed, merged contributions from the same account prior to escalation
+- Vouching by an existing trusted collaborator or maintainer who can attest to the contributor's identity
+- Verification of a persistent, non-anonymous identity (e.g., a GitHub account with verifiable history, linked organization, or public reputation) rather than a newly created or anonymous account
+
+Requests that cannot establish any of the above should be denied or downgraded to a lesser scope (e.g., fork-and-PR contribution without direct write access) until sufficient trust is established.
+
+### Periodic Review & Revocation
+
+- Maintainers should periodically review the list of collaborators with escalated access (`Settings > Collaborators and teams`) and remove access that is no longer needed.
+- Access must be revoked promptly when a contributor's engagement ends, their role changes, or trust in their identity/affiliation is called into question.
+- Any suspected compromise of a collaborator account or leaked secret must be treated as a security incident: revoke access immediately, rotate affected secrets, and follow the vulnerability reporting process above.


### PR DESCRIPTION
## Description

Publishes an enforceable policy requiring code collaborators to be reviewed and approved before being granted escalated permissions to sensitive resources (merge/write access, secrets, infrastructure). Adds a new "Collaborator Access & Escalation Policy" section to `.github/SECURITY.md` covering:

- Scope of what counts as "escalated permissions" (repo roles, merge/bypass rights, secrets, infra access, CI/CD config changes)
- A requirement that every grant be requested, recorded, and approved by an admin/maintainer other than the requester (no self-approval), following least privilege
- Identity vetting guidance recommending contributors establish a justifiable lineage of identity, e.g. confirming association with a known trusted organization, verified contribution history, or vouching by an existing trusted collaborator
- Periodic review and prompt revocation of access, including incident-response steps if a collaborator account or secret is compromised

Also cross-links the new policy from `.github/CONTRIBUTING.md` so contributors requesting elevated access are pointed to it.

## Type of change

- [x] Documentation update

## Checklist:

- [x] My changes follow the style/structure of existing docs in this project
- [x] I have performed a self-review of the changes
- [x] N/A — no code changes, tests, or comments required

---

_Generated by [Claude Code](https://claude.ai/code/session_01Wgx7of554dCW2Ret63YbHz)_