### PR TITLE
Enhance notifications to avoid duplicates during auto search cycles

### DIFF
--- a/client/src/components/PreferredReleaseGroupsSettings.tsx
+++ b/client/src/components/PreferredReleaseGroupsSettings.tsx
@@ -168,7 +168,8 @@ export default function PreferredReleaseGroupsSettings({
                 Pre-filter Download Search
               </Label>
               <p className="text-xs text-muted-foreground">
-                Automatically filter the download dialog to show only preferred groups
+                Automatically filter the download dialog to show only preferred groups, and only
+                send availability/update notifications when a preferred group release is found
               </p>
             </div>
             <Switch

--- a/server/__tests__/cron_autosearch.test.ts
+++ b/server/__tests__/cron_autosearch.test.ts
@@ -1147,4 +1147,245 @@ describe("Cron - checkAutoSearch", () => {
       expect(mockUpdateGameSearchResultsAvailable).toHaveBeenCalledWith(game.id, true);
     });
   });
+
+  describe("Notification dedup (transition gating)", () => {
+    const SINGLE_ITEM_RESULT = {
+      items: [
+        {
+          title: "Test Game",
+          link: "https://example.com/1",
+          pubDate: FIXED_PUB_DATE,
+          seeders: 50,
+          size: 10_000,
+        },
+      ],
+      errors: [],
+      total: 1,
+    };
+    const TWO_ITEM_RESULT = {
+      items: [
+        {
+          title: "Test Game",
+          link: "https://example.com/1",
+          pubDate: FIXED_PUB_DATE,
+          seeders: 50,
+          size: 10_000,
+        },
+        {
+          title: "Test Game v2",
+          link: "https://example.com/2",
+          pubDate: FIXED_PUB_DATE,
+          seeders: 30,
+          size: 8_000,
+        },
+      ],
+      errors: [],
+      total: 2,
+    };
+
+    beforeEach(() => {
+      mockGetUserSettings.mockResolvedValue({ ...baseSettings, autoDownloadEnabled: false });
+    });
+
+    it("does not re-notify 'Game Available' while still available on the next cycle", async () => {
+      const game = {
+        ...baseGame,
+        status: "wanted" as const,
+        releaseStatus: "released" as const,
+        searchResultsAvailable: false,
+      };
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+      mockSearchAllIndexers.mockResolvedValue(SINGLE_ITEM_RESULT);
+
+      await checkAutoSearch();
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Available" })
+      );
+      mockAddNotification.mockClear();
+
+      // Next cycle: same single result, but the game is already marked available from last cycle
+      const stillAvailable = { ...game, searchResultsAvailable: true };
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [stillAvailable]]]));
+
+      await checkAutoSearch();
+      expect(mockAddNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Available" })
+      );
+    });
+
+    it("does not re-notify 'Multiple Results Found' while still available on the next cycle", async () => {
+      const game = {
+        ...baseGame,
+        status: "wanted" as const,
+        releaseStatus: "released" as const,
+        searchResultsAvailable: false,
+      };
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+      mockSearchAllIndexers.mockResolvedValue(TWO_ITEM_RESULT);
+
+      await checkAutoSearch();
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Multiple Results Found" })
+      );
+      mockAddNotification.mockClear();
+
+      const stillAvailable = { ...game, searchResultsAvailable: true };
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [stillAvailable]]]));
+
+      await checkAutoSearch();
+      expect(mockAddNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Multiple Results Found" })
+      );
+    });
+
+    it("does not re-notify 'Game Updates Available' while still available on the next cycle", async () => {
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, []]]));
+      mockSearchAllIndexers.mockResolvedValue({
+        items: [
+          {
+            title: "Test Game Update v1.1",
+            link: "https://example.com/update",
+            pubDate: FIXED_PUB_DATE,
+            seeders: 100,
+            size: 1024,
+          },
+        ],
+        errors: [],
+        total: 1,
+      });
+
+      const ownedGame = {
+        ...baseGame,
+        status: "owned" as const,
+        releaseStatus: "released" as const,
+        searchResultsAvailable: false,
+      };
+      mockGetUserGames.mockResolvedValue([ownedGame]);
+
+      await checkAutoSearch();
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Updates Available" })
+      );
+      mockAddNotification.mockClear();
+
+      const stillAvailable = { ...ownedGame, searchResultsAvailable: true };
+      mockGetUserGames.mockResolvedValue([stillAvailable]);
+
+      await checkAutoSearch();
+      expect(mockAddNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Updates Available" })
+      );
+    });
+
+    it("re-notifies 'Game Available' after a false→true→false→true flap", async () => {
+      let game = {
+        ...baseGame,
+        status: "wanted" as const,
+        releaseStatus: "released" as const,
+        searchResultsAvailable: false,
+      };
+
+      // Cycle 1: becomes available → notifies
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+      mockSearchAllIndexers.mockResolvedValue(SINGLE_ITEM_RESULT);
+      await checkAutoSearch();
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Available" })
+      );
+      mockAddNotification.mockClear();
+
+      // Cycle 2: still available → no re-notify
+      game = { ...game, searchResultsAvailable: true };
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+      await checkAutoSearch();
+      expect(mockAddNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Available" })
+      );
+
+      // Cycle 3: no results → flag clears, no notification either way
+      mockSearchAllIndexers.mockResolvedValue({ items: [], errors: [], total: 0 });
+      await checkAutoSearch();
+      expect(mockUpdateGameSearchResultsAvailable).toHaveBeenCalledWith(game.id, false);
+      mockAddNotification.mockClear();
+
+      // Cycle 4: becomes available again → notifies again
+      game = { ...game, searchResultsAvailable: false };
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+      mockSearchAllIndexers.mockResolvedValue(SINGLE_ITEM_RESULT);
+      await checkAutoSearch();
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Available" })
+      );
+    });
+
+    it("only notifies when a preferred-group release appears (filterByPreferredGroups enabled), and dedups afterward", async () => {
+      mockGetUserSettings.mockResolvedValue({
+        ...baseSettings,
+        autoDownloadEnabled: false,
+        filterByPreferredGroups: true,
+        preferredReleaseGroups: '["SKIDROW"]',
+      });
+
+      const CODEX_ONLY = {
+        items: [
+          {
+            title: "Test Game CODEX",
+            link: "https://example.com/codex",
+            pubDate: FIXED_PUB_DATE,
+            seeders: 80,
+            size: 10_000,
+            group: "CODEX",
+          },
+        ],
+        errors: [],
+        total: 1,
+      };
+      const SKIDROW_ONLY = {
+        items: [
+          {
+            title: "Test Game SKIDROW",
+            link: "https://example.com/skidrow",
+            pubDate: FIXED_PUB_DATE,
+            seeders: 50,
+            size: 10_000,
+            group: "SKIDROW",
+          },
+        ],
+        errors: [],
+        total: 1,
+      };
+
+      let game = {
+        ...baseGame,
+        status: "wanted" as const,
+        releaseStatus: "released" as const,
+        searchResultsAvailable: false,
+      };
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+
+      // Cycle 1: only a non-preferred group release exists → strict filter drops it → no notification
+      mockSearchAllIndexers.mockResolvedValue(CODEX_ONLY);
+      await checkAutoSearch();
+      expect(mockAddNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Available" })
+      );
+      expect(mockUpdateGameSearchResultsAvailable).toHaveBeenCalledWith(game.id, false);
+
+      // Cycle 2: preferred group release appears → notifies
+      mockSearchAllIndexers.mockResolvedValue(SKIDROW_ONLY);
+      await checkAutoSearch();
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Available" })
+      );
+      mockAddNotification.mockClear();
+
+      // Cycle 3: same preferred release still there → no re-notify
+      game = { ...game, searchResultsAvailable: true };
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, [game]]]));
+      await checkAutoSearch();
+      expect(mockAddNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Available" })
+      );
+    });
+  });
 });

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -146,6 +146,51 @@ describe("MemStorage", () => {
       expect(retrieved?.status).toBe("downloading");
     });
 
+    it("should reset searchResultsAvailable when leaving 'wanted' status", async () => {
+      const game = await storage.addGame({
+        title: "Wanted Game",
+        igdbId: 3,
+        status: "wanted",
+        userId: "user-1",
+        hidden: null,
+      });
+      await storage.updateGameSearchResultsAvailable(game.id, true);
+
+      const updated = await storage.updateGameStatus(game.id, { status: "downloading" });
+      expect(updated?.searchResultsAvailable).toBe(false);
+
+      const retrieved = await storage.getGame(game.id);
+      expect(retrieved?.searchResultsAvailable).toBe(false);
+    });
+
+    it("should reset searchResultsAvailable when moving from 'wanted' straight to 'owned'", async () => {
+      const game = await storage.addGame({
+        title: "Wanted Game 2",
+        igdbId: 4,
+        status: "wanted",
+        userId: "user-1",
+        hidden: null,
+      });
+      await storage.updateGameSearchResultsAvailable(game.id, true);
+
+      const updated = await storage.updateGameStatus(game.id, { status: "owned" });
+      expect(updated?.searchResultsAvailable).toBe(false);
+    });
+
+    it("should preserve searchResultsAvailable when status is not leaving 'wanted'", async () => {
+      const game = await storage.addGame({
+        title: "Owned Game With Update",
+        igdbId: 5,
+        status: "downloading",
+        userId: "user-1",
+        hidden: null,
+      });
+      await storage.updateGameSearchResultsAvailable(game.id, true);
+
+      const updated = await storage.updateGameStatus(game.id, { status: "owned" });
+      expect(updated?.searchResultsAvailable).toBe(true);
+    });
+
     it("should remove a game", async () => {
       const gameData: InsertGame = {
         title: "Game to Remove",

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -954,6 +954,10 @@ export async function checkAutoSearch() {
               continue;
             }
 
+            // Snapshot pre-cycle availability (fetched before any writes this cycle) to gate
+            // notifications on the false→true transition instead of firing every cycle.
+            const wasAvailable = game.searchResultsAvailable;
+
             // Apply platform filter first (strict), then preferred groups filter, then
             // de-duplicate releases that appear on multiple indexers (keep highest-priority indexer).
             const platformFilteredMain = applyPreferredPlatformFilter(
@@ -1030,8 +1034,8 @@ export async function checkAutoSearch() {
                   }
                 }
               } else {
-                // Just notify about availability
-                if (prefs.gameAvailable.inApp) {
+                // Just notify about availability (only on the false→true transition)
+                if (!wasAvailable && prefs.gameAvailable.inApp) {
                   const notification = await storage.addNotification({
                     userId,
                     type: "success",
@@ -1043,7 +1047,7 @@ export async function checkAutoSearch() {
                   if (prefs.gameAvailable.apprise) appriseClient.send(notification);
                 }
               }
-            } else if (mainItems.length > 1 && prefs.multipleResults.inApp) {
+            } else if (mainItems.length > 1 && !wasAvailable && prefs.multipleResults.inApp) {
               // Multiple results found, notify user to choose
               const notification = await storage.addNotification({
                 userId,
@@ -1077,6 +1081,8 @@ export async function checkAutoSearch() {
               continue;
             }
 
+            const wasUpdateAvailable = game.searchResultsAvailable;
+
             const platformFilteredUpdate = applyPreferredPlatformFilter(
               searchResult.updateItems,
               preferredPlatform
@@ -1090,7 +1096,7 @@ export async function checkAutoSearch() {
 
             await storage.updateGameSearchResultsAvailable(game.id, updateItems.length > 0);
 
-            if (updateItems.length > 0 && prefs.gameUpdates.inApp) {
+            if (updateItems.length > 0 && !wasUpdateAvailable && prefs.gameUpdates.inApp) {
               const notification = await storage.addNotification({
                 userId,
                 type: "info",

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -477,10 +477,13 @@ export class MemStorage implements IStorage {
     const game = this.games.get(id);
     if (!game) return undefined;
 
+    const leavingWanted = game.status === "wanted" && statusUpdate.status !== "wanted";
+
     const updatedGame: Game = {
       ...game,
       status: statusUpdate.status,
       completedAt: statusUpdate.status === "completed" ? new Date() : null,
+      ...(leavingWanted ? { searchResultsAvailable: false } : {}),
     };
 
     this.games.set(id, updatedGame);
@@ -1603,11 +1606,15 @@ export class DatabaseStorage implements IStorage {
   }
 
   async updateGameStatus(id: string, statusUpdate: UpdateGameStatus): Promise<Game | undefined> {
+    const existingGame = await this.getGame(id);
+    const leavingWanted = existingGame?.status === "wanted" && statusUpdate.status !== "wanted";
+
     const [updatedGame] = await db
       .update(games)
       .set({
         status: statusUpdate.status,
         completedAt: statusUpdate.status === "completed" ? new Date() : null,
+        ...(leavingWanted ? { searchResultsAvailable: false } : {}),
       })
       .where(eq(games.id, id))
       .returning();


### PR DESCRIPTION
This pull request improves notification logic for game availability and updates, ensuring users are only notified when new results become available (i.e., on a false→true transition), rather than on every search cycle. It also updates the UI to clarify notification behavior when preferred release groups are enabled, and adds comprehensive tests to verify deduplication and gating logic.

**Notification deduplication and transition gating:**

* Only send "Game Available", "Multiple Results Found", and "Game Updates Available" notifications when a game transitions from unavailable to available (false→true), preventing repeated notifications on subsequent cycles if the item remains available (`server/cron.ts`). [[1]](diffhunk://#diff-ba75421762c7e2b9cb1f0fa76c848def77f657ddd7b9306cead260d843a10a72R957-R960) [[2]](diffhunk://#diff-ba75421762c7e2b9cb1f0fa76c848def77f657ddd7b9306cead260d843a10a72L1033-R1038) [[3]](diffhunk://#diff-ba75421762c7e2b9cb1f0fa76c848def77f657ddd7b9306cead260d843a10a72L1046-R1050) [[4]](diffhunk://#diff-ba75421762c7e2b9cb1f0fa76c848def77f657ddd7b9306cead260d843a10a72R1084-R1085) [[5]](diffhunk://#diff-ba75421762c7e2b9cb1f0fa76c848def77f657ddd7b9306cead260d843a10a72L1093-R1099)

**Preferred release groups notification logic:**

* Update UI help text to clarify that enabling preferred release groups will also limit notifications to only when a preferred group release is found (`client/src/components/PreferredReleaseGroupsSettings.tsx`).

**Testing and verification:**

* Add extensive tests to ensure notifications are deduplicated correctly, only sent on state transitions, and respect preferred release group settings (`server/__tests__/cron_autosearch.test.ts`).