### PR TITLE
Fix qBittorrent v5+ downloads not being tracked

### DIFF
--- a/server/__tests__/downloaders_qbittorrent_regression.test.ts
+++ b/server/__tests__/downloaders_qbittorrent_regression.test.ts
@@ -52,6 +52,11 @@ const emptyHeaders = {
   get: () => null,
 };
 
+const jsonHeaders = {
+  entries: () => [][Symbol.iterator](),
+  get: (name: string) => (name.toLowerCase() === "content-type" ? "application/json" : null),
+};
+
 describe("qbittorrent regression coverage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -550,6 +555,111 @@ describe("qbittorrent regression coverage", () => {
     });
 
     setTimeoutSpy.mockRestore();
+  });
+
+  it("resolves the hash when qBittorrent v5+ accepts a URL add asynchronously", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: TimerHandler,
+      _delay?: number,
+      ...args: unknown[]
+    ) => {
+      if (typeof callback === "function") {
+        callback(...args);
+      }
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+
+    const client = new QBittorrentClient(createDownloader());
+    const privateClient = client as unknown as {
+      authenticate(force?: boolean): Promise<void>;
+      makeRequest(
+        method: string,
+        path: string,
+        body?: string | Buffer,
+        additionalHeaders?: Record<string, string>
+      ): Promise<Response>;
+    };
+
+    vi.spyOn(privateClient, "authenticate").mockResolvedValue(undefined);
+    vi.spyOn(privateClient, "makeRequest")
+      // qBittorrent >= 5.1 answers URL adds with HTTP 202 and JSON. The torrent
+      // file still has to be fetched, so added_torrent_ids is empty here.
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 202,
+        text: async () =>
+          JSON.stringify({
+            added_torrent_ids: [],
+            failure_count: 0,
+            pending_count: 1,
+            success_count: 0,
+          }),
+        headers: jsonHeaders,
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            hash: "async-hash",
+            name: "Queued via URL",
+            added_on: Math.floor(Date.now() / 1000),
+          },
+        ],
+      } as Response);
+
+    await expect(
+      client.addDownload({
+        url: "http://indexer.local/pending.torrent",
+        title: "Queued via URL",
+      })
+    ).resolves.toEqual({
+      success: true,
+      id: "async-hash",
+      message: "Download queued in qBittorrent",
+    });
+
+    setTimeoutSpy.mockRestore();
+  });
+
+  it("uses added_torrent_ids when qBittorrent v5+ adds a torrent immediately", async () => {
+    const client = new QBittorrentClient(createDownloader());
+    const privateClient = client as unknown as {
+      authenticate(force?: boolean): Promise<void>;
+      makeRequest(
+        method: string,
+        path: string,
+        body?: string | Buffer,
+        additionalHeaders?: Record<string, string>
+      ): Promise<Response>;
+    };
+
+    vi.spyOn(privateClient, "authenticate").mockResolvedValue(undefined);
+    const makeRequestSpy = vi.spyOn(privateClient, "makeRequest").mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          added_torrent_ids: ["immediate-hash"],
+          failure_count: 0,
+          pending_count: 0,
+          success_count: 1,
+        }),
+      headers: jsonHeaders,
+    } as unknown as Response);
+
+    await expect(
+      client.addDownload({
+        url: "http://indexer.local/immediate.torrent",
+        title: "Added immediately",
+      })
+    ).resolves.toEqual({
+      success: true,
+      id: "immediate-hash",
+      message: "Download added successfully",
+    });
+
+    // No polling needed when the hash is already known.
+    expect(makeRequestSpy).toHaveBeenCalledTimes(1);
   });
 
   it("covers torrent-download failure, free-space fallbacks, and request error branches", async () => {

--- a/server/downloaders/qbittorrent.ts
+++ b/server/downloaders/qbittorrent.ts
@@ -249,6 +249,7 @@ export class QBittorrentClient implements DownloaderClient {
           const contentType = urlAddResponse.headers.get("content-type") ?? "";
           if (contentType.includes("application/json")) {
             const parsed = JSON.parse(urlAddResponseText) as {
+              added_torrent_ids?: string[];
               failure_count?: number;
               pending_count?: number;
               success_count?: number;
@@ -262,8 +263,33 @@ export class QBittorrentClient implements DownloaderClient {
                   ? "qBittorrent accepted URL for async processing"
                   : "qBittorrent added torrent immediately via URL"
               );
+
+              // A pending URL add means qBittorrent still has to fetch the
+              // .torrent itself, so added_torrent_ids is empty at this point.
+              // Without a hash the caller cannot link the download to a game
+              // (see routes.ts: `result.id` guard), so poll for it briefly.
+              let resolvedHash = parsed.added_torrent_ids?.[0];
+              if (!resolvedHash) {
+                for (let attempt = 0; attempt < 10 && !resolvedHash; attempt++) {
+                  await new Promise((resolve) => setTimeout(resolve, 1000));
+                  const recent = await findRecentlyAddedDownload();
+                  if (recent?.hash) resolvedHash = recent.hash;
+                }
+              }
+
+              if (resolvedHash) {
+                await maybeSetForceStarted(resolvedHash);
+              } else {
+                downloadersLogger.warn(
+                  { url: request.url, title: request.title },
+                  "qBittorrent accepted the URL but no matching torrent appeared; " +
+                    "the download cannot be tracked"
+                );
+              }
+
               return {
                 success: true,
+                ...(resolvedHash ? { id: resolvedHash } : {}),
                 message: isPending
                   ? "Download queued in qBittorrent"
                   : "Download added successfully",


### PR DESCRIPTION
# Fix qBittorrent v5+ downloads not being tracked

## Problem

Torrents added through qBittorrent 5.1 or newer are never linked to a game. They
download and seed normally, but Questarr never tracks them, so the import is
never triggered. `GET /api/downloads` reports them with
`trackedByQuestarr: false`. SABnzbd is unaffected.

## Root cause

qBittorrent 5.1 changed `/api/v2/torrents/add` to answer with JSON. When a URL is
added, qBittorrent has to fetch the `.torrent` itself, so it replies
asynchronously:

```
HTTP 202
{"added_torrent_ids":[],"failure_count":0,"pending_count":1,"success_count":0}
```

`QBittorrentClient.addDownload()` handles this in its JSON branch and returns

```ts
return {
  success: true,
  message: isPending ? "Download queued in qBittorrent" : "Download added successfully",
};
```

without an `id`. In `server/routes.ts` the link to the game is guarded by exactly
that field:

```ts
if (gameId && result.success && result.id && result.downloaderId) {
  await storage.addGameDownload({ /* ... */ downloadHash: result.id /* ... */ });
```

So `addGameDownload()` is never reached, no download record exists, the tracking
loop never picks the torrent up, and no import candidate is created.

The plain-text branch used by qBittorrent 4.x already resolves the hash through
the existing `findRecentlyAddedDownload()` helper and returns `id: recent.hash` —
which is why only v5+ installations are affected.

## Fix

Reuse `findRecentlyAddedDownload()` in the JSON branch. It is defined in the same
scope and already matches by normalized torrent name with a most-recently-added
fallback. Polling runs for up to ten seconds, which covers the time qBittorrent
needs to fetch the `.torrent` from the indexer.

`added_torrent_ids` is now parsed as well. It is populated immediately for
torrent file uploads, so those return without any polling at all.

If no torrent shows up, the add is still reported as successful (it did succeed)
but a warning is logged so the missing tracking is visible in the log rather than
silent.

## Tests

Two regression tests added to `server/__tests__/downloaders_qbittorrent_regression.test.ts`:

- `resolves the hash when qBittorrent v5+ accepts a URL add asynchronously` —
  covers the `pending_count: 1` case with an empty `added_torrent_ids`
- `uses added_torrent_ids when qBittorrent v5+ adds a torrent immediately` —
  asserts the hash is taken from the response and that no extra request is made

Both fail on `main` and pass with this change. The other six tests in the file are
unaffected.

```
Test Files  1 passed (1)
     Tests  8 passed (8)
```

`npx tsc --noEmit`, ESLint and Prettier are clean for both files.

## Verified against

qBittorrent 5.2.3 with Prowlarr-proxied torznab download URLs. Before the change
the torrent stayed at `trackedByQuestarr: false`; afterwards `POST /api/downloads`
returns the infohash as `id` and the download is tracked and imported normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved qBittorrent download handling for newer versions.
  * Asynchronously added downloads can now be tracked until their torrent ID is available.
  * Downloads with an immediately returned torrent ID are handled without unnecessary follow-up requests.
  * Force-start behavior is applied when a newly added torrent is identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->