### PR TITLE
🎨 Palette: Replace native title tooltips with UI tooltips in NotificationCenter

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,6 +12,7 @@
 
 **Learning:** When adding context-rich ARIA labels to parent interactive elements (like a button or anchor tag), the ARIA label completely overrides the text content of its children for screen readers. However, marking all children (including visual text) as hidden from ARIA is an anti-pattern that can cause some screen readers to treat the element as empty or skip it.
 **Action:** When adding an ARIA label to a parent interactive element, only mark purely decorative elements (like icons) as hidden. Do not apply aria-hidden to visual text spans inside the interactive element.
+
 ## 2026-07-15 - UI Tooltips over Native Titles
 
 **Learning:** Native `title` attributes on icon-only buttons suffer from unpredictable delay and poor visual integration compared to UI tooltips.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 
 **Learning:** When adding context-rich ARIA labels to parent interactive elements (like a button or anchor tag), the ARIA label completely overrides the text content of its children for screen readers. However, marking all children (including visual text) as hidden from ARIA is an anti-pattern that can cause some screen readers to treat the element as empty or skip it.
 **Action:** When adding an ARIA label to a parent interactive element, only mark purely decorative elements (like icons) as hidden. Do not apply aria-hidden to visual text spans inside the interactive element.
+## 2026-07-15 - UI Tooltips over Native Titles
+
+**Learning:** Native `title` attributes on icon-only buttons suffer from unpredictable delay and poor visual integration compared to UI tooltips.
+**Action:** Replace native `title` tooltips with custom UI tooltips (e.g., using `@/components/ui/tooltip`) for a more responsive and consistent user experience, being careful to retain `aria-label` for screen reader accessibility.

--- a/client/src/components/NotificationCenter.tsx
+++ b/client/src/components/NotificationCenter.tsx
@@ -4,6 +4,7 @@ import { Bell, CheckCheck, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { NotificationItem } from "./NotificationItem";
 import { Notification, Game } from "@shared/schema";
 import { apiRequest } from "@/lib/queryClient";
@@ -164,28 +165,40 @@ export function NotificationCenter() {
           <div className="flex items-center justify-between p-4 border-b">
             <h4 className="font-semibold leading-none">Notifications</h4>
             <div className="flex gap-1">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                title="Mark all as read"
-                aria-label="Mark all notifications as read"
-                onClick={() => markAllAsReadMutation.mutate()}
-                disabled={unreadCount === 0}
-              >
-                <CheckCheck className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-destructive hover:text-destructive"
-                title="Clear all"
-                aria-label="Clear all notifications"
-                onClick={() => clearAllMutation.mutate()}
-                disabled={notifications.length === 0}
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    aria-label="Mark all notifications as read"
+                    onClick={() => markAllAsReadMutation.mutate()}
+                    disabled={unreadCount === 0}
+                  >
+                    <CheckCheck className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Mark all as read</p>
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-destructive hover:text-destructive"
+                    aria-label="Clear all notifications"
+                    onClick={() => clearAllMutation.mutate()}
+                    disabled={notifications.length === 0}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Clear all</p>
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
           <ScrollArea className="h-[600px]">

--- a/client/src/components/NotificationCenter.tsx
+++ b/client/src/components/NotificationCenter.tsx
@@ -167,16 +167,18 @@ export function NotificationCenter() {
             <div className="flex gap-1">
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8"
-                    aria-label="Mark all notifications as read"
-                    onClick={() => markAllAsReadMutation.mutate()}
-                    disabled={unreadCount === 0}
-                  >
-                    <CheckCheck className="h-4 w-4" />
-                  </Button>
+                  <span className="inline-block" tabIndex={unreadCount === 0 ? 0 : undefined}>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8"
+                      aria-label="Mark all notifications as read"
+                      onClick={() => markAllAsReadMutation.mutate()}
+                      disabled={unreadCount === 0}
+                    >
+                      <CheckCheck className="h-4 w-4" />
+                    </Button>
+                  </span>
                 </TooltipTrigger>
                 <TooltipContent>
                   <p>Mark all as read</p>
@@ -184,16 +186,21 @@ export function NotificationCenter() {
               </Tooltip>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 text-destructive hover:text-destructive"
-                    aria-label="Clear all notifications"
-                    onClick={() => clearAllMutation.mutate()}
-                    disabled={notifications.length === 0}
+                  <span
+                    className="inline-block"
+                    tabIndex={notifications.length === 0 ? 0 : undefined}
                   >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-destructive hover:text-destructive"
+                      aria-label="Clear all notifications"
+                      onClick={() => clearAllMutation.mutate()}
+                      disabled={notifications.length === 0}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </span>
                 </TooltipTrigger>
                 <TooltipContent>
                   <p>Clear all</p>


### PR DESCRIPTION
### 💡 What
Replaced the native HTML `title` attributes on the "Mark all as read" and "Clear all" buttons within `NotificationCenter` with custom UI tooltips using Shadcn UI's Tooltip component.

### 🎯 Why
Native `title` tooltips rely on the operating system and browser to render, causing them to have unpredictable delays, inconsistent styles, and generally poor visual integration with the rest of the application. Custom UI tooltips trigger reliably, look consistent with the design system, and provide a snappier user experience.

### 📸 Before/After
*(Visual changes verified via screenshot/video demonstrating the instant hover states over the notification center buttons).*

### ♿ Accessibility
The `aria-label` attribute was retained on both icon-only buttons to ensure they remain fully accessible to screen readers, while the visual tooltip is handled by the new UI components.

---
*PR created automatically by Jules for task [6837506020631397224](https://jules.google.com/task/6837506020631397224) started by @Doezer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility & Usability**
  * Replaced native hover titles on notification action buttons with clearer in-app tooltips.
  * Added descriptive tooltips for “Mark all as read” and “Clear all” actions.
  * Preserved accessibility labels and existing button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->