### PR TITLE
Add carousel navigation to the screenshot lightbox

### DIFF
--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -67,6 +67,12 @@ vi.mock("lucide-react", () => ({
   Info: (props: Record<string, unknown>) => <div data-testid="icon-info" {...props} />,
   Image: (props: Record<string, unknown>) => <div data-testid="icon-image" {...props} />,
   Link: (props: Record<string, unknown>) => <div data-testid="icon-link" {...props} />,
+  ChevronLeft: (props: Record<string, unknown>) => (
+    <div data-testid="icon-chevron-left" {...props} />
+  ),
+  ChevronRight: (props: Record<string, unknown>) => (
+    <div data-testid="icon-chevron-right" {...props} />
+  ),
 }));
 
 vi.mock("react-icons/fa", () => ({
@@ -187,6 +193,52 @@ describe("GameDetailsModal", () => {
     // Media tab uses forceMount so screenshots are always in the DOM (hidden until tab activated)
     expect(screen.getByTestId("screenshot-0")).toBeInTheDocument();
     expect(screen.getByTestId("screenshot-1")).toBeInTheDocument();
+  });
+
+  it("opens the screenshot lightbox and navigates with the carousel controls", async () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByTestId("screenshot-0"));
+
+    const lightboxImage = await screen.findByTestId("screenshot-lightbox");
+    expect(lightboxImage).toHaveAttribute("src", "http://test.com/screen1.jpg");
+    expect(screen.getByTestId("screenshot-lightbox-counter")).toHaveTextContent("1 / 2");
+
+    fireEvent.click(screen.getByTestId("screenshot-lightbox-next"));
+    await waitFor(() => {
+      expect(screen.getByTestId("screenshot-lightbox")).toHaveAttribute(
+        "src",
+        "http://test.com/screen2.jpg"
+      );
+    });
+    expect(screen.getByTestId("screenshot-lightbox-counter")).toHaveTextContent("2 / 2");
+
+    // Wraps around back to the first screenshot.
+    fireEvent.click(screen.getByTestId("screenshot-lightbox-next"));
+    await waitFor(() => {
+      expect(screen.getByTestId("screenshot-lightbox")).toHaveAttribute(
+        "src",
+        "http://test.com/screen1.jpg"
+      );
+    });
+
+    // Previous wraps back to the last screenshot.
+    fireEvent.click(screen.getByTestId("screenshot-lightbox-prev"));
+    await waitFor(() => {
+      expect(screen.getByTestId("screenshot-lightbox")).toHaveAttribute(
+        "src",
+        "http://test.com/screen2.jpg"
+      );
+    });
+
+    // Arrow keys also navigate the carousel.
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    await waitFor(() => {
+      expect(screen.getByTestId("screenshot-lightbox")).toHaveAttribute(
+        "src",
+        "http://test.com/screen1.jpg"
+      );
+    });
   });
 
   it("opens download dialog when download button is clicked", async () => {

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -241,6 +241,28 @@ describe("GameDetailsModal", () => {
     });
   });
 
+  it("opens the screenshot lightbox as a fullscreen sheet on mobile", async () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
+
+    try {
+      renderComponent();
+
+      fireEvent.click(screen.getByTestId("screenshot-0"));
+
+      const lightboxImage = await screen.findByTestId("screenshot-lightbox");
+      expect(lightboxImage).toHaveAttribute("src", "http://test.com/screen1.jpg");
+      // The mobile lightbox renders as a fullscreen sheet, not the centered desktop dialog.
+      expect(lightboxImage.closest(".bg-black\\/95")).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    }
+  });
+
   it("opens download dialog when download button is clicked", async () => {
     renderComponent();
     const downloadButton = screen.getByTestId("button-download-game");

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -19,7 +19,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Sheet, SheetContent } from "@/components/ui/sheet";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
@@ -1360,20 +1366,15 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
       )}
 
       {/* Screenshot Lightbox */}
-      {selectedScreenshotIndex !== null && screenshots[selectedScreenshotIndex] && (
-        <Dialog
-          open={selectedScreenshotIndex !== null}
-          onOpenChange={() => setSelectedScreenshotIndex(null)}
-        >
-          <DialogContent className="max-w-4xl">
-            <DialogHeader>
-              <DialogTitle>
-                Screenshot {selectedScreenshotIndex + 1} of {screenshots.length}
-              </DialogTitle>
-              <DialogDescription className="sr-only">Full size game screenshot</DialogDescription>
-            </DialogHeader>
+      {selectedScreenshotIndex !== null &&
+        screenshots[selectedScreenshotIndex] &&
+        (() => {
+          const lightboxImage = (
             <div
-              className="relative flex justify-center items-center"
+              className={cn(
+                "relative flex justify-center items-center",
+                isMobile && "flex-1 min-h-0"
+              )}
               onTouchStart={handleScreenshotTouchStart}
               onTouchEnd={handleScreenshotTouchEnd}
               onTouchCancel={handleScreenshotTouchCancel}
@@ -1394,7 +1395,10 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
               <img
                 src={screenshots[selectedScreenshotIndex]}
                 alt={`${game.title} screenshot ${selectedScreenshotIndex + 1}`}
-                className="max-w-full max-h-[70vh] object-contain rounded-lg select-none"
+                className={cn(
+                  "max-w-full object-contain rounded-lg select-none",
+                  isMobile ? "max-h-full" : "max-h-[70vh]"
+                )}
                 data-testid="screenshot-lightbox"
                 draggable={false}
               />
@@ -1412,19 +1416,58 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                 </Button>
               )}
             </div>
-            {screenshots.length > 1 && (
-              <p
-                className="text-center text-sm text-muted-foreground"
-                data-testid="screenshot-lightbox-counter"
-                aria-live="polite"
-                role="status"
+          );
+
+          const lightboxCounter = screenshots.length > 1 && (
+            <p
+              className="text-center text-sm text-muted-foreground flex-shrink-0"
+              data-testid="screenshot-lightbox-counter"
+              aria-live="polite"
+              role="status"
+            >
+              {selectedScreenshotIndex + 1} / {screenshots.length}
+            </p>
+          );
+
+          return isMobile ? (
+            <Sheet
+              open={selectedScreenshotIndex !== null}
+              onOpenChange={() => setSelectedScreenshotIndex(null)}
+            >
+              <SheetContent
+                side="fullscreen"
+                className="flex flex-col gap-4 bg-black/95 pb-[max(1.5rem,env(safe-area-inset-bottom))]"
               >
-                {selectedScreenshotIndex + 1} / {screenshots.length}
-              </p>
-            )}
-          </DialogContent>
-        </Dialog>
-      )}
+                <SheetHeader>
+                  <SheetTitle>
+                    Screenshot {selectedScreenshotIndex + 1} of {screenshots.length}
+                  </SheetTitle>
+                  <SheetDescription className="sr-only">Full size game screenshot</SheetDescription>
+                </SheetHeader>
+                {lightboxImage}
+                {lightboxCounter}
+              </SheetContent>
+            </Sheet>
+          ) : (
+            <Dialog
+              open={selectedScreenshotIndex !== null}
+              onOpenChange={() => setSelectedScreenshotIndex(null)}
+            >
+              <DialogContent className="max-w-4xl">
+                <DialogHeader>
+                  <DialogTitle>
+                    Screenshot {selectedScreenshotIndex + 1} of {screenshots.length}
+                  </DialogTitle>
+                  <DialogDescription className="sr-only">
+                    Full size game screenshot
+                  </DialogDescription>
+                </DialogHeader>
+                {lightboxImage}
+                {lightboxCounter}
+              </DialogContent>
+            </Dialog>
+          );
+        })()}
 
       {downloadOpen && (
         <Suspense fallback={null}>

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -365,9 +365,12 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
 
   useEffect(() => {
     setIsSummaryExpanded(false);
-    setSelectedScreenshotIndex(null);
     setNotesValue(game?.notes ?? "");
   }, [game?.id, game?.notes]);
+
+  useEffect(() => {
+    setSelectedScreenshotIndex(null);
+  }, [game?.id]);
 
   const screenshots = game?.screenshots ?? [];
 
@@ -408,19 +411,26 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [isLightboxOpen, showPreviousScreenshot, showNextScreenshot]);
 
-  const touchStartX = useRef<number | null>(null);
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
 
   const handleScreenshotTouchStart = (e: React.TouchEvent) => {
-    touchStartX.current = e.touches[0].clientX;
+    const touch = e.touches[0];
+    touchStart.current = touch ? { x: touch.clientX, y: touch.clientY } : null;
+  };
+
+  const handleScreenshotTouchCancel = () => {
+    touchStart.current = null;
   };
 
   const handleScreenshotTouchEnd = (e: React.TouchEvent) => {
-    if (touchStartX.current === null) return;
+    if (touchStart.current === null) return;
     const touch = e.changedTouches[0];
     if (!touch) return;
-    const deltaX = touch.clientX - touchStartX.current;
-    touchStartX.current = null;
+    const deltaX = touch.clientX - touchStart.current.x;
+    const deltaY = touch.clientY - touchStart.current.y;
+    touchStart.current = null;
     const SWIPE_THRESHOLD = 50;
+    if (Math.abs(deltaX) <= Math.abs(deltaY)) return;
     if (deltaX > SWIPE_THRESHOLD) {
       showPreviousScreenshot();
     } else if (deltaX < -SWIPE_THRESHOLD) {
@@ -1079,13 +1089,11 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                       onClick={() => setSelectedScreenshotIndex(index)}
                       data-testid={`screenshot-${index}`}
                     >
-                      <CardContent className="p-0">
-                        <img
-                          src={screenshot}
-                          alt={`${game.title} screenshot ${index + 1}`}
-                          className="w-full h-24 object-cover"
-                        />
-                      </CardContent>
+                      <img
+                        src={screenshot}
+                        alt={`${game.title} screenshot ${index + 1}`}
+                        className="w-full h-24 object-cover"
+                      />
                     </button>
                   ))}
                 </div>
@@ -1368,6 +1376,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
               className="relative flex justify-center items-center"
               onTouchStart={handleScreenshotTouchStart}
               onTouchEnd={handleScreenshotTouchEnd}
+              onTouchCancel={handleScreenshotTouchCancel}
             >
               {screenshots.length > 1 && (
                 <Button
@@ -1407,6 +1416,8 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
               <p
                 className="text-center text-sm text-muted-foreground"
                 data-testid="screenshot-lightbox-counter"
+                aria-live="polite"
+                role="status"
               >
                 {selectedScreenshotIndex + 1} / {screenshots.length}
               </p>

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -371,17 +371,21 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
   const screenshots = game?.screenshots ?? [];
 
   const showPreviousScreenshot = React.useCallback(() => {
+    if (screenshots.length === 0) return;
     setSelectedScreenshotIndex((prev) =>
       prev === null ? prev : (prev - 1 + screenshots.length) % screenshots.length
     );
   }, [screenshots.length]);
 
   const showNextScreenshot = React.useCallback(() => {
+    if (screenshots.length === 0) return;
     setSelectedScreenshotIndex((prev) => (prev === null ? prev : (prev + 1) % screenshots.length));
   }, [screenshots.length]);
 
+  const isLightboxOpen = selectedScreenshotIndex !== null;
+
   useEffect(() => {
-    if (selectedScreenshotIndex === null) return;
+    if (!isLightboxOpen) return;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "ArrowLeft") {
         e.preventDefault();
@@ -393,7 +397,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedScreenshotIndex, showPreviousScreenshot, showNextScreenshot]);
+  }, [isLightboxOpen, showPreviousScreenshot, showNextScreenshot]);
 
   const touchStartX = useRef<number | null>(null);
 
@@ -403,7 +407,9 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
 
   const handleScreenshotTouchEnd = (e: React.TouchEvent) => {
     if (touchStartX.current === null) return;
-    const deltaX = e.changedTouches[0].clientX - touchStartX.current;
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+    const deltaX = touch.clientX - touchStartX.current;
     touchStartX.current = null;
     const SWIPE_THRESHOLD = 50;
     if (deltaX > SWIPE_THRESHOLD) {

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -365,10 +365,19 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
 
   useEffect(() => {
     setIsSummaryExpanded(false);
+    setSelectedScreenshotIndex(null);
     setNotesValue(game?.notes ?? "");
   }, [game?.id, game?.notes]);
 
   const screenshots = game?.screenshots ?? [];
+
+  // Clear the selection if it falls outside the current screenshots list
+  // (e.g. the list shrinks while the lightbox is open).
+  useEffect(() => {
+    setSelectedScreenshotIndex((index) =>
+      index !== null && (index < 0 || index >= screenshots.length) ? null : index
+    );
+  }, [screenshots.length]);
 
   const showPreviousScreenshot = React.useCallback(() => {
     if (screenshots.length === 0) return;

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, lazy, Suspense } from "react";
+import React, { useState, useEffect, useRef, lazy, Suspense } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   AlertDialog,
@@ -55,6 +55,8 @@ import {
   Info,
   Image,
   Link,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
 import { FaSteam, FaRedditAlien, FaDiscord, FaWikipediaW, FaTwitch } from "react-icons/fa";
 import {
@@ -342,7 +344,7 @@ function StarRatingInput({
 
 export default function GameDetailsModal({ game, open, onOpenChange }: GameDetailsModalProps) {
   const isMobile = useIsMobile();
-  const [selectedScreenshot, setSelectedScreenshot] = useState<string | null>(null);
+  const [selectedScreenshotIndex, setSelectedScreenshotIndex] = useState<number | null>(null);
   const [downloadOpen, setDownloadOpen] = useState(false);
   const [isSummaryExpanded, setIsSummaryExpanded] = useState(false);
   const [notesValue, setNotesValue] = useState<string>("");
@@ -356,7 +358,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
   useEffect(() => {
     if (!open) {
       setIsSummaryExpanded(false);
-      setSelectedScreenshot(null);
+      setSelectedScreenshotIndex(null);
       setDownloadOpen(false);
     }
   }, [open]);
@@ -365,6 +367,51 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
     setIsSummaryExpanded(false);
     setNotesValue(game?.notes ?? "");
   }, [game?.id, game?.notes]);
+
+  const screenshots = game?.screenshots ?? [];
+
+  const showPreviousScreenshot = React.useCallback(() => {
+    setSelectedScreenshotIndex((prev) =>
+      prev === null ? prev : (prev - 1 + screenshots.length) % screenshots.length
+    );
+  }, [screenshots.length]);
+
+  const showNextScreenshot = React.useCallback(() => {
+    setSelectedScreenshotIndex((prev) => (prev === null ? prev : (prev + 1) % screenshots.length));
+  }, [screenshots.length]);
+
+  useEffect(() => {
+    if (selectedScreenshotIndex === null) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        showPreviousScreenshot();
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        showNextScreenshot();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectedScreenshotIndex, showPreviousScreenshot, showNextScreenshot]);
+
+  const touchStartX = useRef<number | null>(null);
+
+  const handleScreenshotTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+
+  const handleScreenshotTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const deltaX = e.changedTouches[0].clientX - touchStartX.current;
+    touchStartX.current = null;
+    const SWIPE_THRESHOLD = 50;
+    if (deltaX > SWIPE_THRESHOLD) {
+      showPreviousScreenshot();
+    } else if (deltaX < -SWIPE_THRESHOLD) {
+      showNextScreenshot();
+    }
+  };
 
   // GDM-2: Subscribe to socket download updates and invalidate the downloads query.
   // The shared socket connection stays alive app-wide, so only register/unregister handlers here.
@@ -1012,7 +1059,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                     <Card
                       key={index}
                       className="overflow-hidden cursor-pointer hover-elevate"
-                      onClick={() => setSelectedScreenshot(screenshot)}
+                      onClick={() => setSelectedScreenshotIndex(index)}
                       data-testid={`screenshot-${index}`}
                     >
                       <CardContent className="p-0">
@@ -1288,21 +1335,65 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
       )}
 
       {/* Screenshot Lightbox */}
-      {selectedScreenshot && (
-        <Dialog open={!!selectedScreenshot} onOpenChange={() => setSelectedScreenshot(null)}>
+      {selectedScreenshotIndex !== null && screenshots[selectedScreenshotIndex] && (
+        <Dialog
+          open={selectedScreenshotIndex !== null}
+          onOpenChange={() => setSelectedScreenshotIndex(null)}
+        >
           <DialogContent className="max-w-4xl">
             <DialogHeader>
-              <DialogTitle>Screenshot</DialogTitle>
+              <DialogTitle>
+                Screenshot {selectedScreenshotIndex + 1} of {screenshots.length}
+              </DialogTitle>
               <DialogDescription className="sr-only">Full size game screenshot</DialogDescription>
             </DialogHeader>
-            <div className="flex justify-center">
+            <div
+              className="relative flex justify-center items-center"
+              onTouchStart={handleScreenshotTouchStart}
+              onTouchEnd={handleScreenshotTouchEnd}
+            >
+              {screenshots.length > 1 && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="icon"
+                  className="absolute left-1 sm:left-2 top-1/2 -translate-y-1/2 z-10 h-11 w-11 rounded-full shadow-lg"
+                  onClick={showPreviousScreenshot}
+                  aria-label="Previous screenshot"
+                  data-testid="screenshot-lightbox-prev"
+                >
+                  <ChevronLeft className="w-5 h-5" />
+                </Button>
+              )}
               <img
-                src={selectedScreenshot}
-                alt={`${game.title} screenshot`}
-                className="max-w-full max-h-[70vh] object-contain rounded-lg"
+                src={screenshots[selectedScreenshotIndex]}
+                alt={`${game.title} screenshot ${selectedScreenshotIndex + 1}`}
+                className="max-w-full max-h-[70vh] object-contain rounded-lg select-none"
                 data-testid="screenshot-lightbox"
+                draggable={false}
               />
+              {screenshots.length > 1 && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="icon"
+                  className="absolute right-1 sm:right-2 top-1/2 -translate-y-1/2 z-10 h-11 w-11 rounded-full shadow-lg"
+                  onClick={showNextScreenshot}
+                  aria-label="Next screenshot"
+                  data-testid="screenshot-lightbox-next"
+                >
+                  <ChevronRight className="w-5 h-5" />
+                </Button>
+              )}
             </div>
+            {screenshots.length > 1 && (
+              <p
+                className="text-center text-sm text-muted-foreground"
+                data-testid="screenshot-lightbox-counter"
+              >
+                {selectedScreenshotIndex + 1} / {screenshots.length}
+              </p>
+            )}
           </DialogContent>
         </Dialog>
       )}

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -1071,9 +1071,11 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
               {game.screenshots && game.screenshots.length > 0 ? (
                 <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
                   {game.screenshots.map((screenshot, index) => (
-                    <Card
+                    <button
                       key={index}
-                      className="overflow-hidden cursor-pointer hover-elevate"
+                      type="button"
+                      aria-label={`Open screenshot ${index + 1}`}
+                      className="shadcn-card overflow-hidden cursor-pointer hover-elevate rounded-xl border bg-card border-card-border text-card-foreground shadow-sm"
                       onClick={() => setSelectedScreenshotIndex(index)}
                       data-testid={`screenshot-${index}`}
                     >
@@ -1084,7 +1086,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
                           className="w-full h-24 object-cover"
                         />
                       </CardContent>
-                    </Card>
+                    </button>
                   ))}
                 </div>
               ) : (


### PR DESCRIPTION
## Summary
- The screenshot lightbox in the game details "Media" tab now tracks the selected screenshot by index instead of URL, enabling carousel navigation
- Added left/right chevron buttons (44px touch targets) overlaid on the lightbox image to step between screenshots, wrapping around at the ends
- Added left/right arrow key navigation while the lightbox is open
- Added touch swipe navigation for mobile
- Added an image counter ("2 / 8") below the lightbox image when there's more than one screenshot

## Test plan
- [x] `npm run check` (TypeScript)
- [x] `npx eslint` on changed files
- [x] `npx prettier --check` on changed files
- [x] `npx vitest run client/__tests__/GameDetailsModal.test.tsx` (33 passed, including new carousel navigation tests covering click-to-open, next/prev buttons with wraparound, and arrow-key navigation)


---
_Generated by [Claude Code](https://claude.ai/code/session_019LsehfpmQYULRNZeSTHWxt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the screenshot lightbox to browse multiple images with previous/next navigation, including wrap-around.
  * Added ArrowLeft/ArrowRight keyboard navigation and touch-swipe gesture support.
  * Updated the lightbox UI to display “Screenshot X of Y” and enable chevrons only when multiple screenshots are available.
* **Bug Fixes**
  * Improved lightbox state handling by clearing selection when the modal closes, the game changes, or the screenshot list updates.
* **Tests**
  * Added/expanded tests to validate lightbox navigation, wrap-around behavior, and keyboard interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->