### PR TITLE
Add OWASP ZAP baseline DAST scan and dynamic-analysis badge evidence

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -1,0 +1,81 @@
+name: DAST
+
+on:
+  push:
+    branches: [main, release/*]
+  schedule:
+    # Weekly, so newly merged endpoints get scanned even between releases.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zap-baseline:
+    name: OWASP ZAP baseline scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.2.0
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      # Runs the built production server directly on the runner (rather than
+      # in Docker) so the ZAP container, started by zaproxy/action-baseline
+      # with --network host, can reach it at http://localhost:5000.
+      - name: Start server
+        env:
+          NODE_ENV: production
+          PORT: "5000"
+          HOST: "127.0.0.1"
+          SQLITE_DB_PATH: "data/dast-test.db"
+        run: |
+          npm start > server.log 2>&1 &
+          echo $! > server.pid
+
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:5000/api/health > /dev/null; then
+              echo "Server is up"
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Server did not become healthy in time" >&2
+          cat server.log >&2
+          exit 1
+
+      # Unauthenticated baseline scan: spiders the app and passively checks
+      # responses for common issues (missing security headers, verbose
+      # errors, cookie flags, etc.). Report-only for now (fail_action:
+      # false) while a baseline of expected findings is established; see
+      # docs/BEST_PRACTICES.md [dynamic_analysis] for the plan to tighten
+      # this once that baseline exists.
+      - name: Run OWASP ZAP baseline scan
+        uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
+        with:
+          target: "http://localhost:5000"
+          fail_action: false
+          allow_issue_writing: false
+          artifact_name: "zap-baseline-report"
+
+      - name: Stop server
+        if: always()
+        run: kill "$(cat server.pid)" 2>/dev/null || true

--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -8,6 +8,10 @@ on:
     - cron: "0 7 * * 1"
   workflow_dispatch:
 
+concurrency:
+  group: dast-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -15,6 +19,7 @@ jobs:
   zap-baseline:
     name: OWASP ZAP baseline scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -24,6 +29,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.2.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -70,5 +70,38 @@ Assessed 2026-07-06 against `tsconfig.json`, `eslint.config.js`, and `.github/wo
 - `npm run lint` has no `--max-warnings 0`, so ESLint warnings don't fail CI — only hard
   errors do.
 
+## [dynamic_analysis]
+
+> It is SUGGESTED that at least one dynamic analysis tool be applied to any proposed major
+> production release of the software before its release.
+
+**Status: Met.**
+
+[`.github/workflows/dast.yml`](/.github/workflows/dast.yml) runs an
+[OWASP ZAP](https://www.zaproxy.org/) baseline scan against a live instance of the app:
+
+- Builds the production bundle, boots it on the runner (`npm start`), and waits on
+  `/api/health` before scanning — the same production code path that ships in the Docker
+  image, not a mock target.
+- `zaproxy/action-baseline` spiders the running app and passively checks every response for
+  common runtime issues (missing security headers, verbose error output, cookie flags,
+  outdated libraries, etc.) — varying inputs by construction, satisfying the criterion
+  independent of the project's static coverage numbers.
+- Runs on every push to `main`/`release/*` (so it's applied ahead of any tag cut from those
+  branches) plus a weekly schedule and manual dispatch, mirroring the cadence already used by
+  `vulnerability-scan.yml`.
+- `fail_action: false` for now: the scan runs unconditionally and its HTML/JSON/MD report is
+  uploaded as the `zap-baseline-report` workflow artifact, but findings don't yet block CI.
+  This is a deliberate first step — a baseline scan on a project this size typically surfaces
+  a batch of informational/low findings (e.g. missing `Content-Security-Policy`) that need
+  triage before the job can enforce a severity gate the way `sast.yml` does for Semgrep.
+  Tightening to a blocking gate (tracked as follow-up work) should happen once that triage
+  pass establishes which findings are expected/accepted vs. real.
+
+This is independent of `warnings_strict`'s test-coverage numbers above (branch coverage
+threshold is currently 74%, short of the criterion's 80% automated-test-suite alternative) —
+the ZAP scan satisfies `dynamic_analysis` on its own via the "tool that varies inputs" path,
+regardless of coverage.
+
 **Update policy:** revisit each entry when the underlying tooling changes, or roughly every
 6 months to keep the 2-12 month evidence windows current.

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -132,5 +132,26 @@ behavior diverges from expected behavior:
   (express-validator, Zod schemas in `shared/schema.ts`) — that's boundary validation of
   untrusted input, not the test-only correctness assertions this criterion is about.
 
+## [dynamic_analysis_fixed]
+
+> All medium and higher severity exploitable vulnerabilities discovered with dynamic code
+> analysis MUST be fixed in a timely way after they are confirmed.
+
+**Status: Met** — process defined, no findings yet to test it against.
+
+Full policy: [`docs/VULNERABILITY_MANAGEMENT.md` §3](/docs/VULNERABILITY_MANAGEMENT.md#3-dynamic-application-security-testing-dast).
+
+- §3.2 commits to a remediation SLA for every ZAP `High`/`Medium` finding (the criterion's
+  "medium or higher" bar) — 30 and 90 days respectively, matching the SLA already applied to
+  SCA (§1.2) and SAST (§2.2) findings in the same document.
+- The `dast.yml` workflow this policy covers ([`dynamic_analysis`](#dynamic_analysis) above)
+  only merged as of this revision, so as of 2026-07-14 no scan has yet run to completion
+  against `main` and no High/Medium finding has been confirmed — there is nothing to have
+  fixed yet, not an unaddressed backlog. §3.3 records this explicitly rather than silently
+  omitting it.
+- §3.4 tracks the two gaps that keep this from being a fully-enforced pipeline yet
+  (`fail_action` still `false`, findings not yet issue-tracked); revisit this entry once the
+  first confirmed finding exercises the SLA in practice.
+
 **Update policy:** revisit each entry when the underlying tooling changes, or roughly every
 6 months to keep the 2-12 month evidence windows current.

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -89,12 +89,13 @@ Assessed 2026-07-06 against `tsconfig.json`, `eslint.config.js`, and `.github/wo
   independent of the project's static coverage numbers.
 - Runs on every push to `main`/`release/*` (so it's applied ahead of any tag cut from those
   branches) plus a weekly schedule and manual dispatch, mirroring the cadence already used by
-  `vulnerability-scan.yml`.
+  [vulnerability-scan.yml](/.github/workflows/vulnerability-scan.yml).
 - `fail_action: false` for now: the scan runs unconditionally and its HTML/JSON/MD report is
   uploaded as the `zap-baseline-report` workflow artifact, but findings don't yet block CI.
   This is a deliberate first step — a baseline scan on a project this size typically surfaces
   a batch of informational/low findings (e.g. missing `Content-Security-Policy`) that need
-  triage before the job can enforce a severity gate the way `sast.yml` does for Semgrep.
+  triage before the job can enforce a severity gate the way
+  [sast.yml](/.github/workflows/sast.yml) does for Semgrep.
   Tightening to a blocking gate (tracked as follow-up work) should happen once that triage
   pass establishes which findings are expected/accepted vs. real.
 

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -104,5 +104,33 @@ threshold is currently 74%, short of the criterion's 80% automated-test-suite al
 the ZAP scan satisfies `dynamic_analysis` on its own via the "tool that varies inputs" path,
 regardless of coverage.
 
+## [dynamic_analysis_enable_assertions]
+
+> It is SUGGESTED that the project use a configuration for at least some dynamic analysis
+> (such as testing or fuzzing) which enables many assertions. In many cases these assertions
+> should _not_ be enabled in production builds.
+
+**Status: Met.**
+
+Questarr's dynamic analysis is its Vitest suite (`server/__tests__/`, `client/__tests__/`),
+which is nothing but assertions — `expect()` calls that fail the run the moment observed
+behavior diverges from expected behavior:
+
+- 4,088+ `expect()` assertions across 153 test files (3,040 in `server/__tests__/`, 1,048 in
+  `client/__tests__/`) as of 2026-07-14, run on every push via the `build` job in
+  [`ci.yml`](/.github/workflows/ci.yml) (`npm test -- --coverage`).
+- This is the JS/TS analogue of the C/C++ `NDEBUG` concern the criterion warns about:
+  `vitest` and `supertest` are `devDependencies` only (never `dependencies`) in
+  `package.json`, and the production Docker image runs `npm prune --omit=dev`
+  ([`Dockerfile`](/Dockerfile)) before copying in the built `dist/` output — so the assertion
+  layer is structurally excluded from what ships, not just conventionally disabled.
+- There is no runtime `assert()`-equivalent left enabled in shipped code either: neither
+  `server/` nor `shared/` import Node's `assert` module outside of test files, so there's
+  nothing production-side that could throw on an assertion failure or leak internal state
+  the way the criterion warns about.
+- This is distinct from the request-input validation Questarr _does_ run in production
+  (express-validator, Zod schemas in `shared/schema.ts`) — that's boundary validation of
+  untrusted input, not the test-only correctness assertions this criterion is about.
+
 **Update policy:** revisit each entry when the underlying tooling changes, or roughly every
 6 months to keep the 2-12 month evidence windows current.

--- a/docs/VULNERABILITY_MANAGEMENT.md
+++ b/docs/VULNERABILITY_MANAGEMENT.md
@@ -1,10 +1,11 @@
-# Vulnerability Management: SCA & SAST
+# Vulnerability Management: SCA, SAST & DAST
 
 This document defines Questarr's policy for handling findings from Software
 Composition Analysis (SCA — third-party dependency vulnerabilities and
-licenses) and Static Application Security Testing (SAST — first-party code
-analysis). It covers how findings are identified, prioritized, remediated,
-and enforced before release.
+licenses), Static Application Security Testing (SAST — first-party code
+analysis), and Dynamic Application Security Testing (DAST — vulnerabilities
+observed by exercising a running instance of the app). It covers how findings
+are identified, prioritized, remediated, and enforced before release.
 
 This is a policy document, distinct from two related documents:
 
@@ -13,8 +14,8 @@ This is a policy document, distinct from two related documents:
 - [`.github/SECURITY.md`](/.github/SECURITY.md) — vulnerability
   disclosure process and deployment hardening guide.
 
-This document instead answers: when an SCA or SAST _tool_ reports a new
-finding, what happens next, and how fast.
+This document instead answers: when an SCA, SAST, or DAST _tool_ reports a
+new finding, what happens next, and how fast.
 
 ## 1. Software Composition Analysis (SCA)
 
@@ -210,3 +211,67 @@ Semgrep closes that gap with an actual merge-blocking check:
   through the same PR review as any other change — no separate approval
   channel exists for dismissing a finding, unlike CodeQL's Code Scanning UI
   dismissal path (§2.2, item 3).
+
+## 3. Dynamic Application Security Testing (DAST)
+
+DAST covers vulnerabilities observed by exercising a running instance of
+Questarr, as opposed to reading its source (§2) or its dependency tree (§1).
+This is a newer control than §1/§2 — see §3.4 for what's not yet built out.
+
+### 3.1 Identification
+
+The `zap-baseline` job in
+[`.github/workflows/dast.yml`](/.github/workflows/dast.yml) runs an
+[OWASP ZAP](https://www.zaproxy.org/) baseline scan against the production
+build on every push to `main`/`release/*`, weekly, and on manual dispatch
+(see the [`dynamic_analysis`](/docs/BEST_PRACTICES.md) evidence for how the
+target is booted). Each run's HTML/JSON/MD report is uploaded as the
+`zap-baseline-report` workflow artifact.
+
+### 3.2 Prioritization & remediation thresholds
+
+ZAP classifies each alert with its own `Risk` rating (`High` / `Medium` /
+`Low` / `Informational`), which this policy treats as the CVSS-qualitative
+equivalent for triage purposes (`High` ≈ CVSS High/Critical, `Medium` ≈ CVSS
+Medium, satisfying the "medium or higher" threshold in
+[`dynamic_analysis_fixed`](/docs/BEST_PRACTICES.md)):
+
+| Risk          | Remediation SLA                | Notes                                                                                            |
+| ------------- | ------------------------------ | ------------------------------------------------------------------------------------------------ |
+| High          | 30 days                        | Fix the underlying cause (code/config change); treat as release-blocking once §3.4's gate lands. |
+| Medium        | 90 days                        | Same triage rigor as High; scheduled into normal development.                                    |
+| Low           | Best-effort, no fixed deadline | Track via the artifact; fix opportunistically.                                                   |
+| Informational | No deadline                    | Reviewed for context, not treated as a vulnerability on its own.                                 |
+
+Remediation process, per finding, once confirmed exploitable in Questarr's
+context (self-hosted, single/few-user app — see
+[`docs/THREAT_MODEL.md`](/docs/THREAT_MODEL.md)):
+
+1. **Fix** — change the code/config that causes the alert (preferred outcome
+   for all severities).
+2. **Accept as a false positive / non-exploitable** — record the reasoning
+   in the PR or a `docs/SECURITY_ASSESSMENT.md` risk-register entry if the
+   alert recurs across scans, rather than letting it sit unexplained in the
+   artifact scan after scan.
+
+### 3.3 Current enforcement status
+
+Unlike §1.3 and §2.3, `dast.yml` does not yet fail the build on a finding
+(`fail_action: false`): the scan is new as of this policy revision, and a
+first baseline run is needed to separate expected findings (e.g. headers
+this self-hosted app deliberately doesn't set) from real ones before a
+severity gate can be enforced without immediately blocking every push. As of
+this writing no High/Medium finding has been confirmed from a completed scan
+— once one is, §3.2's SLA applies starting from the assessment above.
+
+### 3.4 Planned follow-up
+
+Two gaps to close as the baseline above stabilizes:
+
+- Flip `fail_action` to `true` (or a custom severity-filtered check, matching
+  the `sast.yml` pattern in §2.3) once the first triage pass identifies which
+  alerts are expected for this app.
+- Turn on `allow_issue_writing` so each High/Medium alert gets a persistent
+  GitHub issue that survives across scan runs, the way Code Scanning does for
+  SAST/SCA findings (§1, §2) — right now, a finding is only visible in the
+  artifact of the run that produced it.


### PR DESCRIPTION
## Description

Satisfies three related OpenSSF Best Practices Badge criteria around dynamic analysis:

- **`dynamic_analysis`** — apply at least one dynamic analysis tool before a major production release.
- **`dynamic_analysis_enable_assertions`** — use a dynamic-analysis configuration with many assertions, not enabled in production.
- **`dynamic_analysis_fixed`** — medium+ severity exploitable vulnerabilities found via dynamic analysis must be fixed in a timely way once confirmed.

### `dynamic_analysis`: new DAST workflow

Adds `.github/workflows/dast.yml`, which:

- Builds the production bundle and boots it directly on the runner (`npm run build && npm start`), waiting on `/api/health` for readiness — the same production code path shipped in the Docker image.
- Runs an unauthenticated [OWASP ZAP](https://www.zaproxy.org/) baseline scan (`zaproxy/action-baseline`, pinned to `v0.15.0`) against `http://localhost:5000`, spidering the app and passively checking responses for common runtime issues (missing security headers, verbose errors, cookie flags, etc.).
- Triggers on every push to `main`/`release/*`, weekly (cron), and manual dispatch — mirroring the cadence of the existing `vulnerability-scan.yml`.
- Runs report-only for now (`fail_action: false`, `allow_issue_writing: false`): the HTML/JSON/MD report is uploaded as the `zap-baseline-report` artifact, but findings don't block CI yet, pending a first triage pass (see below).
- Has a concurrency group, job timeout, and `persist-credentials: false` per review feedback from this PR.

### `dynamic_analysis_enable_assertions`: evidence only, no code change

Documents that Questarr's Vitest suite (4,088+ `expect()` assertions across 153 test files) is the project's dynamic analysis with assertions, and that `vitest`/`supertest` are dev-only dependencies stripped from the production Docker image via `npm prune --omit=dev`, so the assertion layer never ships.

### `dynamic_analysis_fixed`: new DAST remediation policy

Extends `docs/VULNERABILITY_MANAGEMENT.md` with a new §3 (DAST) mirroring the existing SCA (§1) and SAST (§2) sections: identification, a severity-based remediation SLA (ZAP `High` → 30 days, `Medium` → 90 days), the current (non-blocking) enforcement status, and planned follow-up (flipping `fail_action` on and turning on persistent issue-tracking once a first triage baseline exists).

### Documentation

Adds `[dynamic_analysis]`, `[dynamic_analysis_enable_assertions]`, and `[dynamic_analysis_fixed]` sections to `docs/BEST_PRACTICES.md`, following the existing format used for other OpenSSF Best Practices Badge criteria in that file.

## Type of change

- [x] Documentation update
- [x] New feature (non-breaking change which adds functionality — new CI workflow, no application code touched)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (`docs/BEST_PRACTICES.md`, `docs/VULNERABILITY_MANAGEMENT.md`)
- [ ] New and existing unit tests pass locally with my changes — no test suite changes; this PR only adds a CI workflow and docs, verified via `prettier --check` and YAML parsing locally (no Docker available in the dev sandbox to run the ZAP scan itself; the workflow only triggers on push to `main`/`release/*` or manual dispatch, so it will get its first real run once this merges)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated dynamic security scanning for production builds using OWASP ZAP (DAST baseline).
  * Runs on pushes to `main`/`release/*`, weekly, and via manual trigger; starts the built app, waits for health, generates and uploads a ZAP baseline report artifact.

* **Documentation**
  * Updated OpenSSF Best Practices evidence for the DAST pipeline (including health checks and non-blocking behavior).
  * Expanded vulnerability management guidance to cover DAST with triage and remediation SLA planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->