### PR TITLE
Fix node base image digest to correct node:26-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage with shared dependencies
 # node:26-alpine
-FROM node@sha256:725aeba2364a9b16beae49e180d83bd597dbd0b15c47f1f28875c290bfd255b9 AS base
+FROM node@sha256:c9f02360d2bc66e709b300214395588acd2d3603f600db8141117e67c0faf4ff AS base
 WORKDIR /app
 
 COPY package*.json ./
@@ -14,7 +14,7 @@ RUN npm run build
 
 # Production stage
 # node:26-alpine
-FROM node@sha256:725aeba2364a9b16beae49e180d83bd597dbd0b15c47f1f28875c290bfd255b9 AS production
+FROM node@sha256:c9f02360d2bc66e709b300214395588acd2d3603f600db8141117e67c0faf4ff AS production
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Closes/replaces #828: Dependabot resolved the wrong digest for the pinned `node@sha256` base image in `Dockerfile`, pointing to `node:26` (Debian, no `apk`) instead of `node:26-alpine`
- This broke the `docker-build` CI check with `apk: not found` during the production stage's `RUN apk add ...` step
- Pinned to the current correct `node:26-alpine` digest (`sha256:c9f02360d2bc66e709b300214395588acd2d3603f600db8141117e67c0faf4ff`), confirmed against Docker Hub's registry API

## Test plan
- [x] `docker build` completes successfully locally with the corrected digest
- [ ] CI `docker-build` check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying Node.js container image to a newer pinned version for build and production environments.
  * Existing application build and runtime behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->