### PR TITLE
Document dependency selection, sourcing, and tracking process

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -103,6 +103,10 @@ Not every change needs new tests, but treat the following as **major changes** t
 
 Changes that are typically **exempt** from new tests: pure styling/CSS tweaks, copy/wording changes, internal refactors that don't alter behavior (already covered by existing tests), and dependency bumps with no code changes. When in doubt, prefer adding a small test over skipping it — reviewers may ask for one if a major change ships without coverage.
 
+### Dependencies
+
+See [docs/DEPENDENCIES.md](../docs/DEPENDENCIES.md) for how Questarr selects, obtains, and tracks its dependencies. New dependencies are reviewed as part of the normal PR process.
+
 ### Commit Messages
 
 - Use clear, descriptive commit messages

--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ See [docs/MIGRATION.md](docs/MIGRATION.md) for more details.
 
 Every published image ships with a Software Bill of Materials — see [docs/SBOM.md](docs/SBOM.md) for how to get it.
 
+See [docs/DEPENDENCIES.md](docs/DEPENDENCIES.md) for how dependencies are selected, obtained, and tracked.
+
 ## Configuration
 
 1. **First-time setup:**

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -1,0 +1,27 @@
+# Dependency Management
+
+This document describes how Questarr selects, obtains, and tracks its dependencies.
+
+## Selection
+
+Dependencies are added deliberately as part of normal development, via `npm install`, and land in `package.json` alongside the feature or fix that needs them. Preference is given to actively maintained, widely used packages already common in the Node/React ecosystem. New dependencies go through the same pull request review process as any other code change (see [.github/CONTRIBUTING.md](../.github/CONTRIBUTING.md)) before merging to `main`.
+
+## Obtaining dependencies
+
+- Packages are installed from the public [npm registry](https://www.npmjs.com/).
+- `package-lock.json` is committed to the repository and used for reproducible installs — the exact resolved version of every direct and transitive dependency is pinned.
+- The `packageManager` field in `package.json` pins the npm version used to install and build the project.
+- The `allowScripts` field in `package.json` explicitly allowlists which packages are permitted to run install-time (postinstall) scripts. Any package not on that list has its scripts blocked by default, limiting the blast radius of a compromised transitive dependency.
+- The `overrides` field is used to force a specific version of a transitive dependency when needed (e.g. pinning `socket.io-parser` to a patched release).
+
+## Tracking and updates
+
+[Dependabot](https://docs.github.com/en/code-security/dependabot) is configured in [`.github/dependabot.yml`](../.github/dependabot.yml) to check for updates weekly (Monday) for both npm dependencies and GitHub Actions used in CI:
+
+- Updates are opened as grouped pull requests (e.g. React-related packages, Radix UI components, dev vs. production dependencies, and all GitHub Actions bumps) to keep the PR volume manageable.
+- Automatic semver-major bumps are excluded and require a manual, reviewed update, since these are more likely to introduce breaking changes.
+- Every dependency-update PR runs through the same CI gate as any other change — lint, type check, the full test suite, and a Docker build (see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)) — before it can be merged.
+
+## Release-time visibility
+
+Every published Docker image ships with a generated Software Bill of Materials listing the exact versions of every dependency included in that release. See [docs/SBOM.md](SBOM.md) for how to inspect it.


### PR DESCRIPTION
## Description

Adds `docs/DEPENDENCIES.md`, a new doc describing how Questarr selects, obtains, and tracks its dependencies, satisfying OSPS Baseline control DO-06.01 (project documentation must describe dependency practices once a release has been made).

The doc consolidates existing, already-in-place practices rather than introducing new tooling or process:

- **Selection**: dependencies are added deliberately during development and reviewed like any other code change via the normal PR process.
- **Obtaining**: installed from the public npm registry, pinned via committed `package-lock.json`, with `packageManager` pinning the npm version and `allowScripts` restricting which packages may run postinstall scripts.
- **Tracking/updates**: `.github/dependabot.yml` opens weekly, grouped update PRs for npm and GitHub Actions (major bumps excluded and require manual review); every update PR runs the full CI gate (lint, typecheck, tests, Docker build) before merge; `overrides` in `package.json` used for manual transitive pins.
- **Release-time visibility**: links to the existing `docs/SBOM.md`, since every published Docker image ships a Syft-generated SBOM listing exact dependency versions.

Also links the new doc from `README.md` (near the existing SBOM/secrets doc links) and adds a short "Dependencies" subsection to `.github/CONTRIBUTING.md`.

No code or behavior changes.

## Type of change

- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

_Generated by [Claude Code](https://claude.ai/code/session_01261ZRknBND5z39pqfifAKa)_