### PR TITLE
🛡️ Sentinel: Improve Discord webhook validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,8 @@
 **Vulnerability:** The `/api/stats/discord-share` endpoint was vulnerable to Server-Side Request Forgery (SSRF) because it validated webhook URLs using `startsWith("https://discord.com/api/webhooks/")` and then fetched them using the standard `fetch` API.
 **Learning:** Checking for string prefixes on URLs is insufficient for security because the userinfo component (e.g. `https://discord.com/api/webhooks/@127.0.0.1`) can be used to bypass the check. The `fetch` API and URL parsers will interpret `127.0.0.1` as the hostname and `discord.com` as the credentials.
 **Prevention:** Never rely on string prefix matching for URL validation. Always use the project's `safeFetch` utility which properly resolves and validates the target IP address to prevent SSRF and DNS rebinding attacks.
+
+## $(date +%Y-%m-%d) - Prevent SSRF by validating parsed URL components instead of prefix matching
+**Vulnerability:** The application validated Discord webhook URLs (and potentially other external URLs) by matching the string prefix (`url.startsWith("https://discord.com")`). This is vulnerable to SSRF bypasses via the userinfo component (e.g., `https://discord.com@127.0.0.1/api/webhooks/`).
+**Learning:** Checking string prefixes for URL validation is fundamentally insecure because parts of the prefix might be interpreted as the username/password in a URL with a different domain. Attackers can leverage this to bypass domain allowlists.
+**Prevention:** Always use the `URL` object (e.g., `new URL()`) to parse URLs and explicitly validate the `hostname` and `pathname` properties instead of checking raw string prefixes.

--- a/client/src/lib/downloads-utils.ts
+++ b/client/src/lib/downloads-utils.ts
@@ -2,13 +2,7 @@
  * Download status type for torrent and usenet clients
  */
 export type DownloadStatusType =
-  | "downloading"
-  | "seeding"
-  | "completed"
-  | "paused"
-  | "error"
-  | "repairing"
-  | "unpacking";
+  "downloading" | "seeding" | "completed" | "paused" | "error" | "repairing" | "unpacking";
 
 /**
  * Download type

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -1888,6 +1888,15 @@ describe("API Routes - Extended Coverage", () => {
         expect(storage.setSystemConfig).not.toHaveBeenCalled();
       });
 
+      it("should reject SSRF payload bypassing string matching", async () => {
+        const response = await request(app)
+          .post("/api/settings/discord")
+          .send({ webhookUrl: "https://discord.com@127.0.0.1/api/webhooks/123/abc" });
+        expect(response.status).toBe(400);
+        expect(response.body.error).toMatch(/invalid/i);
+        expect(storage.setSystemConfig).not.toHaveBeenCalled();
+      });
+
       it("should clear the webhook URL when empty string is sent", async () => {
         vi.mocked(storage.setSystemConfig).mockResolvedValue(undefined);
         const response = await request(app).post("/api/settings/discord").send({ webhookUrl: "" });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2760,12 +2760,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/settings/discord", async (req, res) => {
     try {
       const { webhookUrl } = req.body as { webhookUrl?: string };
-      if (
-        webhookUrl &&
-        !webhookUrl.startsWith("https://discord.com/api/webhooks/") &&
-        !webhookUrl.startsWith("https://discordapp.com/api/webhooks/")
-      ) {
-        return res.status(400).json({ error: "Invalid Discord webhook URL" });
+      if (webhookUrl) {
+        try {
+          const url = new URL(webhookUrl);
+          if (
+            (url.hostname !== "discord.com" && url.hostname !== "discordapp.com") ||
+            !url.pathname.startsWith("/api/webhooks/")
+          ) {
+            return res.status(400).json({ error: "Invalid Discord webhook URL" });
+          }
+        } catch {
+          return res.status(400).json({ error: "Invalid Discord webhook URL" });
+        }
       }
       await storage.setSystemConfig("discord.webhookUrl", webhookUrl?.trim() ?? "");
       res.json({ success: true });
@@ -3228,10 +3234,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
         });
       }
 
-      if (
-        !webhookUrl.startsWith("https://discord.com/api/webhooks/") &&
-        !webhookUrl.startsWith("https://discordapp.com/api/webhooks/")
-      ) {
+      try {
+        const url = new URL(webhookUrl);
+        if (
+          (url.hostname !== "discord.com" && url.hostname !== "discordapp.com") ||
+          !url.pathname.startsWith("/api/webhooks/")
+        ) {
+          throw new Error("Invalid webhook domain or path");
+        }
+      } catch {
         routesLogger.error(
           { webhookUrl },
           "Attempted to use an invalid Discord webhook URL for sharing."

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1527,8 +1527,7 @@ export class DatabaseStorage implements IStorage {
             topStatus: row.topStatus as DownloadSummary["topStatus"],
             count: row.count,
             downloadTypes: (row.downloadTypes ?? "torrent").split(",").filter(Boolean) as (
-              | "torrent"
-              | "usenet"
+              "torrent" | "usenet"
             )[],
             hasUpdateDownload: row.hasUpdateDownload > 0,
           },


### PR DESCRIPTION
This pull request improves the validation of Discord webhook URLs in the backend settings and stats sharing endpoints. \n\nBy parsing the URL directly and strictly checking the `hostname` and `pathname` properties rather than relying on string prefix matching, it prevents potential bypasses via the userinfo component, making the webhook configuration much more robust and less susceptible to malicious input. \n\nAlso adds automated tests for this behavior.

---

*PR created automatically by Jules for task [5417910714600272450](https://jules.google.com/task/5417910714600272450) started by @Doezer*