### PR TITLE
Add DCO requirement with automated status check

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -109,6 +109,20 @@ Changes that are typically **exempt** from new tests: pure styling/CSS tweaks, c
 - Start with a verb in the present tense (e.g., "Add", "Fix", "Update")
 - Reference issue numbers when applicable (e.g., "Fix #123: description")
 
+### Developer Certificate of Origin (DCO)
+
+Every commit must be signed off to certify that you have the right to submit
+it under the project's license, per the [Developer Certificate of Origin](../DCO.md).
+Sign off with the `-s` flag:
+
+```bash
+git commit -s -m "Add feature: description"
+```
+
+Pull requests are checked automatically by the `DCO` status check; any commit
+missing a `Signed-off-by` trailer will cause the check to fail. See
+[`DCO.md`](../DCO.md) for how to sign off commits you've already made.
+
 ### Pull Requests
 
 - Provide a clear description of what your PR does

--- a/.github/PR_TEMPLATE.md
+++ b/.github/PR_TEMPLATE.md
@@ -19,3 +19,4 @@ Please include a summary of the change and which issue is fixed. Please also inc
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
+- [ ] All commits are signed off per the [DCO](../DCO.md) (`git commit -s`)

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,55 @@
+name: DCO
+
+on:
+  pull_request:
+    branches: [main, release/*]
+  workflow_dispatch:
+
+jobs:
+  dco-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.2.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check DCO sign-off on every commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          missing=0
+
+          while IFS= read -r sha; do
+            subject="$(git log -1 --format='%s' "$sha")"
+            if ! git log -1 --format='%B' "$sha" | grep -qiE '^Signed-off-by: .+ <[^ >]+@[^ >]+>$'; then
+              echo "::error::Commit $sha (\"$subject\") is missing a valid 'Signed-off-by' trailer."
+              missing=1
+            fi
+          done < <(git rev-list "$merge_base..$HEAD_SHA")
+
+          if [ "$missing" -ne 0 ]; then
+            echo ""
+            echo "One or more commits in this pull request are missing the required"
+            echo "Developer Certificate of Origin (DCO) sign-off."
+            echo ""
+            echo "Sign off commits with 'git commit -s', or amend/rebase existing ones:"
+            echo "  git commit --amend -s"
+            echo "  git rebase --signoff $BASE_SHA"
+            echo ""
+            echo "See DCO.md for details."
+            exit 1
+          fi
+
+          echo "All commits are signed off."

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, release/*]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   dco-check:
     runs-on: ubuntu-latest

--- a/DCO.md
+++ b/DCO.md
@@ -1,0 +1,73 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+have the right to submit it under the open source license
+indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+of my knowledge, is covered under an appropriate open source
+license and I have the right under that license to submit that
+work with modifications, whether created in whole or in part
+by me, under the same open source license (unless I am
+permitted to submit under a different license), as indicated
+in the file; or
+
+(c) The contribution was provided directly to me by some other
+person who certified (a), (b) or (c) and I have not modified
+it.
+
+(d) I understand and agree that this project and the contribution
+are public and that a record of the contribution (including all
+personal information I submit with it, including my sign-off) is
+maintained indefinitely and may be redistributed consistent with
+this project or the open source license(s) involved.
+
+---
+
+## How to sign off a commit
+
+Every commit contributed to this project must include a `Signed-off-by`
+trailer certifying the statement above. Add it automatically with the
+`-s` (or `--signoff`) flag:
+
+```bash
+git commit -s -m "Add feature: description"
+```
+
+This appends a line to the commit message in the form:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Use your real name and a reachable email address — anonymous or pseudonymous
+sign-offs are not accepted.
+
+If you forgot to sign off a commit, amend it:
+
+```bash
+git commit --amend -s
+```
+
+For multiple commits on a branch, sign off all of them at once:
+
+```bash
+git rebase --signoff origin/main
+```
+
+Pull requests are checked automatically for this trailer (see
+`.github/workflows/dco.yml`); PRs with unsigned commits will fail the
+`DCO` status check and cannot be merged until every commit is signed off.


### PR DESCRIPTION
## Description

Adds a Developer Certificate of Origin (DCO) requirement so every contribution is asserted to be legally authorized, enforced by an automated CI status check (satisfies OSPS-LE-01.01).

- `DCO.md` — standard DCO 1.1 text plus instructions for signing off commits (`git commit -s`).
- `.github/workflows/dco.yml` — new `DCO` GitHub Actions workflow that runs on every pull request, walks the commits unique to the PR (`git rev-list <merge-base>..<head>`), and fails the check if any commit is missing a valid `Signed-off-by: Name <email>` trailer.
- `.github/CONTRIBUTING.md` — documents the sign-off requirement and links to `DCO.md`.
- `.github/PR_TEMPLATE.md` — adds a checklist item confirming commits are signed off.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All commits are signed off per the DCO (`git commit -s`)

## Test plan

- [x] Validated `.github/workflows/dco.yml` YAML syntax
- [x] Ran `npx prettier --check` on all new/changed files
- [ ] Confirm the `DCO` status check appears and passes on this PR (all commits are signed off)
- [ ] Maintainer: mark `DCO` as a required status check in branch protection settings for `main`

---

_Generated by [Claude Code](https://claude.ai/code/session_01GXERyLUU9jDgRJmVRNAtLr)_