### PR TITLE
Parameterize single-header security tests (SonarCloud S6564)

### DIFF
--- a/server/__tests__/security.test.ts
+++ b/server/__tests__/security.test.ts
@@ -125,30 +125,18 @@ describe("Security Headers", () => {
     expect(csp).toContain("https://images.igdb.com");
   });
 
-  it("should set X-Frame-Options header", async () => {
+  it.each([
+    ["x-frame-options", "SAMEORIGIN"],
+    ["x-content-type-options", "nosniff"],
+    ["x-powered-by", undefined],
+    [
+      "permissions-policy",
+      "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()",
+    ],
+  ])("should set %s header to %j", async (headerName, expectedValue) => {
     const app = await createApp();
     const response = await request(app).get("/api/auth/status");
-    expect(response.headers["x-frame-options"]).toBe("SAMEORIGIN");
-  });
-
-  it("should set X-Content-Type-Options header", async () => {
-    const app = await createApp();
-    const response = await request(app).get("/api/auth/status");
-    expect(response.headers["x-content-type-options"]).toBe("nosniff");
-  });
-
-  it("should hide X-Powered-By header", async () => {
-    const app = await createApp();
-    const response = await request(app).get("/api/auth/status");
-    expect(response.headers["x-powered-by"]).toBeUndefined();
-  });
-
-  it("should set a restrictive Permissions-Policy header", async () => {
-    const app = await createApp();
-    const response = await request(app).get("/api/auth/status");
-    expect(response.headers["permissions-policy"]).toBe(
-      "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()"
-    );
+    expect(response.headers[headerName]).toBe(expectedValue);
   });
 });
 


### PR DESCRIPTION
## Description

Addresses a SonarCloud finding (rule S6564, "Similar tests should be grouped in a single Parameterized test") flagged on `server/__tests__/security.test.ts`.

Four tests in the `Security Headers` describe block followed the exact same shape — boot the app, make one request to `/api/auth/status`, assert one response header:

- `should set X-Frame-Options header`
- `should set X-Content-Type-Options header`
- `should hide X-Powered-By header`
- `should set a restrictive Permissions-Policy header`

Replaced with a single `it.each` test over `[headerName, expectedValue]` pairs. Each case still runs and reports as its own test (`should set x-frame-options header to "SAMEORIGIN"`, etc.), so failures are just as diagnosable as before — this is a pure structural dedup, not a coverage reduction.

## Type of change

- [x] Documentation update — n/a
- [x] Bug fix / refactor (non-breaking change, test-only)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes — full `npx vitest run` (1990 tests) passes; the 4 merged assertions now run as 4 `it.each` cases under one `it()`, confirmed individually via `--reporter=verbose`


---
_Generated by [Claude Code](https://claude.ai/code/session_01TQzEV9dQXnhRhRfoeLdUSa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated security-header checks into a single parameterized test.
  * Continued validating frame protection, content-type enforcement, server information exposure, and permissions policy headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->