### PR TITLE
Document maintainer roles and responsibilities in MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,28 @@
 # Maintainers
 
-This file lists the people with access to sensitive project resources — repository
-administration, secrets, and deployment/publishing infrastructure — per the
+This file lists the project's participants, their roles and responsibilities, and — for
+those with escalated access — the sensitive resources they can reach, per the
 [Collaborator Access & Escalation Policy](/.github/SECURITY.md#collaborator-access--escalation-policy).
+
+## Roles & Responsibilities
+
+### Doezer — Project Lead / Maintainer ([@Doezer](https://github.com/Doezer))
+
+- Sets project direction and reviews/merges pull requests.
+- Owns release management: versioning, changelog, and publishing Docker images to
+  Docker Hub and GHCR.
+- Triages and responds to security vulnerability reports (see
+  [SECURITY.md](/.github/SECURITY.md)).
+- Reviews and approves (or denies) requests for escalated collaborator access, per the
+  [Collaborator Access & Escalation Policy](/.github/SECURITY.md#collaborator-access--escalation-policy).
+- Enforces the [Code of Conduct](/CODE_OF_CONDUCT.md) as the community leader responsible
+  for handling reports.
+
+There are currently no other maintainers, reviewers, or triagers with a formal role on
+the project; all other contributions come from the community via pull requests as
+described in [CONTRIBUTING.md](/.github/CONTRIBUTING.md).
+
+## Sensitive Access
 
 | Name   | GitHub                               | Role  | Access                                                                       |
 | ------ | ------------------------------------ | ----- | ---------------------------------------------------------------------------- |


### PR DESCRIPTION
## Description

Follow-up to #727. `MAINTAINERS.md` documented *who* has sensitive access and *what* level of access they hold, satisfying OSPS-GV-01.01, but didn't describe what each member is actually responsible for on the project, per OSPS-GV-01.02.

This adds a "Roles & Responsibilities" section describing `@Doezer`'s responsibilities (project direction, PR review/merge, release management, security vulnerability triage, collaborator access approval, Code of Conduct enforcement) drawn from the existing `SECURITY.md`, `CODE_OF_CONDUCT.md`, and `CONTRIBUTING.md` docs, and notes that there are no other formal maintainer/reviewer roles at this time. The existing access table is kept as a "Sensitive Access" subsection.

## Type of change

- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project (Prettier-formatted)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (n/a, docs only)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a, docs only)
- [x] New and existing unit tests pass locally with my changes (no code changed)

---

_Generated by [Claude Code](https://claude.ai/code/session_01AVBMdt87KWsrnhRsP78Lyu)_