### PR TITLE
Fix download card overflow on mobile with long names

### DIFF
--- a/client/__tests__/DownloadsPage.test.tsx
+++ b/client/__tests__/DownloadsPage.test.tsx
@@ -277,6 +277,36 @@ describe("Downloads page", () => {
     expect(screen.getByTestId("text-error-dl-usenet")).toHaveTextContent("Post-processing failed");
   });
 
+  it("wraps long unbroken download names instead of overflowing the card", async () => {
+    const longName =
+      "Some.Extremely.Long.Release.Name.Without.Spaces.That.Would.Otherwise.Overflow-RLSGROUP";
+    mockDownloadsFetch({
+      downloads: [
+        {
+          id: "dl-long-name",
+          name: longName,
+          status: "downloading",
+          progress: 10,
+          downloaderId: "downloader-1",
+          downloaderName: "qBittorrent",
+          trackedByQuestarr: true,
+          downloadType: "torrent",
+        },
+      ],
+      errors: [],
+    });
+
+    renderPage();
+
+    const title = await screen.findByText(longName);
+    // Flex items default to min-width: auto, which prevents shrinking below an
+    // unbreakable string's intrinsic width and pushes the card (and page) wider
+    // than the viewport on mobile. The title's flex wrapper must opt out via
+    // min-w-0, and the title itself must allow mid-word breaks.
+    expect(title.parentElement).toHaveClass("min-w-0");
+    expect(title).toHaveClass("break-words");
+  });
+
   it("opens details and claim modals, performs download actions, and reports downloader errors", async () => {
     globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
       const target = getRequestUrl(url);

--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -620,8 +620,8 @@ export default function Downloads() {
             >
               <CardHeader>
                 <div className="flex justify-between items-start">
-                  <div className="flex-1">
-                    <CardTitle className="text-base sm:text-lg leading-tight line-clamp-2 sm:line-clamp-none">
+                  <div className="flex-1 min-w-0">
+                    <CardTitle className="text-base sm:text-lg leading-tight line-clamp-2 sm:line-clamp-none break-words">
                       {download.name}
                     </CardTitle>
                     <CardDescription className="mt-2">


### PR DESCRIPTION
## Description

Fixes #835. Download cards on the Downloads page (`client/src/pages/downloads.tsx`) overflowed the page width on mobile when a download had a long name.

Root cause: release/download names commonly have no spaces (dots, underscores, or hyphens as separators, e.g. `Some.Game.Name.Repack-GROUP`), so the browser has few or no natural line-break opportunities. The title lived in a `flex-1` flexbox child with no `min-w-0` — flex items default to `min-width: auto`, which prevents them from shrinking below their content's intrinsic width. Combined with `CardTitle` not allowing mid-word breaks, a long unbreakable name forced the card (and therefore the page) wider than the viewport on mobile instead of wrapping/clamping as intended.

Fix: add `min-w-0` to the title's flex wrapper so it can shrink to the available width, and `break-words` to `CardTitle` so long names wrap within the card instead of overflowing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4yeu5t4jQEpuNEKyk4tti)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download card titles so long, unbroken names wrap correctly on small screens without overflowing the card or page.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->