### PR TITLE
Fix SABnzbd completed-download path resolution for custom incomplete dirs

### DIFF
--- a/server/__tests__/downloaders_comprehensive.test.ts
+++ b/server/__tests__/downloaders_comprehensive.test.ts
@@ -484,6 +484,33 @@ describe("Downloader Comprehensive Tests", () => {
       expect(result?.downloadDir).toBe("/downloads/complete/Test Game");
     });
 
+    it("should use the storage field for a custom incomplete-dir name that the /incomplete/ replace can't fix (issue #815)", async () => {
+      const historyResponse = {
+        history: {
+          slots: [
+            {
+              nzo_id: "nzo123",
+              name: "Test Game",
+              status: "Completed",
+              fail_message: "",
+              path: "/incomplete-bigstorage/Test Game",
+              storage: "/downloads/complete/games/Test Game",
+              bytes: 1073741824,
+              category: "games",
+              download_time: 120,
+              completed: 1700000000,
+            },
+          ],
+        },
+      };
+      mockQueueThenHistory(historyResponse);
+      fetchMock.mockResolvedValueOnce({ ok: true, json: async () => historyResponse });
+
+      const result = await DownloaderManager.getDownloadDetails(downloader, "nzo123");
+
+      expect(result?.downloadDir).toBe("/downloads/complete/games/Test Game");
+    });
+
     it("should return error status when history shows a failed download", async () => {
       mockQueueThenHistory({
         history: {

--- a/server/downloaders/sabnzbd.ts
+++ b/server/downloaders/sabnzbd.ts
@@ -501,16 +501,20 @@ export class SABnzbdClient implements DownloaderClient {
           if (useFilter) continue;
           return undefined;
         }
-        // `storage` is SABnzbd's final resting place for the completed job
-        if (item.storage) return item.storage;
-        // Fallback for older SABnzbd versions that don't expose `storage`.
-        return item.path?.replace(/\/incomplete\//g, "/complete/");
+        return this.resolveHistoryDownloadDir(item);
       } catch {
         if (useFilter) continue;
         return undefined;
       }
     }
     return undefined;
+  }
+
+  private resolveHistoryDownloadDir(item: SABnzbdHistory["slots"][number]): string | undefined {
+    // `storage` is SABnzbd's final resting place for the completed job
+    if (item.storage) return item.storage;
+    // Fallback for older SABnzbd versions that don't expose `storage`.
+    return item.path?.replace(/\/incomplete\//g, "/complete/");
   }
 
   async getDownloadDetails(id: string): Promise<DownloadDetails | null> {

--- a/server/downloaders/sabnzbd.ts
+++ b/server/downloaders/sabnzbd.ts
@@ -40,6 +40,7 @@ interface SABnzbdHistory {
     status: string;
     fail_message: string;
     path: string;
+    storage?: string;
     size: string;
     bytes: number;
     category: string;
@@ -500,7 +501,9 @@ export class SABnzbdClient implements DownloaderClient {
           if (useFilter) continue;
           return undefined;
         }
-        // Normalize SABnzbd's /incomplete/ paths to /complete/
+        // `storage` is SABnzbd's final resting place for the completed job
+        if (item.storage) return item.storage;
+        // Fallback for older SABnzbd versions that don't expose `storage`.
         return item.path?.replace(/\/incomplete\//g, "/complete/");
       } catch {
         if (useFilter) continue;


### PR DESCRIPTION
## Summary
- `getHistoryDownloadDir()` guessed the completed-download path by naively string-replacing `/incomplete/` with `/complete/` in the job's incomplete-dir path. This breaks when the incomplete directory doesn't literally contain that segment (e.g. a custom volume name like `incomplete-bigstorage`).
- SABnzbd's history API already exposes the job's actual final location via the `storage` field. The fix uses `storage` when present, falling back to the old heuristic only for older SABnzbd versions that don't return it.

## Test plan
- [x] Added a regression test covering a custom incomplete-dir name (`/incomplete-bigstorage/...`) where the old `/incomplete/` replace would fail, asserting the resolved dir now matches the `storage` field.
- [x] Full test suite passes locally (162 files, 2010 tests).
- [x] Verified locally against CI-equivalent checks: lint, `tsc` check, production build, secretlint, check-overrides, `npm audit --omit=dev --audit-level=high`, and the license-checker allow-list command.

Fixes #815


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completed download directory detection for SABnzbd.
  * When SABnzbd history provides a storage “complete” path, the app now uses it to determine the download directory, with fallback to the prior incomplete→complete path logic for older formats.
  * Added a comprehensive test covering the storage-based directory derivation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->