### PR TITLE
Shard CI test run across 4 parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.2.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js 26.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -139,6 +141,7 @@ jobs:
             --reporter=blob
 
       - name: Upload blob report
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: blob-report-${{ matrix.shard }}
@@ -158,6 +161,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.2.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js 26.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -209,6 +214,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.2.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,100 @@ jobs:
           npx --yes license-checker@25.0.1 --production --summary \
             --onlyAllow "MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0;CC0-1.0;0BSD;Python-2.0;BlueOak-1.0.0;OFL-1.1;Unlicense;GPL-3.0;GPL-3.0-only;LGPL-2.1;LGPL-2.1-only;LGPL-3.0;LGPL-3.0-only;MPL-2.0"
 
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.2.0
+
+      - name: Setup Node.js 26.x
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 26.x
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Each shard records its own coverage blob; per-shard coverage only reflects
+      # the fraction of the suite that shard ran, so thresholds are disabled here
+      # and enforced once against the merged report in merge-test-reports below.
+      - name: Tests (shard ${{ matrix.shard }}/4)
+        run: |
+          npm test -- --shard=${{ matrix.shard }}/4 --coverage \
+            --coverage.thresholds.statements=0 \
+            --coverage.thresholds.branches=0 \
+            --coverage.thresholds.functions=0 \
+            --coverage.thresholds.lines=0 \
+            --reporter=blob
+
+      - name: Upload blob report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: blob-report-${{ matrix.shard }}
+          path: .vitest-reports/*
+          include-hidden-files: true
+          retention-days: 1
+
+  merge-test-reports:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.2.0
+
+      - name: Setup Node.js 26.x
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 26.x
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download blob reports
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: .vitest-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge shard reports and check coverage thresholds
+        run: npx vitest run --merge-reports --coverage --reporter=junit --outputFile=test-report.junit.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          report_type: coverage
+          skip_validation: true
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
+          skip_validation: true
+
   build:
     runs-on: ubuntu-latest
 
@@ -131,9 +225,6 @@ jobs:
       - name: TypeScript type check
         run: npm run check
 
-      - name: Tests
-        run: npm test -- --coverage --reporter=junit --outputFile=test-report.junit.xml
-
       - name: Build project
         run: npm run build
 
@@ -145,25 +236,9 @@ jobs:
           fi
           echo "Build successful - dist directory created"
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          report_type: coverage
-          skip_validation: true
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          report_type: test_results
-          skip_validation: true
-
   docker-build:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, merge-test-reports]
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ coverage/
 playwright*/
 test-results/
 test-report.junit.xml
+.vitest-reports/
 vite.config.ts.*
 .sonarlint/connectedMode.json
 data_test/


### PR DESCRIPTION
## Summary

- The ~1800-test suite (currently 1999 tests including skips, 162 files) ran as a single sequential job in CI, making the test step the slowest part of the pipeline (~100s locally on 4 cores, longer on the shared runner with coverage instrumentation).
- Replaced the single `Tests` step in `build` with a `test` job that shards the suite 4 ways via `vitest run --shard=N/4 --reporter=blob`, running each shard as its own parallel CI job.
- Added a `merge-test-reports` job that downloads all 4 blob reports, merges them with `vitest run --merge-reports`, and only then checks the real coverage thresholds and uploads to Codecov — so the merged report is equivalent to the old single-job run, but coverage % isn't falsely computed against a partial shard.
- `docker-build` now depends on both `build` (lint/typecheck/build) and `merge-test-reports` (tests + coverage gate), preserving the same overall gate as before.

## Why not `test.concurrent` / `sequence.concurrent`?

I first tried enabling Vitest's intra-file concurrency (`sequence.concurrent: true`) to run tests within a file in parallel. Verified locally: it broke ~35% of the suite (707/1999 tests) because many client tests share jsdom's single DOM/`localStorage`/mock call-state within a file. Cross-file parallelism (already Vitest's default) is safe and is what this PR scales up via CI-level sharding instead — it doesn't change any test semantics, only how the existing test files are distributed across parallel jobs.

## Test plan

- [x] Ran the full suite locally (`npx vitest run`) to get a baseline: 1992 passed / 7 skipped, 100s wall time on 4 cores.
- [x] Verified `--shard=N/4 --reporter=blob --coverage` (with thresholds disabled) produces per-shard blobs without errors.
- [x] Verified `vitest run --merge-reports --coverage --reporter=junit` recombines all 4 shard blobs into one report with the exact same test counts (1992 passed / 7 skipped, 162 files) and the coverage thresholds from `vitest.config.ts` correctly evaluated against the full merged coverage (all four metrics pass).
- [x] Validated the workflow YAML parses correctly.
- [x] Confirmed `actions/upload-artifact` and `actions/download-artifact` pinned SHAs match their respective release tags.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LYXRiDeDPr8bwpP5Nzviqs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test execution is now distributed across four parallel shards.
  * Coverage is generated per shard and merged into a single consolidated report, including JUnit output for improved reporting.

* **Build & Validation**
  * Restored a dedicated build stage running linting, TypeScript checks, build, and distribution validation.
  * Container builds now wait for both build validation and merged test results.

* **Chores**
  * Test report artifacts are now ignored by version control (including Vitest reports).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->