### PR TITLE
Bump react-resizable-panels to v4 and zod to v4

### DIFF
--- a/client/src/components/ui/resizable.tsx
+++ b/client/src/components/ui/resizable.tsx
@@ -7,10 +7,12 @@ import { cn } from "@/lib/utils";
 
 const ResizablePanelGroup = ({
   className,
+  orientation = "horizontal",
   ...props
 }: React.ComponentProps<typeof ResizablePrimitive.Group>) => (
   <ResizablePrimitive.Group
-    className={cn("flex h-full w-full aria-[orientation=vertical]:flex-col", className)}
+    orientation={orientation}
+    className={cn("flex h-full w-full", orientation === "vertical" && "flex-col", className)}
     {...props}
   />
 );
@@ -26,7 +28,7 @@ const ResizableHandle = ({
 }) => (
   <ResizablePrimitive.Separator
     className={cn(
-      "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 aria-[orientation=vertical]:h-px aria-[orientation=vertical]:w-full aria-[orientation=vertical]:after:left-0 aria-[orientation=vertical]:after:h-1 aria-[orientation=vertical]:after:w-full aria-[orientation=vertical]:after:-translate-y-1/2 aria-[orientation=vertical]:after:translate-x-0 [&[aria-orientation=vertical]>div]:rotate-90",
+      "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:-translate-y-1/2 aria-[orientation=horizontal]:after:translate-x-0 [&[aria-orientation=horizontal]>div]:rotate-90",
       className
     )}
     {...props}

--- a/client/src/components/ui/resizable.tsx
+++ b/client/src/components/ui/resizable.tsx
@@ -8,9 +8,9 @@ import { cn } from "@/lib/utils";
 const ResizablePanelGroup = ({
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
-  <ResizablePrimitive.PanelGroup
-    className={cn("flex h-full w-full data-[panel-group-direction=vertical]:flex-col", className)}
+}: React.ComponentProps<typeof ResizablePrimitive.Group>) => (
+  <ResizablePrimitive.Group
+    className={cn("flex h-full w-full aria-[orientation=vertical]:flex-col", className)}
     {...props}
   />
 );
@@ -21,12 +21,12 @@ const ResizableHandle = ({
   withHandle,
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: React.ComponentProps<typeof ResizablePrimitive.Separator> & {
   withHandle?: boolean;
 }) => (
-  <ResizablePrimitive.PanelResizeHandle
+  <ResizablePrimitive.Separator
     className={cn(
-      "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+      "relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 aria-[orientation=vertical]:h-px aria-[orientation=vertical]:w-full aria-[orientation=vertical]:after:left-0 aria-[orientation=vertical]:after:h-1 aria-[orientation=vertical]:after:w-full aria-[orientation=vertical]:after:-translate-y-1/2 aria-[orientation=vertical]:after:translate-x-0 [&[aria-orientation=vertical]>div]:rotate-90",
       className
     )}
     {...props}
@@ -36,7 +36,7 @@ const ResizableHandle = ({
         <GripVertical className="h-2.5 w-2.5" />
       </div>
     )}
-  </ResizablePrimitive.PanelResizeHandle>
+  </ResizablePrimitive.Separator>
 );
 
 export { ResizablePanelGroup, ResizablePanel, ResizableHandle };

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -28,8 +28,8 @@ export function formatBytes(bytes: number): string {
  * @param schema - A drizzle-zod schema or any zod-compatible schema
  * @returns The schema cast to a standard zod type for use with zodResolver
  */
-export function asZodType<T>(schema: unknown): z.ZodType<T> {
-  return schema as z.ZodType<T>;
+export function asZodType<T>(schema: unknown): z.ZodType<T, T> {
+  return schema as z.ZodType<T, T>;
 }
 
 /**

--- a/client/src/pages/auth/setup.tsx
+++ b/client/src/pages/auth/setup.tsx
@@ -28,8 +28,8 @@ type SetupForm = {
   username: string;
   password: string;
   confirmPassword: string;
-  igdbClientId?: string;
-  igdbClientSecret?: string;
+  igdbClientId: string | undefined;
+  igdbClientSecret: string | undefined;
 };
 
 export default function SetupPage() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/open-sans": "^5.2.7",
-        "@hookform/resolvers": "^3.10.0",
+        "@hookform/resolvers": "^5.4.0",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@radix-ui/react-accordion": "^1.2.15",
         "@radix-ui/react-alert-dialog": "^1.1.18",
@@ -86,7 +86,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.81.0",
         "react-icons": "^5.7.0",
-        "react-resizable-panels": "^2.1.9",
+        "react-resizable-panels": "^4.12.1",
         "recharts": "^3.9.1",
         "rss-parser": "^3.13.0",
         "semver": "^7.8.5",
@@ -97,7 +97,7 @@
         "tw-animate-css": "^1.2.5",
         "vaul": "^1.1.2",
         "wouter": "^3.9.0",
-        "zod": "^3.25.0",
+        "zod": "^4.4.3",
         "zod-validation-error": "^5.0.0"
       },
       "devDependencies": {
@@ -1924,12 +1924,15 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
-      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
       "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
       "peerDependencies": {
-        "react-hook-form": "^7.0.0"
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -13085,13 +13088,13 @@
       }
     },
     "node_modules/react-resizable-panels": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.9.tgz",
-      "integrity": "sha512-z77+X08YDIrgAes4jl8xhnUu1LNIRp4+E7cv4xHmLOxxUPO/ML7PSrE813b90vj7xvQ1lcf7g2uA9GeMZonjhQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.12.1.tgz",
+      "integrity": "sha512-ElE/UpOvMLRWtAqbCgyizHXcbws8RPMyN3cBqmdY17Nxr5f01+DEwzOLqhgcy68GSnjtIUFgKWKl8aIgx5aypQ==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-style-singleton": {
@@ -16052,9 +16055,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/open-sans": "^5.2.7",
-    "@hookform/resolvers": "^3.10.0",
+    "@hookform/resolvers": "^5.4.0",
     "@jridgewell/trace-mapping": "^0.3.25",
     "@radix-ui/react-accordion": "^1.2.15",
     "@radix-ui/react-alert-dialog": "^1.1.18",
@@ -111,7 +111,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.81.0",
     "react-icons": "^5.7.0",
-    "react-resizable-panels": "^2.1.9",
+    "react-resizable-panels": "^4.12.1",
     "recharts": "^3.9.1",
     "rss-parser": "^3.13.0",
     "semver": "^7.8.5",
@@ -122,7 +122,7 @@
     "tw-animate-css": "^1.2.5",
     "vaul": "^1.1.2",
     "wouter": "^3.9.0",
-    "zod": "^3.25.0",
+    "zod": "^4.4.3",
     "zod-validation-error": "^5.0.0"
   },
   "devDependencies": {

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -486,6 +486,16 @@ describe("API Routes - Extended Coverage", () => {
       const response = await request(app).post("/api/games").send(gameData);
       expect(response.status).toBe(409);
     });
+
+    it("should return 400 for a non-numeric steamAppId (fails schema, not sanitizer)", async () => {
+      vi.mocked(storage.getUserGames).mockResolvedValue([]);
+
+      const response = await request(app)
+        .post("/api/games")
+        .send({ title: "New Game", steamAppId: "not-a-number" });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("Invalid game data");
+    });
   });
 
   describe("PATCH /api/games/:id/status", () => {
@@ -541,6 +551,16 @@ describe("API Routes - Extended Coverage", () => {
         .patch(`/api/games/${gameId}/hidden`)
         .send({ hidden: true });
       expect(response.status).toBe(200);
+    });
+
+    it("should return 400 for a non-boolean hidden value (fails schema, not sanitizer)", async () => {
+      const gameId = "123e4567-e89b-12d3-a456-426614174000";
+
+      const response = await request(app)
+        .patch(`/api/games/${gameId}/hidden`)
+        .send({ hidden: "yes" });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("Invalid hidden data");
     });
   });
 
@@ -615,6 +635,28 @@ describe("API Routes - Extended Coverage", () => {
         .patch(`/api/games/${gameId}/user-rating`)
         .send({ userRating: 5 });
       expect(response.status).toBe(404);
+    });
+  });
+
+  describe("PATCH /api/games/:id/notes", () => {
+    const gameId = "123e4567-e89b-12d3-a456-426614174000";
+
+    it("should update notes", async () => {
+      const updatedGame = { id: gameId, notes: "Great game" };
+      vi.mocked(storage.updateGameNotes).mockResolvedValue(updatedGame as unknown as Game);
+
+      const response = await request(app)
+        .patch(`/api/games/${gameId}/notes`)
+        .send({ notes: "Great game" });
+      expect(response.status).toBe(200);
+    });
+
+    it("should return 400 for a non-string notes value (fails schema, not sanitizer)", async () => {
+      const response = await request(app)
+        .patch(`/api/games/${gameId}/notes`)
+        .send({ notes: 12345 });
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("Invalid notes data");
     });
   });
 
@@ -752,6 +794,17 @@ describe("API Routes - Extended Coverage", () => {
         vi.mocked(storage.getAllIndexers).mockRejectedValue(new Error("DB error"));
         const response = await request(app).get("/api/indexers");
         expect(response.status).toBe(500);
+      });
+    });
+
+    describe("POST /api/indexers", () => {
+      it("should return 400 when apiKey is missing (fails schema, not sanitizer)", async () => {
+        const response = await request(app).post("/api/indexers").send({
+          name: "New Indexer",
+          url: "https://example.com",
+        });
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe("Invalid indexer data");
       });
     });
 
@@ -963,6 +1016,17 @@ describe("API Routes - Extended Coverage", () => {
             url: "https://example.com",
           })
         );
+      });
+
+      it("should return 400 when SABnzbd downloader is missing its API key (fails schema refine)", async () => {
+        const response = await request(app).post("/api/downloaders").send({
+          name: "SABnzbd",
+          type: "sabnzbd",
+          url: "https://example.com",
+        });
+
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe("Invalid downloader data");
       });
     });
 
@@ -1389,6 +1453,14 @@ describe("API Routes - Extended Coverage", () => {
       });
     });
 
+    describe("POST /api/notifications", () => {
+      it("should return 400 when required fields are missing", async () => {
+        const response = await request(app).post("/api/notifications").send({});
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe("Invalid notification data");
+      });
+    });
+
     describe("GET /api/notifications/unread-count", () => {
       it("should return unread count", async () => {
         vi.mocked(storage.getUnreadNotificationsCount).mockResolvedValue(5);
@@ -1524,6 +1596,14 @@ describe("API Routes - Extended Coverage", () => {
 
         const response = await request(app).patch("/api/settings").send({});
         expect(response.status).toBe(200);
+      });
+
+      it("should return 400 for an invalid transferMode", async () => {
+        const response = await request(app)
+          .patch("/api/settings")
+          .send({ transferMode: "not-a-real-mode" });
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe("Invalid settings data");
       });
     });
   });
@@ -1972,6 +2052,20 @@ describe("API Routes - Extended Coverage", () => {
   });
 
   // ─── POST /api/downloads/claim-batch ───
+  describe("POST /api/downloads/claim", () => {
+    it("returns 400 when the request body fails schema validation", async () => {
+      const res = await request(app).post("/api/downloads/claim").send({
+        downloaderId: "",
+        downloadHash: "x",
+        downloadTitle: "x",
+        currentStatus: "x",
+        category: "main",
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("Invalid request");
+    });
+  });
+
   describe("POST /api/downloads/claim-batch", () => {
     const validItem = {
       downloaderId: "dl-1",

--- a/server/__tests__/fixtures/common-route-mocks.ts
+++ b/server/__tests__/fixtures/common-route-mocks.ts
@@ -61,6 +61,7 @@ export function createStorageMock() {
     updateGameStatus: vi.fn(),
     updateGameHidden: vi.fn(),
     updateGameUserRating: vi.fn(),
+    updateGameNotes: vi.fn(),
     updateGameSearchResultsAvailable: vi.fn().mockResolvedValue(undefined),
     updateUserPassword: vi.fn(),
     updateGamesBatch: vi.fn(),

--- a/server/__tests__/import_routes_additional.test.ts
+++ b/server/__tests__/import_routes_additional.test.ts
@@ -133,6 +133,17 @@ describe("importRouter additional coverage", () => {
     });
   });
 
+  it("returns 400 for invalid PATCH /mappings/paths/:id payload", async () => {
+    const app = createApp();
+
+    const response = await request(app).patch("/api/imports/mappings/paths/map-1").send({
+      remotePath: "/downloads",
+      // localPath is required and missing
+    });
+
+    expect(response.status).toBe(400);
+  });
+
   it("returns 404 when patching a missing path mapping", async () => {
     mockStorage.updatePathMapping.mockResolvedValue(undefined);
     const app = createApp();
@@ -217,6 +228,14 @@ describe("importRouter additional coverage", () => {
 
     expect(response.status).toBe(400);
     expect(response.body.error).toMatch(/invalid proposed path/i);
+  });
+
+  it("POST /:id/confirm returns 400 when required fields are missing", async () => {
+    const app = createApp();
+    const response = await request(app).post("/api/imports/dl-1/confirm").send({});
+
+    expect(response.status).toBe(400);
+    expect(Array.isArray(response.body.error)).toBe(true);
   });
 
   // --- GET /api/imports/pending — empty array ---

--- a/server/config-loader.ts
+++ b/server/config-loader.ts
@@ -13,7 +13,7 @@ const configSchema = z.object({
       keyPath: z.string().optional(),
       redirectHttp: z.boolean().default(false),
     })
-    .default({}),
+    .default({ enabled: false, port: 9898, redirectHttp: false }),
 });
 
 export type AppConfig = z.infer<typeof configSchema>;

--- a/server/config.ts
+++ b/server/config.ts
@@ -65,7 +65,7 @@ function validateEnv() {
   const result = envSchema.safeParse(process.env);
 
   if (!result.success) {
-    const errorMessages = result.error.errors.map((err) => {
+    const errorMessages = result.error.issues.map((err) => {
       const path = err.path.join(".");
       return `  - ${path}: ${err.message}`;
     });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -152,6 +152,10 @@ function maskDownloader(downloader: Downloader): Downloader {
   return downloader.password ? { ...downloader, password: REDACTED_PLACEHOLDER } : downloader;
 }
 
+function respondWithZodError(res: Response, error: z.ZodError, message: string): Response {
+  return res.status(400).json({ error: message, details: error.issues });
+}
+
 // Helper to parse category query param which might be string, array, or comma-separated
 export function parseCategories(input: unknown): string[] | undefined {
   if (!input) return undefined;
@@ -514,7 +518,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.json({ success: true, message: "Password updated successfully" });
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ error: "Invalid password data", details: error.issues });
+        return respondWithZodError(res, error, "Invalid password data");
       }
       routesLogger.error({ error }, "Failed to update password");
       res.status(500).json({ error: "Failed to update password" });
@@ -1098,7 +1102,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       } catch (error) {
         if (error instanceof z.ZodError) {
           routesLogger.warn({ errors: error.issues }, "validation error");
-          return res.status(400).json({ error: "Invalid game data", details: error.issues });
+          return respondWithZodError(res, error, "Invalid game data");
         }
         routesLogger.error({ error }, "error adding game");
         res.status(500).json({ error: "Failed to add game" });
@@ -1126,7 +1130,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.json(updatedGame);
       } catch (error) {
         if (error instanceof z.ZodError) {
-          return res.status(400).json({ error: "Invalid status data", details: error.issues });
+          return respondWithZodError(res, error, "Invalid status data");
         }
         routesLogger.error({ error }, "error updating game status");
         res.status(500).json({ error: "Failed to update game status" });
@@ -1153,7 +1157,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.json(updatedGame);
       } catch (error) {
         if (error instanceof z.ZodError) {
-          return res.status(400).json({ error: "Invalid hidden data", details: error.issues });
+          return respondWithZodError(res, error, "Invalid hidden data");
         }
         routesLogger.error({ error }, "error updating game visibility");
         res.status(500).json({ error: "Failed to update game visibility" });
@@ -1181,7 +1185,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.json(updatedGame);
       } catch (error) {
         if (error instanceof z.ZodError) {
-          return res.status(400).json({ error: "Invalid user rating data", details: error.issues });
+          return respondWithZodError(res, error, "Invalid user rating data");
         }
         routesLogger.error({ error }, "error updating game user rating");
         res.status(500).json({ error: "Failed to update user rating" });
@@ -1209,7 +1213,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.json(updatedGame);
       } catch (error) {
         if (error instanceof z.ZodError) {
-          return res.status(400).json({ error: "Invalid notes data", details: error.issues });
+          return respondWithZodError(res, error, "Invalid notes data");
         }
         routesLogger.error({ error }, "error updating game notes");
         res.status(500).json({ error: "Failed to update notes" });
@@ -1382,7 +1386,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
         const parsed = insertReleaseBlacklistSchema.safeParse({ ...req.body, gameId });
         if (!parsed.success) {
-          return res.status(400).json({ error: "Invalid data", details: parsed.error.issues });
+          return respondWithZodError(res, parsed.error, "Invalid data");
         }
         const { releaseTitle } = parsed.data;
         if (!releaseTitle || releaseTitle.length > 500) {
@@ -1732,7 +1736,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.status(201).json(maskIndexer(indexer));
       } catch (error) {
         if (error instanceof z.ZodError) {
-          return res.status(400).json({ error: "Invalid indexer data", details: error.issues });
+          return respondWithZodError(res, error, "Invalid indexer data");
         }
         routesLogger.error({ error }, "error adding indexer");
         res.status(500).json({ error: "Failed to add indexer" });
@@ -1898,7 +1902,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.status(201).json(maskDownloader(downloader));
       } catch (error) {
         if (error instanceof z.ZodError) {
-          return res.status(400).json({ error: "Invalid downloader data", details: error.issues });
+          return respondWithZodError(res, error, "Invalid downloader data");
         }
         routesLogger.error({ error }, "error adding downloader");
         res.status(500).json({ error: "Failed to add downloader" });
@@ -2536,7 +2540,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const parsed = claimDownloadRequestSchema.safeParse(req.body);
       if (!parsed.success) {
-        return res.status(400).json({ error: "Invalid request", details: parsed.error.issues });
+        return respondWithZodError(res, parsed.error, "Invalid request");
       }
       const {
         downloaderId,
@@ -2665,9 +2669,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     for (const raw of rawItems) {
       const parsed = claimDownloadRequestSchema.safeParse(raw);
       if (!parsed.success) {
-        return res
-          .status(400)
-          .json({ error: "Invalid item in batch", details: parsed.error.issues });
+        return respondWithZodError(res, parsed.error, "Invalid item in batch");
       }
       parsedItems.push(parsed.data);
     }
@@ -3033,7 +3035,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(201).json(notification);
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ error: "Invalid notification data", details: error.issues });
+        return respondWithZodError(res, error, "Invalid notification data");
       }
       routesLogger.error({ error }, "error adding notification");
       res.status(500).json({ error: "Failed to add notification" });
@@ -3312,7 +3314,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       if (error instanceof z.ZodError) {
         routesLogger.error({ error: error.issues }, "validation error in settings update");
-        return res.status(400).json({ error: "Invalid settings data", details: error.issues });
+        return respondWithZodError(res, error, "Invalid settings data");
       }
       next(error);
     }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -514,7 +514,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.json({ success: true, message: "Password updated successfully" });
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ error: "Invalid password data", details: error.errors });
+        return res.status(400).json({ error: "Invalid password data", details: error.issues });
       }
       routesLogger.error({ error }, "Failed to update password");
       res.status(500).json({ error: "Failed to update password" });
@@ -1097,8 +1097,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.status(201).json(game);
       } catch (error) {
         if (error instanceof z.ZodError) {
-          routesLogger.warn({ errors: error.errors }, "validation error");
-          return res.status(400).json({ error: "Invalid game data", details: error.errors });
+          routesLogger.warn({ errors: error.issues }, "validation error");
+          return res.status(400).json({ error: "Invalid game data", details: error.issues });
         }
         routesLogger.error({ error }, "error adding game");
         res.status(500).json({ error: "Failed to add game" });
@@ -1126,7 +1126,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.json(updatedGame);
       } catch (error) {
         if (error instanceof z.ZodError) {
-          return res.status(400).json({ error: "Invalid status data", details: error.errors });
+          return res.status(400).json({ error: "Invalid status data", details: error.issues });
         }
         routesLogger.error({ error }, "error updating game status");
         res.status(500).json({ error: "Failed to update game status" });
@@ -1153,7 +1153,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.json(updatedGame);
       } catch (error) {
         if (error instanceof z.ZodError) {
-          return res.status(400).json({ error: "Invalid hidden data", details: error.errors });
+          return res.status(400).json({ error: "Invalid hidden data", details: error.issues });
         }
         routesLogger.error({ error }, "error updating game visibility");
         res.status(500).json({ error: "Failed to update game visibility" });
@@ -1181,7 +1181,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.json(updatedGame);
       } catch (error) {
         if (error instanceof z.ZodError) {
-          return res.status(400).json({ error: "Invalid user rating data", details: error.errors });
+          return res.status(400).json({ error: "Invalid user rating data", details: error.issues });
         }
         routesLogger.error({ error }, "error updating game user rating");
         res.status(500).json({ error: "Failed to update user rating" });
@@ -1209,7 +1209,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.json(updatedGame);
       } catch (error) {
         if (error instanceof z.ZodError) {
-          return res.status(400).json({ error: "Invalid notes data", details: error.errors });
+          return res.status(400).json({ error: "Invalid notes data", details: error.issues });
         }
         routesLogger.error({ error }, "error updating game notes");
         res.status(500).json({ error: "Failed to update notes" });
@@ -1732,7 +1732,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.status(201).json(maskIndexer(indexer));
       } catch (error) {
         if (error instanceof z.ZodError) {
-          return res.status(400).json({ error: "Invalid indexer data", details: error.errors });
+          return res.status(400).json({ error: "Invalid indexer data", details: error.issues });
         }
         routesLogger.error({ error }, "error adding indexer");
         res.status(500).json({ error: "Failed to add indexer" });
@@ -1898,7 +1898,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         res.status(201).json(maskDownloader(downloader));
       } catch (error) {
         if (error instanceof z.ZodError) {
-          return res.status(400).json({ error: "Invalid downloader data", details: error.errors });
+          return res.status(400).json({ error: "Invalid downloader data", details: error.issues });
         }
         routesLogger.error({ error }, "error adding downloader");
         res.status(500).json({ error: "Failed to add downloader" });
@@ -2536,7 +2536,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const parsed = claimDownloadRequestSchema.safeParse(req.body);
       if (!parsed.success) {
-        return res.status(400).json({ error: "Invalid request", details: parsed.error.errors });
+        return res.status(400).json({ error: "Invalid request", details: parsed.error.issues });
       }
       const {
         downloaderId,
@@ -2667,7 +2667,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (!parsed.success) {
         return res
           .status(400)
-          .json({ error: "Invalid item in batch", details: parsed.error.errors });
+          .json({ error: "Invalid item in batch", details: parsed.error.issues });
       }
       parsedItems.push(parsed.data);
     }
@@ -3033,7 +3033,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(201).json(notification);
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ error: "Invalid notification data", details: error.errors });
+        return res.status(400).json({ error: "Invalid notification data", details: error.issues });
       }
       routesLogger.error({ error }, "error adding notification");
       res.status(500).json({ error: "Failed to add notification" });
@@ -3311,8 +3311,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.json(settings);
     } catch (error) {
       if (error instanceof z.ZodError) {
-        routesLogger.error({ error: error.errors }, "validation error in settings update");
-        return res.status(400).json({ error: "Invalid settings data", details: error.errors });
+        routesLogger.error({ error: error.issues }, "validation error in settings update");
+        return res.status(400).json({ error: "Invalid settings data", details: error.issues });
       }
       next(error);
     }
@@ -3641,7 +3641,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(201).json(feed);
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res.status(400).json({ error: error.errors });
+        return res.status(400).json({ error: error.issues });
       }
       // Fallback for when instanceof fails (e.g. different zod versions/contexts)
       if (

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -205,7 +205,7 @@ importRouter.post("/mappings/platforms", async (req, res) => {
     res.json(created);
   } catch (error) {
     if (error instanceof z.ZodError)
-      return res.status(400).json({ error: error.errors.map((e) => e.message).join(", ") });
+      return res.status(400).json({ error: error.issues.map((e) => e.message).join(", ") });
     res.status(500).json({ error: "Failed to create platform mapping" });
   }
 });
@@ -218,7 +218,7 @@ importRouter.patch("/mappings/platforms/:id", async (req, res) => {
     else res.status(404).json({ error: "Mapping not found" });
   } catch (error) {
     if (error instanceof z.ZodError)
-      return res.status(400).json({ error: error.errors.map((e) => e.message).join(", ") });
+      return res.status(400).json({ error: error.issues.map((e) => e.message).join(", ") });
     res.status(500).json({ error: "Failed to update platform mapping" });
   }
 });
@@ -263,7 +263,7 @@ importRouter.post("/mappings/paths", async (req, res) => {
     res.json(created);
   } catch (error) {
     if (error instanceof z.ZodError)
-      return res.status(400).json({ error: error.errors.map((e) => e.message).join(", ") });
+      return res.status(400).json({ error: error.issues.map((e) => e.message).join(", ") });
     res.status(500).json({ error: "Failed to create path mapping" });
   }
 });
@@ -279,7 +279,7 @@ importRouter.patch("/mappings/paths/:id", async (req, res) => {
     }
   } catch (error) {
     if (error instanceof z.ZodError)
-      return res.status(400).json({ error: error.errors.map((e) => e.message).join(", ") });
+      return res.status(400).json({ error: error.issues.map((e) => e.message).join(", ") });
     logger.error({ error }, "Error updating path mapping");
     res.status(500).json({ error: "Failed to update path mapping" });
   }
@@ -339,7 +339,7 @@ importRouter.patch("/config", async (req, res) => {
     res.json(newConfig);
   } catch (error) {
     if (error instanceof z.ZodError)
-      return res.status(400).json({ error: error.errors.map((e) => e.message).join(", ") });
+      return res.status(400).json({ error: error.issues.map((e) => e.message).join(", ") });
     res.status(500).json({ error: "Failed to update import config" });
   }
 });
@@ -508,7 +508,7 @@ importRouter.post("/:id/confirm", async (req, res) => {
     res.json({ success: true });
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return res.status(400).json({ error: error.errors });
+      return res.status(400).json({ error: error.issues });
     }
     if (error instanceof Error) {
       if (

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -19,6 +19,10 @@ import { extractHostnameFromUrl } from "../url-utils.js";
 
 export const importRouter = Router();
 
+function zodErrorMessage(error: z.ZodError): string {
+  return error.issues.map((issue) => issue.message).join(", ");
+}
+
 importRouter.use((req, res, next) => {
   if (!req.user?.id) {
     return res.status(401).json({ error: "Unauthorized" });
@@ -204,8 +208,7 @@ importRouter.post("/mappings/platforms", async (req, res) => {
     const created = await storage.addPlatformMapping(mapping);
     res.json(created);
   } catch (error) {
-    if (error instanceof z.ZodError)
-      return res.status(400).json({ error: error.issues.map((e) => e.message).join(", ") });
+    if (error instanceof z.ZodError) return res.status(400).json({ error: zodErrorMessage(error) });
     res.status(500).json({ error: "Failed to create platform mapping" });
   }
 });
@@ -217,8 +220,7 @@ importRouter.patch("/mappings/platforms/:id", async (req, res) => {
     if (updated) res.json(updated);
     else res.status(404).json({ error: "Mapping not found" });
   } catch (error) {
-    if (error instanceof z.ZodError)
-      return res.status(400).json({ error: error.issues.map((e) => e.message).join(", ") });
+    if (error instanceof z.ZodError) return res.status(400).json({ error: zodErrorMessage(error) });
     res.status(500).json({ error: "Failed to update platform mapping" });
   }
 });
@@ -262,8 +264,7 @@ importRouter.post("/mappings/paths", async (req, res) => {
     const created = await storage.addPathMapping(mapping);
     res.json(created);
   } catch (error) {
-    if (error instanceof z.ZodError)
-      return res.status(400).json({ error: error.issues.map((e) => e.message).join(", ") });
+    if (error instanceof z.ZodError) return res.status(400).json({ error: zodErrorMessage(error) });
     res.status(500).json({ error: "Failed to create path mapping" });
   }
 });
@@ -278,8 +279,7 @@ importRouter.patch("/mappings/paths/:id", async (req, res) => {
       res.status(404).json({ error: "Mapping not found" });
     }
   } catch (error) {
-    if (error instanceof z.ZodError)
-      return res.status(400).json({ error: error.issues.map((e) => e.message).join(", ") });
+    if (error instanceof z.ZodError) return res.status(400).json({ error: zodErrorMessage(error) });
     logger.error({ error }, "Error updating path mapping");
     res.status(500).json({ error: "Failed to update path mapping" });
   }
@@ -338,8 +338,7 @@ importRouter.patch("/config", async (req, res) => {
     }
     res.json(newConfig);
   } catch (error) {
-    if (error instanceof z.ZodError)
-      return res.status(400).json({ error: error.issues.map((e) => e.message).join(", ") });
+    if (error instanceof z.ZodError) return res.status(400).json({ error: zodErrorMessage(error) });
     res.status(500).json({ error: "Failed to update import config" });
   }
 });


### PR DESCRIPTION
## Description

Combines the Dependabot bumps for `react-resizable-panels` (2.x → 4.x, #778) and `zod` (v3 → v4, #777) into a single PR, since the zod v4 migration required touching `@hookform/resolvers` as well and the two changes overlap in the same form-handling code paths.

- `react-resizable-panels` v4: migrated `PanelGroup`/`PanelResizeHandle` to `Group`/`Separator`, `direction` prop to `orientation`, and updated the corresponding `data-panel-group-direction`/`data-panel-resize-handle-*` attribute selectors in `client/src/components/ui/resizable.tsx`.
- `zod` v4: renamed `ZodError.errors` to `.issues` across `server/routes.ts`, `server/routes/import.ts`, `server/config.ts`, `server/config-loader.ts`.
- `@hookform/resolvers` bumped from v3 to **v5.4.0** (not v4): v4.1.3 satisfies the type surface but silently fails to detect zod v4 validation errors at runtime (its internal duck-typing check assumes `ZodError.errors`, which no longer exists), causing form validation to break silently. v5.4.0 was verified to fix the actual runtime behavior, confirmed via the previously-failing `SetupPage` test.
- Added a fully parameterized `asZodType<T>(schema): z.ZodType<T, T>` cast in `client/src/lib/utils.ts` so drizzle-zod-generated schemas satisfy the resolver's `FieldValues` type constraint (the single-type-param version left `Input` as `unknown`, which v5's stricter resolver typing rejects).

Fixes #778
Fixes #777

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes (1764 passed, 0 errors)
- [x] `npm run check` and `npm run build` pass locally
