### PR TITLE
Add optional auto Steam wishlist sync with configurable interval

### DIFF
--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -170,6 +170,8 @@ export default function SettingsPage() {
 
   // Local state for Steam form
   const [steamIdInput, setSteamIdInput] = useState("");
+  const [steamSyncEnabled, setSteamSyncEnabled] = useState(false);
+  const [steamSyncIntervalHours, setSteamSyncIntervalHours] = useState(24);
 
   // Local state for forms
   const [igdbClientId, setIgdbClientId] = useState("");
@@ -228,6 +230,8 @@ export default function SettingsPage() {
       setPreferredPlatform(userSettings.preferredPlatform ?? "");
       setXrelSceneReleases(userSettings.xrelSceneReleases ?? true);
       setXrelP2pReleases(userSettings.xrelP2pReleases ?? false);
+      setSteamSyncEnabled(userSettings.steamSyncEnabled ?? false);
+      setSteamSyncIntervalHours(userSettings.steamSyncIntervalHours ?? 24);
     }
     if (config?.xrel?.apiBase !== undefined) {
       setXrelApiBase(config.xrel.apiBase);
@@ -768,6 +772,16 @@ export default function SettingsPage() {
     updateSteamIdMutation.mutate(steamIdInput);
   };
 
+  const handleSaveSteamSync = () => {
+    updateSettingsMutation.mutate({
+      updates: {
+        steamSyncEnabled,
+        steamSyncIntervalHours,
+      },
+      successMessage: "Your Steam Wishlist auto-sync preferences have been saved.",
+    });
+  };
+
   if (isLoading) {
     return (
       <div className="p-6">
@@ -1260,6 +1274,62 @@ export default function SettingsPage() {
                         steamid.io
                       </a>
                     </p>
+                  </div>
+
+                  <div className="flex items-center justify-between pt-4 border-t">
+                    <div className="space-y-0.5">
+                      <Label htmlFor="steam-sync-enabled" className="text-sm font-medium">
+                        Auto-Sync Wishlist
+                      </Label>
+                      <p className="text-xs text-muted-foreground">
+                        Periodically import new games from your Steam Wishlist
+                      </p>
+                    </div>
+                    <Switch
+                      id="steam-sync-enabled"
+                      checked={steamSyncEnabled}
+                      onCheckedChange={setSteamSyncEnabled}
+                    />
+                  </div>
+
+                  {steamSyncEnabled && (
+                    <div className="space-y-2 pl-4 border-l-2">
+                      <Label htmlFor="steam-sync-interval" className="text-sm font-medium">
+                        Sync Interval (hours)
+                      </Label>
+                      <Input
+                        id="steam-sync-interval"
+                        type="number"
+                        min="1"
+                        max="168"
+                        value={steamSyncIntervalHours}
+                        onChange={(e) => setSteamSyncIntervalHours(parseInt(e.target.value) || 24)}
+                        className="w-32"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        How often to check your Steam Wishlist for new games (1-168 hours)
+                      </p>
+                    </div>
+                  )}
+
+                  <div className="flex justify-end pt-2 border-t">
+                    <Button
+                      onClick={handleSaveSteamSync}
+                      disabled={updateSettingsMutation.isPending}
+                      className="gap-2"
+                    >
+                      {updateSettingsMutation.isPending ? (
+                        <>
+                          <RefreshCw className="h-4 w-4 animate-spin" />
+                          Saving...
+                        </>
+                      ) : (
+                        <>
+                          <RefreshCw className="h-4 w-4" />
+                          Save Sync Settings
+                        </>
+                      )}
+                    </Button>
                   </div>
                 </div>
               </CardContent>

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1303,7 +1303,11 @@ export default function SettingsPage() {
                         min="1"
                         max="168"
                         value={steamSyncIntervalHours}
-                        onChange={(e) => setSteamSyncIntervalHours(parseInt(e.target.value) || 24)}
+                        onChange={(e) =>
+                          setSteamSyncIntervalHours(
+                            Math.min(168, Math.max(1, parseInt(e.target.value) || 24))
+                          )
+                        }
                         className="w-32"
                       />
                       <p className="text-xs text-muted-foreground">

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -167,6 +167,7 @@ export default function SettingsPage() {
   const [appriseKey, setAppriseKey] = useState("");
   const [appriseUrls, setAppriseUrls] = useState("");
   const appriseLoadedRef = useRef(false);
+  const settingsLoadedRef = useRef(false);
 
   // Local state for Steam form
   const [steamIdInput, setSteamIdInput] = useState("");
@@ -189,9 +190,11 @@ export default function SettingsPage() {
   const [nexusApiKey, setNexusApiKey] = useState("");
   const [showNexusApiKey, setShowNexusApiKey] = useState(false);
 
-  // Sync with fetched settings
+  // Sync with fetched settings. Guarded by settingsLoadedRef so a background
+  // refetch (e.g. after saving one section) doesn't clobber unsaved edits the
+  // user has made in another section of this form.
   useEffect(() => {
-    if (userSettings) {
+    if (userSettings && !settingsLoadedRef.current) {
       setAutoSearchEnabled(userSettings.autoSearchEnabled);
       setAutoSearchUnreleased(userSettings.autoSearchUnreleased ?? false);
       setAutoDownloadEnabled(userSettings.autoDownloadEnabled);
@@ -232,6 +235,7 @@ export default function SettingsPage() {
       setXrelP2pReleases(userSettings.xrelP2pReleases ?? false);
       setSteamSyncEnabled(userSettings.steamSyncEnabled ?? false);
       setSteamSyncIntervalHours(userSettings.steamSyncIntervalHours ?? 24);
+      settingsLoadedRef.current = true;
     }
     if (config?.xrel?.apiBase !== undefined) {
       setXrelApiBase(config.xrel.apiBase);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,8 +181,13 @@ wired up — see `server/cron.ts:534,583`). Two event types are emitted today:
 
 ## 7. Scheduled/background actors (cron jobs)
 
-`server/cron.ts::startCronJobs()` schedules five recurring jobs via
-`setInterval`, each also run once on an initial 10-second delayed startup:
+`server/cron.ts::startCronJobs()` schedules seven recurring `setInterval`
+jobs. The five primary sync/check jobs below also run once on an initial
+10-second delayed startup; `startCronJobs()` additionally runs
+`logClientVersions` (every 12 hours, probes configured indexer/downloader
+client versions for logging) and a daily import-task cleanup (deletes
+`import_tasks` rows older than 30 days), neither of which reads/writes
+domain data covered by this table:
 
 | Job                   | Interval                                                                                  | Upstream read                                                                           | Downstream write                                                                                                 |
 | --------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,21 +181,23 @@ wired up — see `server/cron.ts:534,583`). Two event types are emitted today:
 
 ## 7. Scheduled/background actors (cron jobs)
 
-`server/cron.ts::startCronJobs()` schedules four recurring jobs via
+`server/cron.ts::startCronJobs()` schedules five recurring jobs via
 `setInterval`, each also run once on an initial 10-second delayed startup:
 
-| Job                   | Interval                                                     | Upstream read                                                                           | Downstream write                                                                            |
-| --------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `checkGameUpdates`    | 24 hours                                                     | IGDB (batch fetch by ID)                                                                | `games` table (release date/status), `notifications` table, Socket.io `notification`        |
-| `checkDownloadStatus` | 1 minute                                                     | Configured download clients (via `DownloaderManager`)                                   | `game_downloads`/`games` status, `notifications`, Socket.io `downloadUpdate`/`notification` |
-| `checkAutoSearch`     | 1 hour (per user, gated by their configured search interval) | Torznab/Newznab indexers (via `search.ts`), download clients (if auto-download enabled) | `games` search-results flag, `game_downloads`, `notifications`, Socket.io `notification`    |
-| `checkXrelReleases`   | 6 hours                                                      | xREL.to latest releases                                                                 | `xrel_notified_releases`, `notifications`, Socket.io `notification`                         |
+| Job                   | Interval                                                                                  | Upstream read                                                                           | Downstream write                                                                                                 |
+| --------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `checkGameUpdates`    | 24 hours                                                                                  | IGDB (batch fetch by ID)                                                                | `games` table (release date/status), `notifications` table, Socket.io `notification`                             |
+| `checkDownloadStatus` | 1 minute                                                                                  | Configured download clients (via `DownloaderManager`)                                   | `game_downloads`/`games` status, `notifications`, Socket.io `downloadUpdate`/`notification`                      |
+| `checkAutoSearch`     | 1 hour (per user, gated by their configured search interval)                              | Torznab/Newznab indexers (via `search.ts`), download clients (if auto-download enabled) | `games` search-results flag, `game_downloads`, `notifications`, Socket.io `notification`                         |
+| `checkXrelReleases`   | 6 hours                                                                                   | xREL.to latest releases                                                                 | `xrel_notified_releases`, `notifications`, Socket.io `notification`                                              |
+| `checkSteamWishlist`  | 1 hour (per user, gated by their configured sync interval, opt-in via `steamSyncEnabled`) | Steam Web API wishlist, IGDB (Steam App ID lookup)                                      | `games` table (new/linked entries), `import_tasks`, `notifications`, Socket.io `importTaskUpdate`/`notification` |
 
-Steam wishlist sync (`syncUserSteamWishlist` in `server/cron.ts`) is **not**
-on this schedule — it only runs when a user explicitly triggers it via
-`POST /api/steam/wishlist/sync` (`server/steam-routes.ts:37-56`). A
-`checkSteamWishlist` helper that would loop over all linked users exists in
-`cron.ts` but is not currently wired into `startCronJobs()`.
+Steam wishlist sync (`syncUserSteamWishlist` in `server/cron.ts`) also runs
+on-demand when a user explicitly triggers it via
+`POST /api/steam/wishlist/sync` (`server/steam-routes.ts:37-56`). The
+scheduled path is opt-in per user (`userSettings.steamSyncEnabled`, default
+`false`) with a configurable interval (`userSettings.steamSyncIntervalHours`,
+default 24) tracked via `userSettings.lastSteamSync`.
 
 ## 8. Trust boundaries
 

--- a/migrations/0023_narrow_blade.sql
+++ b/migrations/0023_narrow_blade.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `user_settings` ADD `steam_sync_enabled` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `user_settings` ADD `steam_sync_interval_hours` integer DEFAULT 24 NOT NULL;--> statement-breakpoint
+ALTER TABLE `user_settings` ADD `last_steam_sync` integer;

--- a/migrations/meta/0023_snapshot.json
+++ b/migrations/meta/0023_snapshot.json
@@ -1,0 +1,1599 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "853c5b9d-3c06-411d-9a02-25717dcb0e14",
+  "prevId": "1da4750b-8ea7-4805-b2b2-246beb09feb1",
+  "tables": {
+    "downloaders": {
+      "name": "downloaders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "url_path": {
+          "name": "url_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "download_path": {
+          "name": "download_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'games'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Questarr'"
+        },
+        "add_stopped": {
+          "name": "add_stopped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "remove_completed": {
+          "name": "remove_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "post_import_category": {
+          "name": "post_import_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_downloads": {
+      "name": "game_downloads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "downloader_id": {
+          "name": "downloader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_type": {
+          "name": "download_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torrent'"
+        },
+        "download_hash": {
+          "name": "download_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_title": {
+          "name": "download_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'downloading'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "game_downloads_downloader_hash_idx": {
+          "name": "game_downloads_downloader_hash_idx",
+          "columns": ["downloader_id", "download_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "game_downloads_game_id_games_id_fk": {
+          "name": "game_downloads_game_id_games_id_fk",
+          "tableFrom": "game_downloads",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_downloads_downloader_id_downloaders_id_fk": {
+          "name": "game_downloads_downloader_id_downloaders_id_fk",
+          "tableFrom": "game_downloads",
+          "tableTo": "downloaders",
+          "columnsFrom": ["downloader_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "games": {
+      "name": "games",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steam_appid": {
+          "name": "steam_appid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publishers": {
+          "name": "publishers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "developers": {
+          "name": "developers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "igdb_websites": {
+          "name": "igdb_websites",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "original_release_date": {
+          "name": "original_release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_status": {
+          "name": "release_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'upcoming'"
+        },
+        "early_access": {
+          "name": "early_access",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "user_rating": {
+          "name": "user_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_path": {
+          "name": "library_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_results_available": {
+          "name": "search_results_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_user_id_users_id_fk": {
+          "name": "games_user_id_users_id_fk",
+          "tableFrom": "games",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_task_items": {
+      "name": "import_task_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "game_title": {
+          "name": "game_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "import_task_items_task_id_idx": {
+          "name": "import_task_items_task_id_idx",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "import_task_items_task_id_import_tasks_id_fk": {
+          "name": "import_task_items_task_id_import_tasks_id_fk",
+          "tableFrom": "import_task_items",
+          "tableTo": "import_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_tasks": {
+      "name": "import_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "added_items": {
+          "name": "added_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_items": {
+          "name": "skipped_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_items": {
+          "name": "failed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "import_tasks_user_id_users_id_fk": {
+          "name": "import_tasks_user_id_users_id_fk",
+          "tableFrom": "import_tasks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexers": {
+      "name": "indexers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torznab'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "rss_enabled": {
+          "name": "rss_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_search_enabled": {
+          "name": "auto_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read": {
+          "name": "read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "path_mappings": {
+      "name": "path_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_path": {
+          "name": "remote_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_host": {
+          "name": "remote_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "platform_mappings": {
+      "name": "platform_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "igdb_platform_id": {
+          "name": "igdb_platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_platform_name": {
+          "name": "source_platform_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "release_blacklist": {
+      "name": "release_blacklist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_title": {
+          "name": "release_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexer_name": {
+          "name": "indexer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "release_blacklist_game_title_idx": {
+          "name": "release_blacklist_game_title_idx",
+          "columns": ["game_id", "release_title"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "release_blacklist_game_id_games_id_fk": {
+          "name": "release_blacklist_game_id_games_id_fk",
+          "tableFrom": "release_blacklist",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_feed_items": {
+      "name": "rss_feed_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pub_date": {
+          "name": "pub_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_game_id": {
+          "name": "igdb_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_game_name": {
+          "name": "igdb_game_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rss_feed_items_feed_id_rss_feeds_id_fk": {
+          "name": "rss_feed_items_feed_id_rss_feeds_id_fk",
+          "tableFrom": "rss_feed_items",
+          "tableTo": "rss_feeds",
+          "columnsFrom": ["feed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_feeds": {
+      "name": "rss_feeds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "mapping": {
+          "name": "mapping",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_config": {
+      "name": "system_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auto_search_enabled": {
+          "name": "auto_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_download_enabled": {
+          "name": "auto_download_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_interval_hours": {
+          "name": "search_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 6
+        },
+        "igdb_rate_limit_per_second": {
+          "name": "igdb_rate_limit_per_second",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "download_rules": {
+          "name": "download_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_auto_search": {
+          "name": "last_auto_search",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "xrel_scene_releases": {
+          "name": "xrel_scene_releases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "xrel_p2p_releases": {
+          "name": "xrel_p2p_releases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_search_unreleased": {
+          "name": "auto_search_unreleased",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "steam_sync_failures": {
+          "name": "steam_sync_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "steam_sync_enabled": {
+          "name": "steam_sync_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "steam_sync_interval_hours": {
+          "name": "steam_sync_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "last_steam_sync": {
+          "name": "last_steam_sync",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_release_groups": {
+          "name": "preferred_release_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filter_by_preferred_groups": {
+          "name": "filter_by_preferred_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preferred_platform": {
+          "name": "preferred_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enable_post_processing": {
+          "name": "enable_post_processing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_unpack": {
+          "name": "auto_unpack",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rename_pattern": {
+          "name": "rename_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{Title} ({Region})'"
+        },
+        "overwrite_existing": {
+          "name": "overwrite_existing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "transfer_mode": {
+          "name": "transfer_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'hardlink'"
+        },
+        "import_platform_ids": {
+          "name": "import_platform_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "ignored_extensions": {
+          "name": "ignored_extensions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "min_file_size": {
+          "name": "min_file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "library_root": {
+          "name": "library_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'/data'"
+        },
+        "auto_delete_after_import": {
+          "name": "auto_delete_after_import",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "steam_id_64": {
+          "name": "steam_id_64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "xrel_notified_releases": {
+      "name": "xrel_notified_releases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "xrel_release_id": {
+          "name": "xrel_release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "xrel_notified_releases_game_id_games_id_fk": {
+          "name": "xrel_notified_releases_game_id_games_id_fk",
+          "tableFrom": "xrel_notified_releases",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1783945140680,
       "tag": "0022_plain_wild_child",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1784395451947,
+      "tag": "0023_narrow_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/server/__tests__/steam_wishlist.test.ts
+++ b/server/__tests__/steam_wishlist.test.ts
@@ -509,9 +509,20 @@ describe("checkSteamWishlist", () => {
 
     // The second call should return immediately without waiting on getAllUsers.
     await secondRun;
+    expect(storage.getAllUsers).toHaveBeenCalledTimes(1);
     expect(storage.getUserSettings).not.toHaveBeenCalled();
 
     resolveGetAllUsers!([]);
     await firstRun;
+  });
+
+  it("does not throw and clears the in-progress guard when getAllUsers fails", async () => {
+    vi.mocked(storage.getAllUsers).mockRejectedValueOnce(new Error("DB unavailable"));
+
+    await expect(checkSteamWishlist()).resolves.not.toThrow();
+
+    // The in-progress guard must have been cleared, so a subsequent run proceeds normally.
+    vi.mocked(storage.getAllUsers).mockResolvedValueOnce([]);
+    await expect(checkSteamWishlist()).resolves.not.toThrow();
   });
 });

--- a/server/__tests__/steam_wishlist.test.ts
+++ b/server/__tests__/steam_wishlist.test.ts
@@ -519,10 +519,11 @@ describe("checkSteamWishlist", () => {
   it("does not throw and clears the in-progress guard when getAllUsers fails", async () => {
     vi.mocked(storage.getAllUsers).mockRejectedValueOnce(new Error("DB unavailable"));
 
-    await expect(checkSteamWishlist()).resolves.not.toThrow();
+    await expect(checkSteamWishlist()).resolves.toBeUndefined();
 
     // The in-progress guard must have been cleared, so a subsequent run proceeds normally.
     vi.mocked(storage.getAllUsers).mockResolvedValueOnce([]);
-    await expect(checkSteamWishlist()).resolves.not.toThrow();
+    await expect(checkSteamWishlist()).resolves.toBeUndefined();
+    expect(storage.getAllUsers).toHaveBeenCalledTimes(2);
   });
 });

--- a/server/__tests__/steam_wishlist.test.ts
+++ b/server/__tests__/steam_wishlist.test.ts
@@ -395,22 +395,30 @@ describe("checkSteamWishlist", () => {
   });
 
   it("skips users whose sync interval has not elapsed yet", async () => {
-    vi.mocked(storage.getAllUsers).mockResolvedValue([
-      { id: "user-1", steamId64: "76561198000000000" } as unknown as User,
-    ]);
-    vi.mocked(storage.getUserSettings).mockResolvedValue({
-      steamSyncEnabled: true,
-      steamSyncIntervalHours: 24,
-      lastSteamSync: new Date(),
-    } as unknown as UserSettings);
+    const FIXED_NOW = new Date("2023-01-02T00:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
 
-    await checkSteamWishlist();
+    try {
+      vi.mocked(storage.getAllUsers).mockResolvedValue([
+        { id: "user-1", steamId64: "76561198000000000" } as unknown as User,
+      ]);
+      vi.mocked(storage.getUserSettings).mockResolvedValue({
+        steamSyncEnabled: true,
+        steamSyncIntervalHours: 24,
+        lastSteamSync: new Date(FIXED_NOW.getTime() - 60 * 60 * 1000), // synced 1 hour ago
+      } as unknown as UserSettings);
 
-    expect(steamService.getWishlist).not.toHaveBeenCalled();
-    expect(storage.updateUserSettings).not.toHaveBeenCalledWith(
-      "user-1",
-      expect.objectContaining({ lastSteamSync: expect.anything() })
-    );
+      await checkSteamWishlist();
+
+      expect(steamService.getWishlist).not.toHaveBeenCalled();
+      expect(storage.updateUserSettings).not.toHaveBeenCalledWith(
+        "user-1",
+        expect.objectContaining({ lastSteamSync: expect.anything() })
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("syncs and records lastSteamSync when enabled and the interval has elapsed", async () => {
@@ -434,6 +442,30 @@ describe("checkSteamWishlist", () => {
     expect(storage.updateUserSettings).toHaveBeenCalledWith(
       "user-1",
       expect.objectContaining({ lastSteamSync: expect.any(Date) })
+    );
+  });
+
+  it("does not record lastSteamSync when the scheduled sync fails", async () => {
+    vi.mocked(storage.getAllUsers).mockResolvedValue([
+      { id: "user-1", steamId64: "76561198000000000" } as unknown as User,
+    ]);
+    vi.mocked(storage.getUser).mockResolvedValue({
+      id: "user-1",
+      steamId64: "76561198000000000",
+    } as unknown as User);
+    vi.mocked(storage.getUserSettings).mockResolvedValue({
+      steamSyncEnabled: true,
+      steamSyncIntervalHours: 24,
+      lastSteamSync: null,
+      steamSyncFailures: 0,
+    } as unknown as UserSettings);
+    vi.mocked(steamService.getWishlist).mockRejectedValue(new Error("Steam API down"));
+
+    await checkSteamWishlist();
+
+    expect(storage.updateUserSettings).not.toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ lastSteamSync: expect.anything() })
     );
   });
 

--- a/server/__tests__/steam_wishlist.test.ts
+++ b/server/__tests__/steam_wishlist.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { syncUserSteamWishlist } from "../cron.js";
+import { syncUserSteamWishlist, checkSteamWishlist } from "../cron.js";
 import { storage } from "../storage.js";
 import { steamService } from "../steam.js";
 import { igdbClient, type IGDBGame } from "../igdb.js";
@@ -354,5 +354,112 @@ describe("syncUserSteamWishlist", () => {
 
     expect(result?.addedCount).toBe(1);
     expect(storage.addGame).toHaveBeenCalledOnce();
+  });
+});
+
+describe("checkSteamWishlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(storage.createImportTask).mockResolvedValue({ id: "task-id" } as any);
+    vi.mocked(storage.startImportTask).mockResolvedValue(undefined);
+    vi.mocked(storage.updateImportTask).mockResolvedValue(undefined);
+    vi.mocked(storage.addImportTaskItemsBatch).mockResolvedValue([]);
+    vi.mocked(storage.getUserGames).mockResolvedValue([]);
+    vi.mocked(steamService.getWishlist).mockResolvedValue([]);
+  });
+
+  it("skips users without a linked Steam ID", async () => {
+    vi.mocked(storage.getAllUsers).mockResolvedValue([
+      { id: "user-1", steamId64: null } as unknown as User,
+    ]);
+
+    await checkSteamWishlist();
+
+    expect(storage.getUserSettings).not.toHaveBeenCalled();
+    expect(steamService.getWishlist).not.toHaveBeenCalled();
+  });
+
+  it("skips users who have not opted into auto-sync", async () => {
+    vi.mocked(storage.getAllUsers).mockResolvedValue([
+      { id: "user-1", steamId64: "76561198000000000" } as unknown as User,
+    ]);
+    vi.mocked(storage.getUserSettings).mockResolvedValue({
+      steamSyncEnabled: false,
+      steamSyncIntervalHours: 24,
+      lastSteamSync: null,
+    } as unknown as UserSettings);
+
+    await checkSteamWishlist();
+
+    expect(steamService.getWishlist).not.toHaveBeenCalled();
+  });
+
+  it("skips users whose sync interval has not elapsed yet", async () => {
+    vi.mocked(storage.getAllUsers).mockResolvedValue([
+      { id: "user-1", steamId64: "76561198000000000" } as unknown as User,
+    ]);
+    vi.mocked(storage.getUserSettings).mockResolvedValue({
+      steamSyncEnabled: true,
+      steamSyncIntervalHours: 24,
+      lastSteamSync: new Date(),
+    } as unknown as UserSettings);
+
+    await checkSteamWishlist();
+
+    expect(steamService.getWishlist).not.toHaveBeenCalled();
+    expect(storage.updateUserSettings).not.toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ lastSteamSync: expect.anything() })
+    );
+  });
+
+  it("syncs and records lastSteamSync when enabled and the interval has elapsed", async () => {
+    vi.mocked(storage.getAllUsers).mockResolvedValue([
+      { id: "user-1", steamId64: "76561198000000000" } as unknown as User,
+    ]);
+    vi.mocked(storage.getUser).mockResolvedValue({
+      id: "user-1",
+      steamId64: "76561198000000000",
+    } as unknown as User);
+    vi.mocked(storage.getUserSettings).mockResolvedValue({
+      steamSyncEnabled: true,
+      steamSyncIntervalHours: 24,
+      lastSteamSync: null,
+      steamSyncFailures: 0,
+    } as unknown as UserSettings);
+
+    await checkSteamWishlist();
+
+    expect(steamService.getWishlist).toHaveBeenCalledWith("76561198000000000");
+    expect(storage.updateUserSettings).toHaveBeenCalledWith(
+      "user-1",
+      expect.objectContaining({ lastSteamSync: expect.any(Date) })
+    );
+  });
+
+  it("continues checking other users when one user's sync throws", async () => {
+    vi.mocked(storage.getAllUsers).mockResolvedValue([
+      { id: "user-1", steamId64: "76561198000000000" } as unknown as User,
+      { id: "user-2", steamId64: "76561198000000001" } as unknown as User,
+    ]);
+    vi.mocked(storage.getUserSettings).mockImplementation(async (userId: string) => {
+      if (userId === "user-1") {
+        throw new Error("DB error");
+      }
+      return {
+        steamSyncEnabled: true,
+        steamSyncIntervalHours: 24,
+        lastSteamSync: null,
+        steamSyncFailures: 0,
+      } as unknown as UserSettings;
+    });
+    vi.mocked(storage.getUser).mockResolvedValue({
+      id: "user-2",
+      steamId64: "76561198000000001",
+    } as unknown as User);
+
+    await expect(checkSteamWishlist()).resolves.not.toThrow();
+
+    expect(steamService.getWishlist).toHaveBeenCalledWith("76561198000000001");
   });
 });

--- a/server/__tests__/steam_wishlist.test.ts
+++ b/server/__tests__/steam_wishlist.test.ts
@@ -3,7 +3,7 @@ import { syncUserSteamWishlist, checkSteamWishlist } from "../cron.js";
 import { storage } from "../storage.js";
 import { steamService } from "../steam.js";
 import { igdbClient, type IGDBGame } from "../igdb.js";
-import type { Game, User, UserSettings } from "../../shared/schema.js";
+import type { Game, ImportTask, User, UserSettings } from "../../shared/schema.js";
 
 // Mock dependencies
 vi.mock("../storage.js");
@@ -360,7 +360,9 @@ describe("syncUserSteamWishlist", () => {
 describe("checkSteamWishlist", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(storage.createImportTask).mockResolvedValue({ id: "task-id" } as any);
+    vi.mocked(storage.createImportTask).mockResolvedValue({
+      id: "task-id",
+    } as unknown as ImportTask);
     vi.mocked(storage.startImportTask).mockResolvedValue(undefined);
     vi.mocked(storage.updateImportTask).mockResolvedValue(undefined);
     vi.mocked(storage.addImportTaskItemsBatch).mockResolvedValue([]);
@@ -493,5 +495,23 @@ describe("checkSteamWishlist", () => {
     await expect(checkSteamWishlist()).resolves.not.toThrow();
 
     expect(steamService.getWishlist).toHaveBeenCalledWith("76561198000000001");
+  });
+
+  it("skips a run entirely when a previous run is still in progress", async () => {
+    let resolveGetAllUsers: (users: User[]) => void;
+    const getAllUsersPromise = new Promise<User[]>((resolve) => {
+      resolveGetAllUsers = resolve;
+    });
+    vi.mocked(storage.getAllUsers).mockReturnValueOnce(getAllUsersPromise);
+
+    const firstRun = checkSteamWishlist();
+    const secondRun = checkSteamWishlist();
+
+    // The second call should return immediately without waiting on getAllUsers.
+    await secondRun;
+    expect(storage.getUserSettings).not.toHaveBeenCalled();
+
+    resolveGetAllUsers!([]);
+    await firstRun;
   });
 });

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -37,6 +37,7 @@ const DOWNLOAD_CHECK_INTERVAL_MS = 60 * 1000; // 1 minute
 const downloadMissCount = new Map<string, number>();
 const DOWNLOAD_MISS_THRESHOLD = 3;
 const AUTO_SEARCH_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const STEAM_SYNC_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour (per-user interval gates actual sync)
 const XREL_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours (xREL search rate limit: 2/5s)
 const CLIENT_VERSION_LOG_INTERVAL_MS = 12 * 60 * 60 * 1000; // 12 hours
 const OWNED_STATUSES = new Set(["owned", "completed", "downloading"]);
@@ -274,6 +275,7 @@ export function startCronJobs() {
       gameUpdates: `every ${CHECK_INTERVAL_MS / 1000 / 60 / 60} hours`,
       downloadStatus: `every ${DOWNLOAD_CHECK_INTERVAL_MS / 1000} seconds`,
       autoSearch: `every ${AUTO_SEARCH_CHECK_INTERVAL_MS / 1000 / 60} minutes`,
+      steamSync: `every ${STEAM_SYNC_CHECK_INTERVAL_MS / 1000 / 60} minutes (per-user interval gated)`,
     },
     "Cron job intervals configured"
   );
@@ -285,6 +287,7 @@ export function startCronJobs() {
     checkDownloadStatus().catch((err) => igdbLogger.error({ err }, "Error in checkDownloadStatus"));
     checkAutoSearch().catch((err) => igdbLogger.error({ err }, "Error in checkAutoSearch"));
     checkXrelReleases().catch((err) => igdbLogger.error({ err }, "Error in checkXrelReleases"));
+    checkSteamWishlist().catch((err) => igdbLogger.error({ err }, "Error in checkSteamWishlist"));
     logClientVersions().catch((err) => igdbLogger.warn({ err }, "Error in logClientVersions"));
   }, 10000);
 
@@ -304,6 +307,10 @@ export function startCronJobs() {
   setInterval(() => {
     checkXrelReleases().catch((err) => igdbLogger.error({ err }, "Error in checkXrelReleases"));
   }, XREL_CHECK_INTERVAL_MS);
+
+  setInterval(() => {
+    checkSteamWishlist().catch((err) => igdbLogger.error({ err }, "Error in checkSteamWishlist"));
+  }, STEAM_SYNC_CHECK_INTERVAL_MS);
 
   setInterval(() => {
     logClientVersions().catch((err) => igdbLogger.warn({ err }, "Error in logClientVersions"));
@@ -1247,11 +1254,25 @@ export async function checkXrelReleases() {
 }
 
 export async function checkSteamWishlist() {
-  igdbLogger.info("Starting Steam Wishlist check for all users...");
+  igdbLogger.debug("Checking Steam Wishlist auto-sync for all users...");
   const users = await storage.getAllUsers();
   for (const user of users) {
-    if (user.steamId64) {
-      await syncUserSteamWishlist(user.id);
+    if (!user.steamId64) continue;
+
+    try {
+      const settings = await storage.getUserSettings(user.id);
+      if (!settings || !settings.steamSyncEnabled) continue;
+
+      const lastSync = settings.lastSteamSync ? new Date(settings.lastSteamSync).getTime() : 0;
+      const intervalMs = settings.steamSyncIntervalHours * 60 * 60 * 1000;
+
+      if (Date.now() - lastSync < intervalMs) continue;
+
+      igdbLogger.info({ userId: user.id }, "Running scheduled Steam Wishlist sync");
+      await syncUserSteamWishlist(user.id, "system");
+      await storage.updateUserSettings(user.id, { lastSteamSync: new Date() });
+    } catch (error) {
+      igdbLogger.error({ userId: user.id, error }, "Error during scheduled Steam Wishlist sync");
     }
   }
 }

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -1253,29 +1253,41 @@ export async function checkXrelReleases() {
   }
 }
 
+let steamWishlistCheckInProgress = false;
+
 export async function checkSteamWishlist() {
-  igdbLogger.debug("Checking Steam Wishlist auto-sync for all users...");
-  const users = await storage.getAllUsers();
-  for (const user of users) {
-    if (!user.steamId64) continue;
+  if (steamWishlistCheckInProgress) {
+    igdbLogger.debug("Skipping Steam Wishlist auto-sync check — previous run still in progress");
+    return;
+  }
 
-    try {
-      const settings = await storage.getUserSettings(user.id);
-      if (!settings || !settings.steamSyncEnabled) continue;
+  steamWishlistCheckInProgress = true;
+  try {
+    igdbLogger.debug("Checking Steam Wishlist auto-sync for all users...");
+    const users = await storage.getAllUsers();
+    for (const user of users) {
+      if (!user.steamId64) continue;
 
-      const lastSync = settings.lastSteamSync ? new Date(settings.lastSteamSync).getTime() : 0;
-      const intervalMs = settings.steamSyncIntervalHours * 60 * 60 * 1000;
+      try {
+        const settings = await storage.getUserSettings(user.id);
+        if (!settings || !settings.steamSyncEnabled) continue;
 
-      if (Date.now() - lastSync < intervalMs) continue;
+        const lastSync = settings.lastSteamSync ? new Date(settings.lastSteamSync).getTime() : 0;
+        const intervalMs = settings.steamSyncIntervalHours * 60 * 60 * 1000;
 
-      igdbLogger.info({ userId: user.id }, "Running scheduled Steam Wishlist sync");
-      const result = await syncUserSteamWishlist(user.id, "system");
-      if (result && result.success) {
-        await storage.updateUserSettings(user.id, { lastSteamSync: new Date() });
+        if (Date.now() - lastSync < intervalMs) continue;
+
+        igdbLogger.info({ userId: user.id }, "Running scheduled Steam Wishlist sync");
+        const result = await syncUserSteamWishlist(user.id, "system");
+        if (result && result.success) {
+          await storage.updateUserSettings(user.id, { lastSteamSync: new Date() });
+        }
+      } catch (error) {
+        igdbLogger.error({ userId: user.id, error }, "Error during scheduled Steam Wishlist sync");
       }
-    } catch (error) {
-      igdbLogger.error({ userId: user.id, error }, "Error during scheduled Steam Wishlist sync");
     }
+  } finally {
+    steamWishlistCheckInProgress = false;
   }
 }
 

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -1269,8 +1269,10 @@ export async function checkSteamWishlist() {
       if (Date.now() - lastSync < intervalMs) continue;
 
       igdbLogger.info({ userId: user.id }, "Running scheduled Steam Wishlist sync");
-      await syncUserSteamWishlist(user.id, "system");
-      await storage.updateUserSettings(user.id, { lastSteamSync: new Date() });
+      const result = await syncUserSteamWishlist(user.id, "system");
+      if (result && result.success) {
+        await storage.updateUserSettings(user.id, { lastSteamSync: new Date() });
+      }
     } catch (error) {
       igdbLogger.error({ userId: user.id, error }, "Error during scheduled Steam Wishlist sync");
     }

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -1286,6 +1286,8 @@ export async function checkSteamWishlist() {
         igdbLogger.error({ userId: user.id, error }, "Error during scheduled Steam Wishlist sync");
       }
     }
+  } catch (error) {
+    igdbLogger.error({ error }, "Failed scheduled Steam Wishlist auto-sync check");
   } finally {
     steamWishlistCheckInProgress = false;
   }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1063,6 +1063,9 @@ export class MemStorage implements IStorage {
       xrelP2pReleases: insertSettings.xrelP2pReleases ?? false,
       autoSearchUnreleased: insertSettings.autoSearchUnreleased ?? false,
       steamSyncFailures: 0,
+      steamSyncEnabled: insertSettings.steamSyncEnabled ?? false,
+      steamSyncIntervalHours: insertSettings.steamSyncIntervalHours ?? 24,
+      lastSteamSync: insertSettings.lastSteamSync ?? null,
 
       // Import Engine Defaults
       enablePostProcessing: insertSettings.enablePostProcessing ?? false,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -44,6 +44,9 @@ export const userSettings = sqliteTable("user_settings", {
     .notNull()
     .default(false),
   steamSyncFailures: integer("steam_sync_failures").notNull().default(0),
+  steamSyncEnabled: integer("steam_sync_enabled", { mode: "boolean" }).notNull().default(false),
+  steamSyncIntervalHours: integer("steam_sync_interval_hours").notNull().default(24),
+  lastSteamSync: integer("last_steam_sync", { mode: "timestamp_ms" }),
   preferredReleaseGroups: text("preferred_release_groups"),
   filterByPreferredGroups: integer("filter_by_preferred_groups", { mode: "boolean" })
     .notNull()


### PR DESCRIPTION
## Description

Adds an opt-in, per-user auto-sync for Steam Wishlist imports with a user-configurable interval, alongside the existing manual "sync now" flow.

A `checkSteamWishlist` cron helper already existed in `server/cron.ts` but was never wired into `startCronJobs()` (noted as a known gap in `docs/ARCHITECTURE.md`). This PR wires it up, gated per user:

- New `userSettings` columns: `steamSyncEnabled` (default `false`, opt-in), `steamSyncIntervalHours` (default `24`), `lastSteamSync` (last successful scheduled run).
- `checkSteamWishlist` now runs hourly (mirroring the `checkAutoSearch` pattern) and, for each user with a linked Steam ID, only performs a sync once `steamSyncIntervalHours` has elapsed since `lastSteamSync`, and only if `steamSyncEnabled` is on. Per-user errors are caught so one user's failure doesn't block others.
- Settings UI: new "Auto-Sync Wishlist" toggle + "Sync Interval (hours)" input in the Steam Integration card, following the same pattern as the existing Auto-Search interval control.
- `docs/ARCHITECTURE.md` updated to reflect the job now being scheduled.
- DB migration `0023_narrow_blade.sql` generated via `drizzle-kit generate` for the new columns.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Updated `docs/ARCHITECTURE.md` (new scheduled job / behavior change to an existing actor)
- [x] I have added tests that prove my feature works (new `checkSteamWishlist` gating tests in `server/__tests__/steam_wishlist.test.ts`)
- [x] New and existing unit tests pass locally with my changes (`npm run test:run`, `npm run check`, `npm run lint`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GHUrdTk76nMFKbjvtcZ5k6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Steam Wishlist auto-sync controls to Settings (enable/disable toggle, interval in hours with a clamped range, and a save action).
  - Introduced an hourly scheduled Steam Wishlist sync for opted-in accounts, rate-limited by the selected interval and recording the last successful sync.
- **Bug Fixes**
  - Prevented initial Settings hydration from overwriting later edits; added protections to avoid overlapping scheduled sync runs.
- **Documentation**
  - Updated the architecture overview to document the new scheduled Steam Wishlist sync job and flow.
- **Database**
  - Added user settings fields for Steam sync enablement, interval, and last-sync tracking (including schema snapshot updates).
- **Tests**
  - Added scheduler tests for gating, interval rate-limiting, resilience to per-account failures, and overlap prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->