### PR TITLE
Add MAINTAINERS.md documenting project members with sensitive access

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -41,7 +41,7 @@ Questarr uses SQLite, not PostgreSQL — the provided `docker-compose.yml` does 
 
 This policy governs how contributors are granted escalated permissions to this repository and its associated infrastructure. It is enforced by repository maintainers/admins for every access request — no escalation may be granted outside this process.
 
-The current list of project members holding escalated access is maintained in [MAINTAINERS.md](../MAINTAINERS.md).
+The current list of project members holding escalated access is maintained in [MAINTAINERS.md](/MAINTAINERS.md).
 
 ### Scope
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -41,6 +41,8 @@ Questarr uses SQLite, not PostgreSQL — the provided `docker-compose.yml` does 
 
 This policy governs how contributors are granted escalated permissions to this repository and its associated infrastructure. It is enforced by repository maintainers/admins for every access request — no escalation may be granted outside this process.
 
+The current list of project members holding escalated access is maintained in [MAINTAINERS.md](../MAINTAINERS.md).
+
 ### Scope
 
 "Escalated permissions" covers any of the following:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,7 +2,7 @@
 
 This file lists the people with access to sensitive project resources — repository
 administration, secrets, and deployment/publishing infrastructure — per the
-[Collaborator Access & Escalation Policy](.github/SECURITY.md#collaborator-access--escalation-policy).
+[Collaborator Access & Escalation Policy](/.github/SECURITY.md#collaborator-access--escalation-policy).
 
 | Name   | GitHub                               | Role  | Access                                                                       |
 | ------ | ------------------------------------ | ----- | ---------------------------------------------------------------------------- |
@@ -12,5 +12,5 @@ administration, secrets, and deployment/publishing infrastructure — per the
 
 Any change in repository collaborators, org membership, or access to secrets/deployment
 infrastructure must be reflected here as part of the same change, per the
-[Periodic Review & Revocation](.github/SECURITY.md#periodic-review--revocation) section of the
+[Periodic Review & Revocation](/.github/SECURITY.md#periodic-review--revocation) section of the
 security policy.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,16 @@
+# Maintainers
+
+This file lists the people with access to sensitive project resources — repository
+administration, secrets, and deployment/publishing infrastructure — per the
+[Collaborator Access & Escalation Policy](.github/SECURITY.md#collaborator-access--escalation-policy).
+
+| Name   | GitHub                               | Role  | Access                                                                       |
+| ------ | ------------------------------------ | ----- | ---------------------------------------------------------------------------- |
+| Doezer | [@Doezer](https://github.com/Doezer) | Admin | Repository admin, GitHub Actions secrets, Docker Hub / GHCR image publishing |
+
+## Updating this file
+
+Any change in repository collaborators, org membership, or access to secrets/deployment
+infrastructure must be reflected here as part of the same change, per the
+[Periodic Review & Revocation](.github/SECURITY.md#periodic-review--revocation) section of the
+security policy.

--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ See [Troubleshooting on the Wiki](https://github.com/Doezer/Questarr/wiki/Troubl
 
 See [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) for guidelines on how to contribute to this project.
 
+See [MAINTAINERS.md](MAINTAINERS.md) for the current list of project members with access to sensitive resources.
+
 ## Contributors
 
 <a href="https://github.com/Doezer/Questarr/graphs/contributors">

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ See [Troubleshooting on the Wiki](https://github.com/Doezer/Questarr/wiki/Troubl
 
 See [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) for guidelines on how to contribute to this project.
 
-See [MAINTAINERS.md](MAINTAINERS.md) for the current list of project members with access to sensitive resources.
+See [MAINTAINERS.md](/MAINTAINERS.md) for the current list of project members with access to sensitive resources.
 
 ## Contributors
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1574,7 +1574,8 @@ export class DatabaseStorage implements IStorage {
             topStatus: row.topStatus as DownloadSummary["topStatus"],
             count: row.count,
             downloadTypes: (row.downloadTypes ?? "torrent").split(",").filter(Boolean) as (
-              "torrent" | "usenet"
+              | "torrent"
+              | "usenet"
             )[],
             hasUpdateDownload: row.hasUpdateDownload > 0,
           },


### PR DESCRIPTION
## Description

The project's documentation didn't include a list of project members/maintainers with access to sensitive resources (repository admin, secrets, deployment infrastructure), required by control OSPS-GV-01.01. `SECURITY.md` had a detailed *Collaborator Access & Escalation Policy* describing how access is granted, but no actual roster of who currently holds it, and no `MAINTAINERS.md`/`MEMBERS.md`/`GOVERNANCE.md` existed anywhere in the repo.

This adds `MAINTAINERS.md` listing current project members with escalated access (currently just the sole repository admin, `@Doezer`, per GitHub's collaborator list), and cross-links it from `SECURITY.md` and `README.md` so it's discoverable.

## Type of change

- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project (Prettier-formatted)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (n/a, docs only)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a, docs only)
- [x] New and existing unit tests pass locally with my changes (no code changed)

---

_Generated by [Claude Code](https://claude.ai/code/session_01AVBMdt87KWsrnhRsP78Lyu)_