### PR TITLE
Fix silent import skip when download disappears from client

### DIFF
--- a/server/__tests__/cron_download_status.test.ts
+++ b/server/__tests__/cron_download_status.test.ts
@@ -222,6 +222,34 @@ describe("Cron - checkDownloadStatus", () => {
     expect(mockUpdateGameStatus).toHaveBeenCalledWith(baseDownload.gameId, { status: "owned" });
   });
 
+  it("should flag a missing download for manual review instead of skipping import when post-processing is enabled", async () => {
+    mockGetDownloadingGameDownloads.mockResolvedValue([baseDownload]);
+    mockGetDownloader.mockResolvedValue(baseDownloader);
+    mockGetImportConfig.mockResolvedValue({ enablePostProcessing: true });
+
+    // Both bulk and individual checks return nothing
+    mockGetAllDownloads.mockResolvedValue([]);
+    mockGetDownloadStatus.mockResolvedValue(null);
+
+    // DOWNLOAD_MISS_THRESHOLD = 3: must miss 3 consecutive times before acting
+    await checkDownloadStatus();
+    await checkDownloadStatus();
+    await checkDownloadStatus();
+
+    // Never silently marked completed/owned — files were never actually imported.
+    expect(mockUpdateGameDownloadStatus).toHaveBeenCalledWith(
+      baseDownload.id,
+      "manual_review_required",
+      null
+    );
+    expect(mockUpdateGameDownloadStatus).not.toHaveBeenCalledWith(
+      baseDownload.id,
+      "completed",
+      null
+    );
+    expect(mockUpdateGameStatus).not.toHaveBeenCalledWith(baseDownload.gameId, { status: "owned" });
+  });
+
   it("should not call getDownloadStatus when the bulk map already contains the download", async () => {
     mockGetDownloadingGameDownloads.mockResolvedValue([baseDownload]);
     mockGetDownloader.mockResolvedValue(baseDownloader);

--- a/server/__tests__/cron_download_status.test.ts
+++ b/server/__tests__/cron_download_status.test.ts
@@ -60,8 +60,10 @@ vi.mock("../services/index.js", () => ({
   },
 }));
 
+const mockNotifyUser = vi.fn();
+
 vi.mock("../socket.js", () => ({
-  notifyUser: vi.fn(),
+  notifyUser: mockNotifyUser,
 }));
 
 vi.mock("../igdb.js", () => ({
@@ -220,6 +222,7 @@ describe("Cron - checkDownloadStatus", () => {
     // Falls through to the "missing" path after threshold is reached
     expect(mockUpdateGameDownloadStatus).toHaveBeenCalledWith(baseDownload.id, "completed", null);
     expect(mockUpdateGameStatus).toHaveBeenCalledWith(baseDownload.gameId, { status: "owned" });
+    expect(mockNotifyUser).toHaveBeenCalledWith("downloadUpdate", baseDownload.gameId);
   });
 
   it("should flag a missing download for manual review instead of skipping import when post-processing is enabled", async () => {
@@ -248,6 +251,7 @@ describe("Cron - checkDownloadStatus", () => {
       null
     );
     expect(mockUpdateGameStatus).not.toHaveBeenCalledWith(baseDownload.gameId, { status: "owned" });
+    expect(mockNotifyUser).toHaveBeenCalledWith("downloadUpdate", baseDownload.gameId);
   });
 
   it("should not call getDownloadStatus when the bulk map already contains the download", async () => {

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -858,6 +858,7 @@ export async function checkDownloadStatus() {
             // for manual review instead of silently marking the game "owned" with
             // nothing actually imported into the library.
             await storage.updateGameDownloadStatus(download.id, "manual_review_required", null);
+            notifyUser("downloadUpdate", download.gameId);
 
             igdbLogger.warn(
               { gameId: download.gameId, downloadId: download.id, gameTitle },
@@ -882,6 +883,7 @@ export async function checkDownloadStatus() {
 
             // Update game status to owned (assumption)
             await storage.updateGameStatus(download.gameId, { status: "owned" });
+            notifyUser("downloadUpdate", download.gameId);
 
             // Send notification to user about this automatic status change
             if (missedPrefs.downloadCompleted.inApp) {

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -835,6 +835,7 @@ export async function checkDownloadStatus() {
           // Fetch game info for better logging and notification
           const game = await storage.getGame(download.gameId);
           const gameTitle = game ? game.title : download.downloadTitle;
+          const missedImportConfig = await storage.getImportConfig(game?.userId ?? undefined);
 
           igdbLogger.warn(
             {
@@ -844,35 +845,62 @@ export async function checkDownloadStatus() {
               gameTitle,
               downloadHash: download.downloadHash,
             },
-            "Download not found in downloader - assuming completion and marking as owned. " +
+            "Download not found in downloader - assuming completion. " +
               "This could indicate the download was manually removed."
           );
 
-          // Mark download as completed (assumption)
-          await storage.updateGameDownloadStatus(download.id, "completed", null);
-
-          // Update game status to owned (assumption)
-          await storage.updateGameStatus(download.gameId, { status: "owned" });
-
-          // Send notification to user about this automatic status change
           const missedSettings = await storage.getUserSettings(game?.userId ?? "");
           const missedPrefs = resolvePrefs(missedSettings);
-          if (missedPrefs.downloadCompleted.inApp) {
-            const notification = await storage.addNotification({
-              type: "info",
-              title: "Download Status Changed",
-              message: `Download for "${gameTitle}" was not found in the downloader and has been marked as completed. If this was removed due to an error, you may need to re-download it.`,
-              link: "/",
-              userId: game?.userId ?? undefined,
-            });
-            notifyUser("notification", notification);
-            if (missedPrefs.downloadCompleted.apprise) appriseClient.send(notification);
-          }
 
-          igdbLogger.info(
-            { gameId: download.gameId, gameTitle },
-            "Automatically updated game status to 'owned' after download not found in downloader"
-          );
+          if (missedImportConfig.enablePostProcessing) {
+            // We no longer have a download-client reference to resolve the source
+            // path from, so the import pipeline can't run automatically. Flag it
+            // for manual review instead of silently marking the game "owned" with
+            // nothing actually imported into the library.
+            await storage.updateGameDownloadStatus(download.id, "manual_review_required", null);
+
+            igdbLogger.warn(
+              { gameId: download.gameId, downloadId: download.id, gameTitle },
+              "Download not found in downloader — post-processing is enabled but the source " +
+                "path can no longer be resolved. Flagged for manual import review."
+            );
+
+            if (missedPrefs.downloadCompleted.inApp) {
+              const notification = await storage.addNotification({
+                type: "warning",
+                title: "Import Requires Manual Review",
+                message: `"${gameTitle}" finished downloading but disappeared from the download client before it could be imported. Please review it manually under Downloads.`,
+                link: "/",
+                userId: game?.userId ?? undefined,
+              });
+              notifyUser("notification", notification);
+              if (missedPrefs.downloadCompleted.apprise) appriseClient.send(notification);
+            }
+          } else {
+            // Mark download as completed (assumption)
+            await storage.updateGameDownloadStatus(download.id, "completed", null);
+
+            // Update game status to owned (assumption)
+            await storage.updateGameStatus(download.gameId, { status: "owned" });
+
+            // Send notification to user about this automatic status change
+            if (missedPrefs.downloadCompleted.inApp) {
+              const notification = await storage.addNotification({
+                type: "info",
+                title: "Download Status Changed",
+                message: `Download for "${gameTitle}" was not found in the downloader and has been marked as completed. If this was removed due to an error, you may need to re-download it.`,
+                link: "/",
+                userId: game?.userId ?? undefined,
+              });
+              notifyUser("notification", notification);
+              if (missedPrefs.downloadCompleted.apprise) appriseClient.send(notification);
+            }
+
+            igdbLogger.info(
+              { gameId: download.gameId, gameTitle },
+              "Automatically updated game status to 'owned' after download not found in downloader"
+            );
+          }
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Description

Fixes #817. A user reported that torrents finished downloading but Questarr never attempted to import them — no import lines in the logs, and no import history entry.

Root cause: in `checkDownloadStatus()` (`server/cron.ts`), when a tracked download could no longer be found in the download client (e.g. removed after hitting a seed ratio/time limit, or pruned from history), the code unconditionally marked the download `completed` and the game `owned` — **without ever invoking the import pipeline**, regardless of whether post-processing/import was enabled. The files were left untouched in the downloader's folder, with only a generic `warn` log line and no indication that import was skipped.

This fix routes that specific case (download gone from the client + post-processing enabled) to `manual_review_required` instead of silently assuming completion, so the user is prompted to resolve/confirm the import via the existing manual review flow (Downloads page → pending import review, which supports specifying the source path manually) rather than the download vanishing into "owned" state with nothing actually imported.

When post-processing is disabled, behavior is unchanged (still marks `completed`/`owned`, since there's nothing to import).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4yeu5t4jQEpuNEKyk4tti)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When a download cannot be found after repeated status checks, it’s now set to **manual review required** if post-processing is enabled.
  * Prevents incorrectly marking the download as **completed** and the game as **owned** in this scenario.
  * Sends an **Import Requires Manual Review** notification to alert users.
* **Tests**
  * Added a cron test covering missing-download handling, manual-review status updates, and notification dispatch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->