### PR TITLE
🎨 Palette: [UX improvement] Contextual ARIA labels for icon buttons

### DIFF
--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -884,7 +884,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                                 variant="ghost"
                                 size="icon"
                                 className="h-7 w-7 text-muted-foreground hover:text-destructive"
-                                aria-label="Remove download record"
+                                aria-label={`Remove download record ${dl.downloadTitle}`}
                                 disabled={
                                   removeDownloadMutation.isPending &&
                                   removeDownloadMutation.variables === dl.id

--- a/client/src/components/PreferredReleaseGroupsSettings.tsx
+++ b/client/src/components/PreferredReleaseGroupsSettings.tsx
@@ -126,6 +126,7 @@ export default function PreferredReleaseGroupsSettings({
                 size="icon"
                 onClick={handleAddGroup}
                 disabled={!inputValue.trim()}
+                aria-label="Add group"
               >
                 <Plus className="h-4 w-4" />
               </Button>

--- a/client/src/lib/downloads-utils.ts
+++ b/client/src/lib/downloads-utils.ts
@@ -2,13 +2,7 @@
  * Download status type for torrent and usenet clients
  */
 export type DownloadStatusType =
-  | "downloading"
-  | "seeding"
-  | "completed"
-  | "paused"
-  | "error"
-  | "repairing"
-  | "unpacking";
+  "downloading" | "seeding" | "completed" | "paused" | "error" | "repairing" | "unpacking";
 
 /**
  * Download type

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1527,8 +1527,7 @@ export class DatabaseStorage implements IStorage {
             topStatus: row.topStatus as DownloadSummary["topStatus"],
             count: row.count,
             downloadTypes: (row.downloadTypes ?? "torrent").split(",").filter(Boolean) as (
-              | "torrent"
-              | "usenet"
+              "torrent" | "usenet"
             )[],
             hasUpdateDownload: row.hasUpdateDownload > 0,
           },


### PR DESCRIPTION
### 💡 What

Added context-rich `aria-label` attributes to icon-only buttons:

1. In `PreferredReleaseGroupsSettings.tsx`, the `+` button now has `aria-label="Add group"`.
2. In `GameDetailsModal.tsx`, the remove download button now includes the specific download title (e.g., `aria-label="Remove download record The Legend of Zelda"`).

### 🎯 Why

Icon-only buttons without accessible names are announced simply as "button" by screen readers, providing no context about their function. This is especially problematic in lists where multiple identical buttons exist (like the download history in the Game Details modal). Adding descriptive, contextual labels makes the UI predictable and fully navigable for assistive technology users.

### ♿ Accessibility

- Fixed WCAG 4.1.2 (Name, Role, Value) violations for icon-only buttons.
- Improved context for screen reader users when interacting with repeating list items.

---

*PR created automatically by Jules for task [16596642747240817358](https://jules.google.com/task/16596642747240817358) started by @Doezer*