### PR TITLE
Add Windows 2000 style mode

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,7 @@ import { ThemeProvider } from "next-themes";
 import { routerBase } from "@/lib/app-path";
 import { routePaths } from "@/lib/routes";
 import { GHOST_THEME_KEY } from "@/lib/ghost-mode";
+import { WIN2K_THEME_KEY } from "@/lib/win2k-mode";
 
 // ⚡ Bolt: Code splitting with React.lazy
 // This reduces the initial bundle size by loading pages only when needed.
@@ -131,6 +132,12 @@ function AppShell() {
   useEffect(() => {
     const enabled = localStorage.getItem(GHOST_THEME_KEY) === "true";
     document.documentElement.classList.toggle("theme-ghost", enabled);
+  }, []);
+
+  // Re-apply the cosmetic Windows 2000 skin (if enabled) on load.
+  useEffect(() => {
+    const enabled = localStorage.getItem(WIN2K_THEME_KEY) === "true";
+    document.documentElement.classList.toggle("theme-win2k", enabled);
   }, []);
 
   // Custom sidebar width for the application

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,7 +10,7 @@ import MobileBottomNav from "@/components/MobileBottomNav";
 import { getPageTitle } from "@/components/navigation-items";
 import { useBackgroundNotifications } from "@/hooks/use-background-notifications";
 import { AuthProvider } from "@/lib/auth";
-import { Suspense, lazy, useEffect, useRef } from "react";
+import { Suspense, lazy, useEffect, useLayoutEffect, useRef } from "react";
 import LoadingFallback from "@/components/LoadingFallback";
 import { ThemeProvider } from "next-themes";
 import { routerBase } from "@/lib/app-path";
@@ -134,8 +134,9 @@ function AppShell() {
     document.documentElement.classList.toggle("theme-ghost", enabled);
   }, []);
 
-  // Re-apply the cosmetic Windows 2000 skin (if enabled) on load.
-  useEffect(() => {
+  // Re-apply the cosmetic Windows 2000 skin (if enabled) on load. useLayoutEffect (rather than
+  // useEffect) so the class is applied before paint, avoiding a flash of the default theme.
+  useLayoutEffect(() => {
     const enabled = localStorage.getItem(WIN2K_THEME_KEY) === "true";
     document.documentElement.classList.toggle("theme-win2k", enabled);
   }, []);

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -404,7 +404,7 @@
   --radius-3xl: 0px;
   --radius: 0px;
 
-  --font-sans: Tahoma, "Segoe UI", "MS Sans Serif", Geneva, Verdana, sans-serif;
+  --font-sans: tahoma, "Segoe UI", "MS Sans Serif", geneva, verdana, sans-serif;
 
   --shadow-2xs: none;
   --shadow-xs: none;
@@ -573,6 +573,20 @@
     border-radius: 0;
   }
 
+  .theme-win2k button[role="switch"] {
+    border-radius: 0;
+    border-width: 2px;
+    border-style: solid;
+    border-top-color: #404040;
+    border-left-color: #404040;
+    border-right-color: #fff;
+    border-bottom-color: #fff;
+  }
+
+  .theme-win2k button[role="switch"] > span {
+    border-radius: 0;
+  }
+
   .theme-win2k
     button.border:not(.border-transparent):not([role="switch"]):not([role="checkbox"]):not(
       [role="radio"]
@@ -620,6 +634,7 @@
     border-right-color: #fff;
     border-bottom-color: #fff;
     background-color: #fff;
+    color: #000;
     border-radius: 0;
   }
 
@@ -648,15 +663,18 @@
     border-radius: 0 !important;
   }
 
+  .theme-win2k::-webkit-scrollbar,
   .theme-win2k ::-webkit-scrollbar {
     width: 16px;
     height: 16px;
   }
 
+  .theme-win2k::-webkit-scrollbar-track,
   .theme-win2k ::-webkit-scrollbar-track {
     background-color: #c0c0c0;
   }
 
+  .theme-win2k::-webkit-scrollbar-thumb,
   .theme-win2k ::-webkit-scrollbar-thumb {
     background-color: #c0c0c0;
     border-width: 2px;
@@ -667,6 +685,7 @@
     border-bottom-color: #404040;
   }
 
+  .theme-win2k::-webkit-scrollbar-button,
   .theme-win2k ::-webkit-scrollbar-button {
     background-color: #c0c0c0;
     border-width: 2px;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -342,6 +342,80 @@
   --chart-5: 120 60% 35%;
 }
 
+/* "Windows 2000" nostalgia skin — classic silver ButtonFace chrome, navy title bars and
+   selection highlight, square corners, and beveled 3D controls. Purely cosmetic. */
+.theme-win2k {
+  --button-outline: rgba(0, 0, 0, 0.4);
+  --badge-outline: rgba(0, 0, 0, 0.3);
+  --elevate-1: rgba(0, 0, 0, 0.06);
+  --elevate-2: rgba(0, 0, 0, 0.14);
+
+  --background: 0 0% 100%;
+  --foreground: 0 0% 0%;
+
+  --border: 0 0% 50%;
+
+  --card: 0 0% 75%;
+  --card-foreground: 0 0% 0%;
+  --card-border: 0 0% 50%;
+
+  --sidebar: 0 0% 75%;
+  --sidebar-foreground: 0 0% 0%;
+  --sidebar-border: 0 0% 50%;
+  --sidebar-primary: 220 84% 23%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-accent: 220 84% 23%;
+  --sidebar-accent-foreground: 0 0% 100%;
+  --sidebar-ring: 220 84% 23%;
+
+  --popover: 0 0% 75%;
+  --popover-foreground: 0 0% 0%;
+  --popover-border: 0 0% 50%;
+
+  --primary: 0 0% 75%;
+  --primary-foreground: 0 0% 0%;
+
+  --secondary: 0 0% 75%;
+  --secondary-foreground: 0 0% 0%;
+
+  --muted: 0 0% 82%;
+  --muted-foreground: 0 0% 25%;
+
+  --accent: 220 84% 23%;
+  --accent-foreground: 0 0% 100%;
+
+  --destructive: 0 100% 33%;
+  --destructive-foreground: 0 0% 100%;
+
+  --input: 0 0% 50%;
+  --ring: 220 84% 23%;
+
+  --chart-1: 220 84% 23%;
+  --chart-2: 0 100% 33%;
+  --chart-3: 120 60% 25%;
+  --chart-4: 45 100% 40%;
+  --chart-5: 300 50% 35%;
+
+  --radius-sm: 0px;
+  --radius-md: 0px;
+  --radius-lg: 0px;
+  --radius-xl: 0px;
+  --radius-2xl: 0px;
+  --radius-3xl: 0px;
+  --radius: 0px;
+
+  --font-sans: Tahoma, "Segoe UI", "MS Sans Serif", Geneva, Verdana, sans-serif;
+
+  --shadow-2xs: none;
+  --shadow-xs: none;
+  --shadow-sm: none;
+  --shadow: none;
+  --shadow-md: none;
+  --shadow-lg: none;
+  --shadow-xl: none;
+  --shadow-2xl: none;
+}
+
 @layer base {
   * {
     border-color: hsl(var(--border));
@@ -476,5 +550,134 @@
     aspect-ratio: 3 / 4;
     object-fit: cover;
     display: block;
+  }
+
+  /* Windows 2000 skin: beveled 3D controls, navy title bar, classic scrollbars. */
+  .theme-win2k ::selection {
+    background-color: #0a246a;
+    color: #fff;
+  }
+
+  .theme-win2k header {
+    background: linear-gradient(90deg, #0a246a 0%, #1e50a2 60%, #a6caf0 100%);
+    border-bottom: 2px solid #000;
+  }
+
+  .theme-win2k header h1,
+  .theme-win2k header svg {
+    color: #fff;
+  }
+
+  .theme-win2k
+    button:not([role="switch"]):not([role="checkbox"]):not([role="radio"]):not(.rounded-full) {
+    border-radius: 0;
+  }
+
+  .theme-win2k
+    button.border:not(.border-transparent):not([role="switch"]):not([role="checkbox"]):not(
+      [role="radio"]
+    ):not(.rounded-full) {
+    border-width: 2px;
+    border-style: solid;
+    border-top-color: #fff;
+    border-left-color: #fff;
+    border-right-color: #404040;
+    border-bottom-color: #404040;
+  }
+
+  .theme-win2k
+    button.border:not(.border-transparent):not([role="switch"]):not([role="checkbox"]):not(
+      [role="radio"]
+    ):not(.rounded-full):active {
+    border-top-color: #404040;
+    border-left-color: #404040;
+    border-right-color: #fff;
+    border-bottom-color: #fff;
+  }
+
+  .theme-win2k button.border-transparent:not([role="switch"]):hover:not(:disabled) {
+    border-style: solid;
+    border-top-color: #fff;
+    border-left-color: #fff;
+    border-right-color: #404040;
+    border-bottom-color: #404040;
+  }
+
+  .theme-win2k button.border-transparent:not([role="switch"]):active:not(:disabled) {
+    border-top-color: #404040;
+    border-left-color: #404040;
+    border-right-color: #fff;
+    border-bottom-color: #fff;
+  }
+
+  .theme-win2k input:not([type="checkbox"]):not([type="radio"]),
+  .theme-win2k textarea,
+  .theme-win2k select {
+    border-width: 2px;
+    border-style: solid;
+    border-top-color: #404040;
+    border-left-color: #404040;
+    border-right-color: #fff;
+    border-bottom-color: #fff;
+    background-color: #fff;
+    border-radius: 0;
+  }
+
+  .theme-win2k [role="checkbox"],
+  .theme-win2k [role="radio"] {
+    border-width: 2px;
+    border-style: solid;
+    border-top-color: #404040;
+    border-left-color: #404040;
+    border-right-color: #fff;
+    border-bottom-color: #fff;
+    background-color: #fff;
+  }
+
+  .theme-win2k .shadcn-card {
+    border-width: 2px;
+    border-style: solid;
+    border-top-color: #fff;
+    border-left-color: #fff;
+    border-right-color: #808080;
+    border-bottom-color: #808080;
+  }
+
+  .theme-win2k [role="dialog"],
+  .theme-win2k [data-radix-popper-content-wrapper] > * {
+    border-radius: 0 !important;
+  }
+
+  .theme-win2k ::-webkit-scrollbar {
+    width: 16px;
+    height: 16px;
+  }
+
+  .theme-win2k ::-webkit-scrollbar-track {
+    background-color: #c0c0c0;
+  }
+
+  .theme-win2k ::-webkit-scrollbar-thumb {
+    background-color: #c0c0c0;
+    border-width: 2px;
+    border-style: solid;
+    border-top-color: #fff;
+    border-left-color: #fff;
+    border-right-color: #404040;
+    border-bottom-color: #404040;
+  }
+
+  .theme-win2k ::-webkit-scrollbar-button {
+    background-color: #c0c0c0;
+    border-width: 2px;
+    border-style: solid;
+    border-top-color: #fff;
+    border-left-color: #fff;
+    border-right-color: #404040;
+    border-bottom-color: #404040;
+  }
+
+  .theme-win2k {
+    scrollbar-color: #c0c0c0 #dfdfdf;
   }
 }

--- a/client/src/lib/win2k-mode.ts
+++ b/client/src/lib/win2k-mode.ts
@@ -1,0 +1,2 @@
+/** Shared localStorage key for the "Windows 2000" retro UI skin. */
+export const WIN2K_THEME_KEY = "questarr-win2k-theme-enabled";

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -22,6 +22,7 @@ import {
   Trash2,
   Bell,
   Ghost,
+  Monitor,
 } from "lucide-react";
 import { NexusModsIcon } from "@/components/NexusModsIcon";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -48,6 +49,7 @@ import AutoDownloadRulesSettings from "@/components/AutoDownloadRulesSettings";
 import PreferredReleaseGroupsSettings from "@/components/PreferredReleaseGroupsSettings";
 import { useLocalStorageState } from "@/hooks/use-local-storage-state";
 import { GHOST_THEME_KEY, GHOST_UNLOCK_KEY } from "@/lib/ghost-mode";
+import { WIN2K_THEME_KEY } from "@/lib/win2k-mode";
 import PasswordSettings from "@/components/PasswordSettings";
 import type {
   Config,
@@ -92,6 +94,11 @@ export default function SettingsPage() {
   useEffect(() => {
     document.documentElement.classList.toggle("theme-ghost", ghostThemeEnabled);
   }, [ghostThemeEnabled]);
+
+  const [win2kThemeEnabled, setWin2kThemeEnabled] = useLocalStorageState(WIN2K_THEME_KEY, false);
+  useEffect(() => {
+    document.documentElement.classList.toggle("theme-win2k", win2kThemeEnabled);
+  }, [win2kThemeEnabled]);
 
   const {
     data: config,
@@ -859,6 +866,36 @@ export default function SettingsPage() {
                 </CardContent>
               </Card>
             )}
+
+            <Card>
+              <CardHeader>
+                <div className="flex items-center space-x-3">
+                  <Monitor className="h-5 w-5 text-muted-foreground" />
+                  <CardTitle className="text-lg">Windows 2000 Mode</CardTitle>
+                </div>
+                <CardDescription>
+                  A cosmetic retro skin &mdash; navy title bars, silver beveled buttons, square
+                  corners, and Tahoma type
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="win2k-theme" className="text-sm font-medium">
+                      Enable Windows 2000 skin
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Purely cosmetic &mdash; nothing else changes
+                    </p>
+                  </div>
+                  <Switch
+                    id="win2k-theme"
+                    checked={win2kThemeEnabled}
+                    onCheckedChange={setWin2kThemeEnabled}
+                  />
+                </div>
+              </CardContent>
+            </Card>
 
             {/* Auto-Search Settings */}
             <Card>


### PR DESCRIPTION
## Summary

- Adds a purely cosmetic "Windows 2000 Mode" UI skin, toggled from **Settings → General**, following the same client-side pattern already used by the existing Ghost Mode accent (a `localStorage`-backed flag that toggles a class on `document.documentElement`).
- The `.theme-win2k` class overrides the app's existing CSS custom-property theme system (same mechanism as `.dark` / `.theme-ghost`) to render a full retro skin:
  - Navy gradient title bar (Header) with white text
  - Silver "ButtonFace" gray chrome for sidebar, cards, dialogs, popovers
  - Square corners everywhere (radius tokens zeroed out)
  - Beveled 3D buttons (raised, pressing gives a sunken look) and sunken/inset text fields, checkboxes, and radios, built from explicit light/dark edge colors rather than relying on browser `outset`/`inset` auto-shading
  - Classic navy "Highlight" selection color for menu/dropdown hover and text selection
  - Tahoma-first font stack
  - Retro-styled scrollbars (WebKit + Firefox `scrollbar-color`)
- No backend or data-model changes — this is a client-only CSS/theme feature, same footprint as Ghost Mode.

## Testing

- `npm run check` (tsc) — passes
- `npm run lint` — passes
- `npx vitest run client/__tests__` — 64 test files / 555 tests passing
- `npm run build` — succeeds
- Manually verified the skin renders correctly (navy title bar, gray beveled buttons/panels, sunken inputs, navy dropdown-hover highlight, square corners) using a static harness built from the compiled CSS, since the sandboxed dev server in this environment currently crashes on any client request for reasons unrelated to this change (reproduced identically on `main` before these changes — pre-existing environment issue, not touched by this PR).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RJPet7pyUJCHLHBWgXmdb5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “Windows 2000” visual theme.
  * Added an “Enable Windows 2000 skin” toggle to Settings.
  * The theme choice is saved locally and reapplied automatically on app load.
  * Updated the look across headers, buttons, inputs, dialogs/popovers, cards, scrollbars, and typography to match a retro Windows 2000 style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->