### PR TITLE
Add Apprise CLI mode (not needed an Apprise server)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,9 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
+          allowed-endpoints: >
+            pypi.org:443
+            files.pythonhosted.org:443
 
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ ENV PORT=5000
 ENV PUID=1000
 ENV PGID=1000
 
-# Install su-exec (for privilege dropping) and shadow (for usermod/groupmod)
-RUN apk add --no-cache su-exec shadow
+# Install su-exec (for privilege dropping), shadow (for usermod/groupmod), and
+# Python + Apprise for local CLI notifications.
+RUN apk add --no-cache su-exec shadow python3 py3-pip && \
+    python3 -m pip install --no-cache-dir --break-system-packages apprise
 
 # Reuse node_modules from base and prune dev dependencies (avoids a second npm ci)
 COPY --from=base /app/node_modules ./node_modules

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - **📚 Library Management**: Track your game collection with status indicators (Wanted, Owned, Playing, Completed), user ratings, and Early Access badges.
 - **⬇️ Download Management**: Integrate with indexers (Prowlarr/Torznab/Newsznab), torrent/usenet downloaders (qBittorrent, Transmission, rTorrent / sabnzbd, nzbget), and optionally enable auto-download to get them right when they're there. Import downloads automatically to your library folder.
 - **🔍 Search & Filter**: Find games by genre, platform, and search terms. Automatically search for added games until available on your indexers. Blacklist unwanted releases and set preferred release groups and platforms.
+- **Notifications**: thanks to Apprise, you can send notifications to 100+ providers.
 - **🗂️ Rich Metadata**: Game details enriched with IGDB, Steam, PCGamingWiki links, and NexusMods pages, as well as trending mods (if applicable).
 - **📊 Stats Page**: Visualize your collection statistics, with Discord sharing support.
 - **📰 RSS Feeds**: Monitor releases from your favorite groups directly within the app.

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -157,6 +157,7 @@ export default function SettingsPage() {
   const [appriseApiUrl, setAppriseApiUrl] = useState("");
   const [appriseKey, setAppriseKey] = useState("");
   const [appriseUrls, setAppriseUrls] = useState("");
+  const appriseLoadedRef = useRef(false);
 
   // Local state for Steam form
   const [steamIdInput, setSteamIdInput] = useState("");
@@ -273,10 +274,13 @@ export default function SettingsPage() {
   });
 
   useEffect(() => {
-    if (appriseSettings?.mode) setAppriseMode(appriseSettings.mode);
-    if (appriseSettings?.apiUrl !== undefined) setAppriseApiUrl(appriseSettings.apiUrl ?? "");
-    if (appriseSettings?.key !== undefined) setAppriseKey(appriseSettings.key ?? "");
-    if (appriseSettings?.urls !== undefined) setAppriseUrls(appriseSettings.urls ?? "");
+    if (appriseSettings && !appriseLoadedRef.current) {
+      if (appriseSettings.mode) setAppriseMode(appriseSettings.mode);
+      if (appriseSettings.apiUrl !== undefined) setAppriseApiUrl(appriseSettings.apiUrl ?? "");
+      if (appriseSettings.key !== undefined) setAppriseKey(appriseSettings.key ?? "");
+      if (appriseSettings.urls !== undefined) setAppriseUrls(appriseSettings.urls ?? "");
+      appriseLoadedRef.current = true;
+    }
   }, [appriseSettings]);
 
   const { data: nexusmodsSettings } = useQuery<{

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -153,6 +153,7 @@ export default function SettingsPage() {
   const [notifPrefs, setNotifPrefs] = useState<NotificationPreferences>(
     DEFAULT_NOTIFICATION_PREFERENCES
   );
+  const [appriseMode, setAppriseMode] = useState<"api" | "cli">("api");
   const [appriseApiUrl, setAppriseApiUrl] = useState("");
   const [appriseKey, setAppriseKey] = useState("");
   const [appriseUrls, setAppriseUrls] = useState("");
@@ -262,6 +263,7 @@ export default function SettingsPage() {
 
   const { data: appriseSettings } = useQuery<{
     configured: boolean;
+    mode: "api" | "cli";
     apiUrl: string | null;
     key: string | null;
     urls: string | null;
@@ -271,9 +273,10 @@ export default function SettingsPage() {
   });
 
   useEffect(() => {
-    if (appriseSettings?.apiUrl) setAppriseApiUrl(appriseSettings.apiUrl);
-    if (appriseSettings?.key) setAppriseKey(appriseSettings.key);
-    if (appriseSettings?.urls) setAppriseUrls(appriseSettings.urls);
+    if (appriseSettings?.mode) setAppriseMode(appriseSettings.mode);
+    if (appriseSettings?.apiUrl !== undefined) setAppriseApiUrl(appriseSettings.apiUrl ?? "");
+    if (appriseSettings?.key !== undefined) setAppriseKey(appriseSettings.key ?? "");
+    if (appriseSettings?.urls !== undefined) setAppriseUrls(appriseSettings.urls ?? "");
   }, [appriseSettings]);
 
   const { data: nexusmodsSettings } = useQuery<{
@@ -285,7 +288,12 @@ export default function SettingsPage() {
   });
 
   const updateAppriseMutation = useMutation({
-    mutationFn: async (data: { apiUrl: string; key: string; urls: string }) => {
+    mutationFn: async (data: {
+      mode: "api" | "cli";
+      apiUrl?: string;
+      key?: string;
+      urls?: string;
+    }) => {
       const res = await apiRequest("POST", "/api/settings/apprise", data);
       return res.json();
     },
@@ -297,6 +305,12 @@ export default function SettingsPage() {
       toast({ title: "Failed to save Apprise settings", variant: "destructive" });
     },
   });
+
+  const appriseSaveDisabled =
+    updateAppriseMutation.isPending ||
+    (appriseMode === "api"
+      ? !appriseApiUrl.trim() || (!appriseKey.trim() && !appriseUrls.trim())
+      : !appriseUrls.trim());
 
   const testAppriseMutation = useMutation({
     mutationFn: async () => {
@@ -948,44 +962,71 @@ export default function SettingsPage() {
                   )}
                 </div>
                 <CardDescription>
-                  Forward notifications to any service via a self-hosted{" "}
-                  <span className="font-medium">Apprise API</span> server — Telegram, Pushover,
-                  Slack, and 100+ others.
+                  Forward notifications through a self-hosted{" "}
+                  <span className="font-medium">Apprise API</span> server or the local{" "}
+                  <span className="font-medium">Apprise CLI</span>.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
                 <div className="space-y-2">
-                  <Label htmlFor="apprise-api-url">
-                    API URL <span className="text-destructive">*</span>
-                  </Label>
-                  <Input
-                    id="apprise-api-url"
-                    type="text"
-                    placeholder="http://apprise:8000"
-                    value={appriseApiUrl}
-                    onChange={(e) => setAppriseApiUrl(e.target.value)}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="apprise-key">
-                    Config Key{" "}
-                    <span className="text-xs text-muted-foreground font-normal">(optional)</span>
-                  </Label>
-                  <Input
-                    id="apprise-key"
-                    type="text"
-                    placeholder="my-config-key"
-                    value={appriseKey}
-                    onChange={(e) => setAppriseKey(e.target.value)}
-                  />
+                  <Label htmlFor="apprise-mode">Mode</Label>
+                  <Select
+                    value={appriseMode}
+                    onValueChange={(value) => {
+                      if (value === "api" || value === "cli") setAppriseMode(value);
+                    }}
+                  >
+                    <SelectTrigger id="apprise-mode" className="w-full sm:w-56">
+                      <SelectValue placeholder="Select mode" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="api">API</SelectItem>
+                      <SelectItem value="cli">CLI</SelectItem>
+                    </SelectContent>
+                  </Select>
                   <p className="text-xs text-muted-foreground">
-                    Persistent mode: a config key pre-configured in your Apprise API server.
+                    API mode sends notifications to a remote Apprise server. CLI mode runs the local{" "}
+                    <code className="px-1">apprise</code> command inside Questarr.
                   </p>
                 </div>
+                {appriseMode === "api" && (
+                  <div className="space-y-2">
+                    <Label htmlFor="apprise-api-url">
+                      API URL <span className="text-destructive">*</span>
+                    </Label>
+                    <Input
+                      id="apprise-api-url"
+                      type="text"
+                      placeholder="http://apprise:8000"
+                      value={appriseApiUrl}
+                      onChange={(e) => setAppriseApiUrl(e.target.value)}
+                    />
+                  </div>
+                )}
+                {appriseMode === "api" && (
+                  <div className="space-y-2">
+                    <Label htmlFor="apprise-key">
+                      Config Key{" "}
+                      <span className="text-xs text-muted-foreground font-normal">(optional)</span>
+                    </Label>
+                    <Input
+                      id="apprise-key"
+                      type="text"
+                      placeholder="my-config-key"
+                      value={appriseKey}
+                      onChange={(e) => setAppriseKey(e.target.value)}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Persistent mode: a config key pre-configured in your Apprise API server.
+                    </p>
+                  </div>
+                )}
                 <div className="space-y-2">
                   <Label htmlFor="apprise-urls">
                     Notification URLs{" "}
-                    <span className="text-xs text-muted-foreground font-normal">(optional)</span>
+                    <span className="text-xs text-muted-foreground font-normal">
+                      {appriseMode === "cli" ? "(required)" : "(optional)"}
+                    </span>
                   </Label>
                   <Textarea
                     id="apprise-urls"
@@ -996,20 +1037,33 @@ export default function SettingsPage() {
                     rows={4}
                   />
                   <p className="text-xs text-muted-foreground">
-                    Stateless mode: one Apprise notification URL per line. Used when no Config Key
-                    is set.
+                    One Apprise URL per line. Build URLs at{" "}
+                    <a
+                      href="https://appriseit.com/url-builder"
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-primary underline underline-offset-2"
+                    >
+                      appriseit.com/url-builder
+                    </a>
+                    .
                   </p>
                 </div>
                 <div className="flex flex-col sm:flex-row gap-2">
                   <Button
                     onClick={() =>
-                      updateAppriseMutation.mutate({
-                        apiUrl: appriseApiUrl,
-                        key: appriseKey,
-                        urls: appriseUrls,
-                      })
+                      updateAppriseMutation.mutate(
+                        appriseMode === "cli"
+                          ? { mode: appriseMode, urls: appriseUrls.trim() }
+                          : {
+                              mode: appriseMode,
+                              apiUrl: appriseApiUrl.trim(),
+                              key: appriseKey.trim(),
+                              urls: appriseUrls.trim(),
+                            }
+                      )
                     }
-                    disabled={updateAppriseMutation.isPending || !appriseApiUrl.trim()}
+                    disabled={appriseSaveDisabled}
                   >
                     {updateAppriseMutation.isPending ? "Saving..." : "Save"}
                   </Button>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - **Import History**: New page listing import tasks (game claims, post-processing imports, Steam syncs) with a retention purge cron job to keep the history tidy (#714).
 - **Deluge Support**: Added Deluge as a supported downloader (#697).
 - **Synology Download Station**: Added support for Synology's built-in Download Station as a downloader (#567).
-- **Apprise Notifications**: Added Apprise support for sending notifications. Fire up your Apprise server and connect it. Set up your notifications in Questarr settings.
+- **Apprise Notifications**: Added Apprise API and CLI notification modes. Use API mode with a remote Apprise server or CLI mode with the local `apprise` binary from Questarr settings.
 - **Personal Notes**: Added the ability to attach personal notes to a game.
 - **Shelved Status**: Added a "shelved" status for games (#645).
 - **Mobile Experience**: Significant improvements to mobile layout and navigation (#644).
@@ -47,6 +47,7 @@ All notable changes to this project will be documented in this file.
   - `SQLITE_DB_PATH` is now exported with a default of `/app/data/sqlite.db`.
   - The `PORT` variable in `docker-compose.yml` has been split into two: `HOST_SIDE_PORT` (host-side binding, default `5000`) and `CONTAINER_INTERNAL_SIDE_PORT` (internal container port, default `5000`). If you had `PORT` set in your `.env` to customize the host port, rename it to `HOST_SIDE_PORT`.
 - **Dependencies**: multiple minor and major dependencies updates. Node 22 to 26.
+- **Docker**: Bundled Python and Apprise in the default image so CLI mode works without a separate image split.
 - **CI**: Pinned GitHub Actions to commit SHAs; fixed Codecov test-results upload to correctly locate the JUnit XML report; added a deprecated-dependencies check and npm overrides relevancy check; moved CI to Node 26.
 - **Dependencies**: Removed duplicate `@types/multer` entry from `package.json`; updated Radix UI, semver, and other minor dependencies; upgraded `codecov/codecov-action` from v5 to v7; updated numerous packages via Dependabot including `lucide-react`, `recharts`, `framer-motion`, `jsdom`, `express`, `express-rate-limit`, `@tanstack/react-query`, `react-hook-form`, and GitHub Actions.
 - **Discord**: Improved Discord webhook validation (#704).

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -13,6 +13,7 @@ import {
   createNewznabMock,
   createProwlarrMock,
   createXrelMock,
+  createAppriseMock,
   createDownloaderManagerMock,
   createSteamRoutesMock,
   createSearchMock,
@@ -30,6 +31,7 @@ import { newznabClient } from "../newznab.js";
 import { rssService } from "../rss.js";
 import { comparePassword } from "../auth.js";
 import { db } from "../db.js";
+import { appriseClient } from "../apprise.js";
 
 // Mock dependencies (factory bodies live in ./fixtures/common-route-mocks.ts so they can be
 // shared with other test files that also boot the full app via registerRoutes())
@@ -43,6 +45,7 @@ vi.mock("../torznab.js", () => ({ torznabClient: createTorznabMock() }));
 vi.mock("../newznab.js", () => ({ newznabClient: createNewznabMock() }));
 vi.mock("../prowlarr.js", () => ({ prowlarrClient: createProwlarrMock() }));
 vi.mock("../xrel.js", () => createXrelMock());
+vi.mock("../apprise.js", async () => createAppriseMock());
 vi.mock("../downloaders.js", () => ({ DownloaderManager: createDownloaderManagerMock() }));
 vi.mock("../steam-routes.js", () => ({ steamRoutes: createSteamRoutesMock() }));
 vi.mock("../search.js", () => createSearchMock());
@@ -2520,6 +2523,83 @@ describe("API Routes - Extended Coverage", () => {
 
       expect(response.status).toBe(500);
       expect(response.body.error).toMatch(/failed to fetch game downloads/i);
+    });
+  });
+
+  // ─── Apprise settings ───
+  describe("Apprise settings", () => {
+    const appriseState: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      appriseState["apprise.mode"] = "api";
+      appriseState["apprise.apiUrl"] = "http://apprise:8000";
+      appriseState["apprise.key"] = "config-key";
+      appriseState["apprise.urls"] = "discord://webhook";
+
+      vi.mocked(storage.getSystemConfig).mockImplementation(
+        async (key: string) => appriseState[key]
+      );
+      vi.mocked(storage.setSystemConfig).mockImplementation(async (key: string, value: string) => {
+        appriseState[key] = value;
+      });
+      vi.mocked(appriseClient.configure).mockClear();
+      vi.mocked(appriseClient.test).mockResolvedValue({ success: true });
+    });
+
+    afterEach(() => {
+      vi.mocked(storage.getSystemConfig).mockReset();
+      vi.mocked(storage.setSystemConfig).mockReset();
+      vi.mocked(appriseClient.configure).mockReset();
+      vi.mocked(appriseClient.test).mockReset();
+    });
+
+    it("should return the saved mode and settings", async () => {
+      const response = await request(app).get("/api/settings/apprise");
+
+      expect(response.status).toBe(200);
+      expect(response.body.mode).toBe("api");
+      expect(response.body.apiUrl).toBe("http://apprise:8000");
+      expect(response.body.key).toBe("config-key");
+      expect(response.body.urls).toBe("discord://webhook");
+    });
+
+    it("should persist CLI mode and URLs", async () => {
+      const response = await request(app)
+        .post("/api/settings/apprise")
+        .send({ mode: "cli", urls: "discord://webhook" });
+
+      expect(response.status).toBe(200);
+      expect(storage.setSystemConfig).toHaveBeenCalledWith("apprise.mode", "cli");
+      expect(storage.setSystemConfig).toHaveBeenCalledWith("apprise.urls", "discord://webhook");
+      expect(appriseClient.configure).toHaveBeenCalled();
+      expect(appriseState["apprise.mode"]).toBe("cli");
+    });
+
+    it("should reject an invalid mode", async () => {
+      const response = await request(app)
+        .post("/api/settings/apprise")
+        .send({ mode: "invalid", apiUrl: "http://apprise:8000" });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("should test the configured transport", async () => {
+      const response = await request(app).post("/api/settings/apprise/test");
+
+      expect(response.status).toBe(200);
+      expect(appriseClient.test).toHaveBeenCalledTimes(1);
+    });
+
+    it("should surface transport errors from the test endpoint", async () => {
+      vi.mocked(appriseClient.test).mockResolvedValueOnce({
+        success: false,
+        error: "CLI timed out",
+      });
+
+      const response = await request(app).post("/api/settings/apprise/test");
+
+      expect(response.status).toBe(502);
+      expect(response.body.error).toBe("CLI timed out");
     });
   });
 });

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -2583,6 +2583,15 @@ describe("API Routes - Extended Coverage", () => {
       expect(response.status).toBe(400);
     });
 
+    it("should reject non-string payload fields instead of crashing", async () => {
+      const response = await request(app)
+        .post("/api/settings/apprise")
+        .send({ mode: "api", apiUrl: { malicious: true }, key: "config-key" });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toMatch(/invalid request payload/i);
+    });
+
     it("should test the configured transport", async () => {
       const response = await request(app).post("/api/settings/apprise/test");
 

--- a/server/__tests__/apprise.test.ts
+++ b/server/__tests__/apprise.test.ts
@@ -1,5 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { execFile } from "child_process";
+import fs from "fs";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
 import { appriseClient } from "../apprise.js";
 import { safeFetch } from "../ssrf.js";
 import type { Notification } from "../../shared/schema.js";
@@ -34,6 +38,22 @@ describe("Apprise client", () => {
     message: "Test notification",
   } as Notification;
 
+  let fakeBinaryDir: string;
+  let fakeBinaryPath: string;
+
+  beforeAll(() => {
+    fakeBinaryDir = mkdtempSync(path.join(tmpdir(), "questarr-apprise-bin-"));
+    fakeBinaryPath = path.join(fakeBinaryDir, "apprise");
+    fs.writeFileSync(fakeBinaryPath, "#!/bin/sh\n");
+    fs.chmodSync(fakeBinaryPath, 0o755);
+    process.env.APPRISE_CLI_PATH = fakeBinaryPath;
+  });
+
+  afterAll(() => {
+    delete process.env.APPRISE_CLI_PATH;
+    rmSync(fakeBinaryDir, { recursive: true, force: true });
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     appriseClient.configure({ mode: "api", apiUrl: null, key: null, urls: null });
@@ -65,8 +85,13 @@ describe("Apprise client", () => {
     );
   });
 
-  it("sends notifications via Apprise CLI mode with argument arrays", async () => {
+  it("sends notifications via Apprise CLI mode using a config file, not argv URLs", async () => {
+    let capturedArgs: string[] = [];
+    let capturedConfigContent = "";
     vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
+      capturedArgs = args[1] as string[];
+      const configIndex = capturedArgs.indexOf("-c");
+      capturedConfigContent = readFileSync(capturedArgs[configIndex + 1], "utf8");
       const callback = args[3] as (error: Error | null, stdout: string, stderr: string) => void;
       callback(null, "ok", "");
       return {} as never;
@@ -80,9 +105,10 @@ describe("Apprise client", () => {
     });
 
     await expect(appriseClient.send(notification)).resolves.toBeUndefined();
+
     expect(execFile).toHaveBeenCalledWith(
-      "apprise",
-      ["-t", "Questarr", "-b", "Test notification", "discord://webhook", "pushover://token@user"],
+      fakeBinaryPath,
+      expect.any(Array),
       expect.objectContaining({
         encoding: "utf8",
         timeout: expect.any(Number),
@@ -91,6 +117,42 @@ describe("Apprise client", () => {
       }),
       expect.any(Function)
     );
+
+    // Title, body, and mapped notification type are passed as CLI flags.
+    expect(capturedArgs).toEqual([
+      "-t",
+      "Questarr",
+      "-b",
+      "Test notification",
+      "-n",
+      "info",
+      "-c",
+      capturedArgs[capturedArgs.length - 1],
+    ]);
+    // Credentialed URLs are written to a private temp config file, not argv.
+    expect(capturedArgs.join(" ")).not.toContain("discord://webhook");
+    expect(capturedConfigContent).toBe("discord://webhook\npushover://token@user\n");
+  });
+
+  it("passes the mapped notification type for non-info notifications", async () => {
+    vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
+      const callback = args[3] as (error: Error | null, stdout: string, stderr: string) => void;
+      callback(null, "ok", "");
+      return {} as never;
+    });
+
+    appriseClient.configure({
+      mode: "cli",
+      apiUrl: null,
+      key: null,
+      urls: "discord://webhook",
+    });
+
+    await appriseClient.send({ ...notification, type: "error" } as Notification);
+
+    const args = vi.mocked(execFile).mock.calls[0][1] as string[];
+    expect(args).toContain("-n");
+    expect(args[args.indexOf("-n") + 1]).toBe("failure");
   });
 
   it("returns a graceful CLI error when the command fails", async () => {
@@ -113,5 +175,26 @@ describe("Apprise client", () => {
       success: false,
       error: "Apprise CLI not found",
     });
+  });
+
+  it("reports a clear error when the Apprise CLI binary cannot be found", async () => {
+    delete process.env.APPRISE_CLI_PATH;
+    vi.resetModules();
+    const { appriseClient: freshClient } = await import("../apprise.js");
+
+    freshClient.configure({
+      mode: "cli",
+      apiUrl: null,
+      key: null,
+      urls: "discord://webhook",
+    });
+
+    await expect(freshClient.test()).resolves.toEqual({
+      success: false,
+      error: "Apprise CLI not found",
+    });
+    expect(execFile).not.toHaveBeenCalled();
+
+    process.env.APPRISE_CLI_PATH = fakeBinaryPath;
   });
 });

--- a/server/__tests__/apprise.test.ts
+++ b/server/__tests__/apprise.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { execFile } from "child_process";
+import { appriseClient } from "../apprise.js";
+import { safeFetch } from "../ssrf.js";
+import type { Notification } from "../../shared/schema.js";
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    child: () => ({
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("../ssrf.js", () => ({
+  safeFetch: vi.fn(),
+}));
+
+vi.mock("child_process", () => {
+  const execFileMock = vi.fn();
+  return {
+    execFile: execFileMock,
+    default: { execFile: execFileMock },
+  };
+});
+
+describe("Apprise client", () => {
+  const notification = {
+    type: "info",
+    title: "Questarr",
+    message: "Test notification",
+  } as Notification;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appriseClient.configure({ mode: "api", apiUrl: null, key: null, urls: null });
+  });
+
+  it("sends notifications via Apprise API mode", async () => {
+    vi.mocked(safeFetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue(""),
+    } as never);
+
+    appriseClient.configure({
+      mode: "api",
+      apiUrl: "http://apprise:8000",
+      key: "config-key",
+      urls: null,
+    });
+
+    await expect(appriseClient.send(notification)).resolves.toBeUndefined();
+    expect(safeFetch).toHaveBeenCalledWith(
+      "http://apprise:8000/notify/config-key",
+      expect.objectContaining({
+        method: "POST",
+        allowPrivate: true,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Questarr", body: "Test notification", type: "info" }),
+      })
+    );
+  });
+
+  it("sends notifications via Apprise CLI mode with argument arrays", async () => {
+    vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
+      const callback = args[3] as (error: Error | null, stdout: string, stderr: string) => void;
+      callback(null, "ok", "");
+      return {} as never;
+    });
+
+    appriseClient.configure({
+      mode: "cli",
+      apiUrl: null,
+      key: null,
+      urls: "discord://webhook\npushover://token@user",
+    });
+
+    await expect(appriseClient.send(notification)).resolves.toBeUndefined();
+    expect(execFile).toHaveBeenCalledWith(
+      "apprise",
+      ["-t", "Questarr", "-b", "Test notification", "discord://webhook", "pushover://token@user"],
+      expect.objectContaining({
+        encoding: "utf8",
+        timeout: expect.any(Number),
+        windowsHide: true,
+        maxBuffer: 64 * 1024,
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it("returns a graceful CLI error when the command fails", async () => {
+    vi.mocked(execFile).mockImplementation((...args: unknown[]) => {
+      const callback = args[3] as (error: Error | null, stdout: string, stderr: string) => void;
+      const error = Object.assign(new Error("spawn apprise ENOENT"), { code: "ENOENT" });
+      callback(error, "", "");
+      return {} as never;
+    });
+
+    appriseClient.configure({
+      mode: "cli",
+      apiUrl: null,
+      key: null,
+      urls: "discord://webhook",
+    });
+
+    await expect(appriseClient.send(notification)).resolves.toBeUndefined();
+    await expect(appriseClient.test()).resolves.toEqual({
+      success: false,
+      error: "Apprise CLI not found",
+    });
+  });
+});

--- a/server/__tests__/fixtures/common-route-mocks.ts
+++ b/server/__tests__/fixtures/common-route-mocks.ts
@@ -220,6 +220,20 @@ export function createXrelMock() {
   };
 }
 
+export async function createAppriseMock() {
+  const actual = await vi.importActual<typeof import("../../apprise.js")>("../../apprise.js");
+  return {
+    ...actual,
+    appriseClient: {
+      configure: vi.fn(),
+      getMode: vi.fn().mockReturnValue("api"),
+      isConfigured: vi.fn().mockReturnValue(true),
+      send: vi.fn().mockResolvedValue(undefined),
+      test: vi.fn().mockResolvedValue({ success: true }),
+    },
+  };
+}
+
 export function createDownloaderManagerMock() {
   return {
     initialize: vi.fn(),

--- a/server/apprise.ts
+++ b/server/apprise.ts
@@ -1,3 +1,4 @@
+import { execFile } from "child_process";
 import { logger } from "./logger.js";
 import { safeFetch } from "./ssrf.js";
 import type { Notification } from "../shared/schema.js";
@@ -12,48 +13,168 @@ const TYPE_MAP: Record<string, string> = {
   info: "info",
 };
 
-class AppriseClient {
-  private apiUrl: string | null = null;
-  private key: string | null = null;
-  private urls: string | null = null;
+export const APPRISE_MODES = ["api", "cli"] as const;
+export type AppriseMode = (typeof APPRISE_MODES)[number];
 
-  configure(apiUrl: string | null, key: string | null, urls: string | null): void {
-    this.apiUrl = apiUrl && apiUrl.trim().length > 0 ? apiUrl.trim() : null;
-    this.key = key && key.trim().length > 0 ? key.trim() : null;
-    this.urls = urls && urls.trim().length > 0 ? urls.trim() : null;
+export interface AppriseSettings {
+  mode: AppriseMode;
+  apiUrl: string | null;
+  key: string | null;
+  urls: string | null;
+}
+
+type ExecFileResult = { stdout: string; stderr: string };
+type ExecFileError = Error & {
+  code?: string | number;
+  killed?: boolean;
+  signal?: NodeJS.Signals | null;
+  stdout?: string;
+  stderr?: string;
+};
+
+const APPRISE_CLI_TIMEOUT_MS = 15_000;
+
+function trimToNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+function parseAppriseUrls(urls: string | null): string[] {
+  if (!urls) return [];
+  return urls
+    .split(/\r?\n/)
+    .map((url) => url.trim())
+    .filter((url) => url.length > 0);
+}
+
+export function normalizeAppriseMode(value: string | null | undefined): AppriseMode {
+  return value === "cli" ? "cli" : "api";
+}
+
+export function isAppriseConfigured(settings: AppriseSettings): boolean {
+  if (settings.mode === "cli") {
+    return parseAppriseUrls(settings.urls).length > 0;
+  }
+
+  return !!(
+    settings.apiUrl &&
+    (trimToNull(settings.key) || parseAppriseUrls(settings.urls).length > 0)
+  );
+}
+
+export async function readAppriseSettings(storage: {
+  getSystemConfig(key: string): Promise<string | undefined>;
+}): Promise<AppriseSettings> {
+  const [mode, apiUrl, key, urls] = await Promise.all([
+    storage.getSystemConfig("apprise.mode"),
+    storage.getSystemConfig("apprise.apiUrl"),
+    storage.getSystemConfig("apprise.key"),
+    storage.getSystemConfig("apprise.urls"),
+  ]);
+
+  return {
+    mode: normalizeAppriseMode(mode),
+    apiUrl: trimToNull(apiUrl),
+    key: trimToNull(key),
+    urls: trimToNull(urls),
+  };
+}
+
+function formatCliError(error: unknown, stdout = "", stderr = ""): string {
+  const execError = error as ExecFileError | undefined;
+  if (execError?.code === "ENOENT") {
+    return "Apprise CLI not found";
+  }
+  if (execError?.killed || execError?.signal) {
+    return "Apprise CLI timed out";
+  }
+
+  const message =
+    trimToNull(stderr) ??
+    trimToNull(stdout) ??
+    (error instanceof Error ? error.message : String(error));
+
+  return message.length > 200 ? `${message.slice(0, 197)}...` : message;
+}
+
+function runAppriseCli(args: string[]): Promise<ExecFileResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "apprise",
+      args,
+      {
+        encoding: "utf8",
+        timeout: APPRISE_CLI_TIMEOUT_MS,
+        windowsHide: true,
+        maxBuffer: 64 * 1024,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject({ error, stdout, stderr });
+          return;
+        }
+        resolve({ stdout, stderr });
+      }
+    );
+  });
+}
+
+class AppriseClient {
+  private settings: AppriseSettings = {
+    mode: "api",
+    apiUrl: null,
+    key: null,
+    urls: null,
+  };
+
+  configure(settings: Partial<AppriseSettings>): void {
+    this.settings = {
+      mode: normalizeAppriseMode(settings.mode),
+      apiUrl: trimToNull(settings.apiUrl),
+      key: trimToNull(settings.key),
+      urls: trimToNull(settings.urls),
+    };
+  }
+
+  getMode(): AppriseMode {
+    return this.settings.mode;
   }
 
   isConfigured(): boolean {
-    return this.apiUrl !== null;
+    return isAppriseConfigured(this.settings);
   }
 
-  private buildRequest(
+  private buildApiRequest(
     title: string,
     message: string,
     type: string
   ): { endpoint: string; payload: Record<string, string> } | null {
-    if (this.key) {
+    if (!this.settings.apiUrl) {
+      return null;
+    }
+
+    if (this.settings.key) {
       return {
-        endpoint: `${this.apiUrl}/notify/${this.key}`,
+        endpoint: `${this.settings.apiUrl}/notify/${this.settings.key}`,
         payload: { title, body: message, type },
       };
     }
-    if (this.urls) {
+
+    if (this.settings.urls) {
       return {
-        endpoint: `${this.apiUrl}/notify/`,
-        payload: { urls: this.urls, title, body: message, type },
+        endpoint: `${this.settings.apiUrl}/notify/`,
+        payload: { urls: this.settings.urls, title, body: message, type },
       };
     }
+
     return null;
   }
 
-  async send(notification: Notification): Promise<void> {
-    if (!this.isConfigured()) return;
-
+  private async sendViaApi(notification: Notification): Promise<void> {
     const type = TYPE_MAP[notification.type] ?? "info";
-    const request = this.buildRequest(notification.title, notification.message, type);
+    const request = this.buildApiRequest(notification.title, notification.message, type);
     if (!request) {
-      appriseLogger.warn("Apprise is configured with an API URL but no key or URLs — skipping");
+      appriseLogger.warn("Apprise API is configured without a key or URLs");
       return;
     }
 
@@ -76,12 +197,64 @@ class AppriseClient {
     }
   }
 
+  private async sendViaCli(notification: Notification): Promise<void> {
+    const urls = parseAppriseUrls(this.settings.urls);
+    if (urls.length === 0) {
+      appriseLogger.warn("Apprise CLI is configured without notification URLs");
+      return;
+    }
+
+    try {
+      await runAppriseCli(["-t", notification.title, "-b", notification.message, ...urls]);
+    } catch (result) {
+      const { error, stdout, stderr } = result as {
+        error: unknown;
+        stdout?: string;
+        stderr?: string;
+      };
+      appriseLogger.warn(
+        { error: formatCliError(error, stdout, stderr), title: notification.title },
+        "Apprise CLI send error"
+      );
+    }
+  }
+
+  async send(notification: Notification): Promise<void> {
+    if (!this.isConfigured()) return;
+
+    if (this.settings.mode === "cli") {
+      await this.sendViaCli(notification);
+      return;
+    }
+
+    await this.sendViaApi(notification);
+  }
+
   async test(): Promise<{ success: boolean; error?: string }> {
     if (!this.isConfigured()) {
       return { success: false, error: "Apprise is not configured" };
     }
 
-    const request = this.buildRequest("Questarr", "Test notification from Questarr", "info");
+    if (this.settings.mode === "cli") {
+      const urls = parseAppriseUrls(this.settings.urls);
+      if (urls.length === 0) {
+        return { success: false, error: "No notification URLs provided" };
+      }
+
+      try {
+        await runAppriseCli(["-t", "Questarr", "-b", "Test notification from Questarr", ...urls]);
+        return { success: true };
+      } catch (result) {
+        const { error, stdout, stderr } = result as {
+          error: unknown;
+          stdout?: string;
+          stderr?: string;
+        };
+        return { success: false, error: formatCliError(error, stdout, stderr) };
+      }
+    }
+
+    const request = this.buildApiRequest("Questarr", "Test notification from Questarr", "info");
     if (!request) {
       return { success: false, error: "No config key or notification URLs provided" };
     }

--- a/server/apprise.ts
+++ b/server/apprise.ts
@@ -1,4 +1,8 @@
 import { execFile } from "child_process";
+import { accessSync, constants as fsConstants } from "fs";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
 import { logger } from "./logger.js";
 import { safeFetch } from "./ssrf.js";
 import type { Notification } from "../shared/schema.js";
@@ -34,6 +38,35 @@ type ExecFileError = Error & {
 
 const APPRISE_CLI_TIMEOUT_MS = 15_000;
 
+// Known absolute install locations for the Apprise CLI. Resolving to a fixed, unwriteable
+// path (rather than letting execFile search $PATH for a bare "apprise" command) avoids
+// executing an attacker-controlled binary that could be placed earlier on the PATH.
+const APPRISE_BINARY_CANDIDATES = ["/usr/local/bin/apprise", "/usr/bin/apprise"];
+
+let cachedAppriseBinary: string | null | undefined;
+
+function resolveAppriseBinary(): string | null {
+  if (cachedAppriseBinary !== undefined) {
+    return cachedAppriseBinary;
+  }
+
+  const candidates = process.env.APPRISE_CLI_PATH
+    ? [process.env.APPRISE_CLI_PATH, ...APPRISE_BINARY_CANDIDATES]
+    : APPRISE_BINARY_CANDIDATES;
+
+  cachedAppriseBinary =
+    candidates.find((candidate) => {
+      try {
+        accessSync(candidate, fsConstants.X_OK);
+        return true;
+      } catch {
+        return false;
+      }
+    }) ?? null;
+
+  return cachedAppriseBinary;
+}
+
 function trimToNull(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : null;
@@ -41,10 +74,15 @@ function trimToNull(value: string | null | undefined): string | null {
 
 function parseAppriseUrls(urls: string | null): string[] {
   if (!urls) return [];
-  return urls
-    .split(/\r?\n/)
-    .map((url) => url.trim())
-    .filter((url) => url.length > 0);
+  const result: string[] = [];
+  const lines = urls.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.length > 0 && !trimmed.startsWith("#")) {
+      result.push(trimmed);
+    }
+  }
+  return result;
 }
 
 export function normalizeAppriseMode(value: string | null | undefined): AppriseMode {
@@ -98,9 +136,18 @@ function formatCliError(error: unknown, stdout = "", stderr = ""): string {
 }
 
 function runAppriseCli(args: string[]): Promise<ExecFileResult> {
+  const binary = resolveAppriseBinary();
+  if (!binary) {
+    return Promise.reject({
+      error: Object.assign(new Error("Apprise CLI binary not found"), { code: "ENOENT" }),
+      stdout: "",
+      stderr: "",
+    });
+  }
+
   return new Promise((resolve, reject) => {
     execFile(
-      "apprise",
+      binary,
       args,
       {
         encoding: "utf8",
@@ -117,6 +164,20 @@ function runAppriseCli(args: string[]): Promise<ExecFileResult> {
       }
     );
   });
+}
+
+// Writes notification URLs (which may embed provider credentials/tokens) to a private
+// temp file and invokes Apprise via `-c/--config` instead of putting them on argv, where
+// they would otherwise be visible to any local user via `ps`.
+async function runAppriseCliWithUrls(urls: string[], args: string[]): Promise<ExecFileResult> {
+  const dir = await mkdtemp(path.join(tmpdir(), "questarr-apprise-"));
+  const configPath = path.join(dir, "apprise.conf");
+  try {
+    await writeFile(configPath, urls.join("\n") + "\n", { mode: 0o600 });
+    return await runAppriseCli([...args, "-c", configPath]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 }
 
 class AppriseClient {
@@ -204,8 +265,16 @@ class AppriseClient {
       return;
     }
 
+    const type = TYPE_MAP[notification.type] ?? "info";
     try {
-      await runAppriseCli(["-t", notification.title, "-b", notification.message, ...urls]);
+      await runAppriseCliWithUrls(urls, [
+        "-t",
+        notification.title,
+        "-b",
+        notification.message,
+        "-n",
+        type,
+      ]);
     } catch (result) {
       const { error, stdout, stderr } = result as {
         error: unknown;
@@ -242,7 +311,14 @@ class AppriseClient {
       }
 
       try {
-        await runAppriseCli(["-t", "Questarr", "-b", "Test notification from Questarr", ...urls]);
+        await runAppriseCliWithUrls(urls, [
+          "-t",
+          "Questarr",
+          "-b",
+          "Test notification from Questarr",
+          "-n",
+          "info",
+        ]);
         return { success: true };
       } catch (result) {
         const { error, stdout, stderr } = result as {

--- a/server/index.ts
+++ b/server/index.ts
@@ -13,7 +13,7 @@ import { setupSocketIO } from "./socket.js";
 import { ensureDatabase } from "./migrate.js";
 import { rssService } from "./rss.js";
 import { nexusmodsClient } from "./nexusmods.js";
-import { appriseClient } from "./apprise.js";
+import { appriseClient, readAppriseSettings } from "./apprise.js";
 import { storage } from "./storage.js";
 
 const app = createApp();
@@ -34,12 +34,10 @@ const app = createApp();
     }
 
     // Initialize Apprise client from DB config
-    const appriseApiUrl = await storage.getSystemConfig("apprise.apiUrl");
-    if (appriseApiUrl && appriseApiUrl.length > 0) {
-      const appriseKey = await storage.getSystemConfig("apprise.key");
-      const appriseUrls = await storage.getSystemConfig("apprise.urls");
-      appriseClient.configure(appriseApiUrl, appriseKey || null, appriseUrls || null);
-      log("Apprise client configured from database");
+    const appriseSettings = await readAppriseSettings(storage);
+    appriseClient.configure(appriseSettings);
+    if (appriseClient.isConfigured()) {
+      log(`Apprise client configured from database (${appriseSettings.mode} mode)`);
     }
 
     const server = await registerRoutes(app);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3206,6 +3206,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ error: "Invalid Apprise mode" });
       }
 
+      if (
+        (apiUrl !== undefined && typeof apiUrl !== "string") ||
+        (key !== undefined && typeof key !== "string") ||
+        (urls !== undefined && typeof urls !== "string")
+      ) {
+        return res.status(400).json({ error: "Invalid request payload types" });
+      }
+
       if (mode === "api") {
         if (!apiUrl || apiUrl.trim().length === 0) {
           return res.status(400).json({ error: "API URL is required in API mode" });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -94,7 +94,7 @@ import {
 } from "../shared/title-utils.js";
 import { categorizeDownload } from "../shared/download-categorizer.js";
 import { SUPPORT_WORKER_ORIGIN } from "../shared/support-config.js";
-import archiver from "archiver";
+import { ZipArchive } from "archiver";
 import helmet from "helmet";
 import { steamRoutes } from "./steam-routes.js";
 import { importRouter } from "./routes/import.js";
@@ -2947,7 +2947,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ error: "No downloads provided" });
       }
 
-      const archive = archiver("zip", { zlib: { level: 9 } });
+      const archive = new ZipArchive({ zlib: { level: 9 } });
 
       res.attachment("download-bundle.zip");
       archive.pipe(res);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -62,7 +62,12 @@ import {
   optionalAuthenticateToken,
 } from "./auth.js";
 import { nexusmodsClient } from "./nexusmods.js";
-import { appriseClient } from "./apprise.js";
+import {
+  appriseClient,
+  isAppriseConfigured,
+  normalizeAppriseMode,
+  readAppriseSettings,
+} from "./apprise.js";
 import multer from "multer";
 import path from "path";
 import fs from "fs";
@@ -89,7 +94,7 @@ import {
 } from "../shared/title-utils.js";
 import { categorizeDownload } from "../shared/download-categorizer.js";
 import { SUPPORT_WORKER_ORIGIN } from "../shared/support-config.js";
-import { ZipArchive } from "archiver";
+import archiver from "archiver";
 import helmet from "helmet";
 import { steamRoutes } from "./steam-routes.js";
 import { importRouter } from "./routes/import.js";
@@ -2942,7 +2947,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ error: "No downloads provided" });
       }
 
-      const archive = new ZipArchive({ zlib: { level: 9 } });
+      const archive = archiver("zip", { zlib: { level: 9 } });
 
       res.attachment("download-bundle.zip");
       archive.pipe(res);
@@ -3167,14 +3172,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Apprise settings
   app.get("/api/settings/apprise", async (_req, res) => {
     try {
-      const apiUrl = await storage.getSystemConfig("apprise.apiUrl");
-      const key = await storage.getSystemConfig("apprise.key");
-      const urls = await storage.getSystemConfig("apprise.urls");
+      const settings = await readAppriseSettings(storage);
       res.json({
-        configured: !!(apiUrl && apiUrl.length > 0),
-        apiUrl: apiUrl || null,
-        key: key || null,
-        urls: urls || null,
+        configured: isAppriseConfigured(settings),
+        mode: settings.mode,
+        apiUrl: settings.apiUrl,
+        key: settings.key,
+        urls: settings.urls,
       });
     } catch (error) {
       routesLogger.error({ error }, "Failed to fetch Apprise settings");
@@ -3185,11 +3189,35 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/settings/apprise", async (req, res) => {
     try {
       const { apiUrl, key, urls } = req.body as {
+        mode?: string;
         apiUrl?: string;
         key?: string;
         urls?: string;
       };
-      if (apiUrl) {
+      const mode = normalizeAppriseMode(
+        typeof req.body?.mode === "string" ? req.body.mode : undefined
+      );
+
+      if (
+        typeof req.body?.mode === "string" &&
+        req.body.mode !== "api" &&
+        req.body.mode !== "cli"
+      ) {
+        return res.status(400).json({ error: "Invalid Apprise mode" });
+      }
+
+      if (mode === "api") {
+        if (!apiUrl || apiUrl.trim().length === 0) {
+          return res.status(400).json({ error: "API URL is required in API mode" });
+        }
+        if (!key?.trim() && !urls?.trim()) {
+          return res.status(400).json({ error: "Provide a config key or notification URLs" });
+        }
+      } else if (!urls || urls.trim().length === 0) {
+        return res.status(400).json({ error: "Notification URLs are required in CLI mode" });
+      }
+
+      if (apiUrl?.trim()) {
         try {
           const parsed = new URL(apiUrl.trim());
           if (!["http:", "https:"].includes(parsed.protocol)) {
@@ -3199,10 +3227,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
           return res.status(400).json({ error: "API URL is not a valid URL" });
         }
       }
-      await storage.setSystemConfig("apprise.apiUrl", apiUrl?.trim() ?? "");
-      await storage.setSystemConfig("apprise.key", key?.trim() ?? "");
-      await storage.setSystemConfig("apprise.urls", urls?.trim() ?? "");
-      appriseClient.configure(apiUrl?.trim() || null, key?.trim() || null, urls?.trim() || null);
+      await storage.setSystemConfig("apprise.mode", mode);
+      if (apiUrl !== undefined) {
+        await storage.setSystemConfig("apprise.apiUrl", apiUrl.trim());
+      }
+      if (key !== undefined) {
+        await storage.setSystemConfig("apprise.key", key.trim());
+      }
+      if (urls !== undefined) {
+        await storage.setSystemConfig("apprise.urls", urls.trim());
+      }
+
+      appriseClient.configure(await readAppriseSettings(storage));
       res.json({ success: true });
     } catch (error) {
       routesLogger.error({ error }, "Failed to update Apprise settings");


### PR DESCRIPTION
This pull request introduces support for two Apprise notification modes—API and CLI—allowing users to send notifications either through a remote Apprise API server or directly via the local Apprise CLI binary. It updates the Docker image to include Python and Apprise, streamlines the settings UI for mode selection, and adds comprehensive tests for both modes. The documentation and changelog are updated to reflect these changes.

**Apprise Notification Modes**

* Added support for both Apprise API and CLI notification modes, with the ability to configure either a remote Apprise server or use the local Apprise CLI from the Questarr settings UI (`client/src/pages/settings.tsx`, `docs/CHANGELOG.md`, `README.md`). (Fd769d4fL13R13, [[1]](diffhunk://#diff-ef86b78ab3a2fcb20b1b2b6d4acb9f78241d5b4c4583ea386e82b788f4aa688aL951-R992) [[2]](diffhunk://#diff-ef86b78ab3a2fcb20b1b2b6d4acb9f78241d5b4c4583ea386e82b788f4aa688aR1005-R1006) [[3]](diffhunk://#diff-ef86b78ab3a2fcb20b1b2b6d4acb9f78241d5b4c4583ea386e82b788f4aa688aR1023-R1029) [[4]](diffhunk://#diff-ef86b78ab3a2fcb20b1b2b6d4acb9f78241d5b4c4583ea386e82b788f4aa688aL999-R1066) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45)
* Updated the backend to persist and validate Apprise settings for both modes, and added tests for correct behavior and error handling (`server/__tests__/api_routes.test.ts`, `server/__tests__/fixtures/common-route-mocks.ts`). [[1]](diffhunk://#diff-33d772e1fd33ebcda5d001b58ae51771f6237e9433abc0ec64d2161082a523dbR2528-R2604) [[2]](diffhunk://#diff-581e7930c85254dc609a0336a9ae8ae626e972965c5166eba0c7831378642fb2R223-R236)

**Docker & Dependencies**

* Bundled Python and Apprise in the default Docker image to ensure CLI mode works out of the box (`Dockerfile`, `docs/CHANGELOG.md`). [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L26-R29) [[2]](diffhunk://#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723bR50)

**Testing Improvements**

* Added dedicated tests for the Apprise client, covering both API and CLI modes, including error scenarios (`server/__tests__/apprise.test.ts`).
* Added and updated mocks for Apprise in the test suite (`server/__tests__/fixtures/common-route-mocks.ts`, `server/__tests__/api_routes.test.ts`). [[1]](diffhunk://#diff-581e7930c85254dc609a0336a9ae8ae626e972965c5166eba0c7831378642fb2R223-R236) [[2]](diffhunk://#diff-33d772e1fd33ebcda5d001b58ae51771f6237e9433abc0ec64d2161082a523dbR16) [[3]](diffhunk://#diff-33d772e1fd33ebcda5d001b58ae51771f6237e9433abc0ec64d2161082a523dbR34) [[4]](diffhunk://#diff-33d772e1fd33ebcda5d001b58ae51771f6237e9433abc0ec64d2161082a523dbR48)

**Documentation**

* Updated the README and changelog to document the new notification modes and Docker image changes (`README.md`, `docs/CHANGELOG.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45) Fd769d4fL13R13, [[2]](diffhunk://#diff-2bfab3db5cc1baf4c6d3ff6b19901926e3bdf4411ec685dac973e5fcff1c723bR50)

**Submodule Update**

* Updated the `.github/wiki` submodule reference.