### PR TITLE
Update Scorecard workflow actions to Node.js 24-native versions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,9 +10,9 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '44 1 * * 3'
+    - cron: "44 1 * * 3"
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -64,7 +64,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- The Scorecard analysis workflow warned that `actions/checkout`, `actions/upload-artifact`, and `codeql-action/upload-sarif` were pinned to versions that still target the deprecated Node.js 20 runtime, so GitHub Actions was forcing them onto Node 24.
- Bumped each action to its latest release, all of which run natively on `node24`:
  - `actions/checkout` → `v7.0.0` (`9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0`)
  - `actions/upload-artifact` → `v7.0.1` (`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`)
  - `github/codeql-action/upload-sarif` → `v4.36.2` (`8aad20d150bbac5944a9f9d289da16a4b0d87c1e`), now pinned to a commit SHA instead of a mutable `@v4` tag, matching the pinning style used by the other steps in this workflow.

## Test plan

- [x] Verified each new commit SHA corresponds to the intended release tag and runs with `runs.using: node24` in its `action.yml`.
- [ ] Confirm the Scorecard analysis workflow run on GitHub Actions no longer emits the Node.js 20 deprecation warning.

---

_Generated by [Claude Code](https://claude.ai/code/session_0136h6QonAYVYPv3fj2bXTHP)_