### PR TITLE
Allow re-attempting import after a failure instead of dead-ending

### DIFF
--- a/client/__tests__/PendingImportsCard.test.tsx
+++ b/client/__tests__/PendingImportsCard.test.tsx
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import PendingImportsCard from "../src/components/PendingImportsCard";
+import { createTestQueryClient, getRequestUrl } from "./test-utils";
+
+vi.mock("../src/components/ImportReviewModal", () => ({
+  default: () => null,
+}));
+
+function createJsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    json: async () => data,
+  } as Response;
+}
+
+function renderCard() {
+  return render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <PendingImportsCard />
+    </QueryClientProvider>
+  );
+}
+
+describe("PendingImportsCard", () => {
+  it("renders nothing when there are no pending imports", async () => {
+    globalThis.fetch = vi.fn(async () => createJsonResponse([]));
+
+    const { container } = renderCard();
+
+    // Wait a tick for the query to settle.
+    await screen.findByText("", { exact: false }).catch(() => undefined);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("surfaces the failure reason for a download flagged after a failed import attempt", async () => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (getRequestUrl(url).includes("/api/imports/pending")) {
+        return createJsonResponse([
+          {
+            id: "dl-1",
+            gameTitle: "My Game",
+            downloadTitle: "My.Game.Release-GROUP",
+            status: "manual_review_required",
+            createdAt: new Date().toISOString(),
+            errorMessage: "disk full",
+          },
+        ]);
+      }
+      return createJsonResponse({});
+    });
+
+    renderCard();
+
+    expect(await screen.findByText("My Game")).toBeInTheDocument();
+    expect(screen.getByText("Import failed: disk full")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Review" })).toBeInTheDocument();
+  });
+});

--- a/client/__tests__/PendingImportsCard.test.tsx
+++ b/client/__tests__/PendingImportsCard.test.tsx
@@ -1,6 +1,6 @@
 /** @vitest-environment jsdom */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
@@ -29,13 +29,15 @@ function renderCard() {
 
 describe("PendingImportsCard", () => {
   it("renders nothing when there are no pending imports", async () => {
-    globalThis.fetch = vi.fn(async () => createJsonResponse([]));
+    const fetchMock = vi.fn(async () => createJsonResponse([]));
+    globalThis.fetch = fetchMock;
 
     const { container } = renderCard();
 
-    // Wait a tick for the query to settle.
-    await screen.findByText("", { exact: false }).catch(() => undefined);
-    expect(container).toBeEmptyDOMElement();
+    // Wait for the pending-imports query to actually resolve before asserting
+    // the empty render, rather than racing an arbitrary findByText timeout.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
   });
 
   it("surfaces the failure reason for a download flagged after a failed import attempt", async () => {

--- a/client/src/components/PendingImportsCard.tsx
+++ b/client/src/components/PendingImportsCard.tsx
@@ -14,6 +14,7 @@ interface PendingImport {
   downloadTitle: string;
   status: string;
   createdAt: string;
+  errorMessage?: string | null;
 }
 
 export default function PendingImportsCard() {
@@ -78,6 +79,14 @@ export default function PendingImportsCard() {
                           : formatDistanceToNow(d, { addSuffix: true });
                       })()}
                   </p>
+                  {item.errorMessage && (
+                    <p
+                      className="text-xs text-destructive truncate max-w-[300px]"
+                      title={item.errorMessage}
+                    >
+                      Import failed: {item.errorMessage}
+                    </p>
+                  )}
                 </div>
                 <div className="flex gap-2">
                   <Button

--- a/server/__tests__/import_manager.test.ts
+++ b/server/__tests__/import_manager.test.ts
@@ -154,7 +154,7 @@ describe("ImportManager", () => {
     expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith("dl-1", "manual_review_required");
   });
 
-  it("marks download as error when processing throws", async () => {
+  it("flags manual review (not a terminal error) when processing throws, so it can be re-attempted", async () => {
     storage.getGameDownload.mockResolvedValue({
       id: "dl-1",
       gameId: "g1",
@@ -179,7 +179,12 @@ describe("ImportManager", () => {
     await manager.processImport("dl-1", "/remote/path");
 
     expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith("dl-1", "unpacking");
-    expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith("dl-1", "error");
+    expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith(
+      "dl-1",
+      "manual_review_required",
+      "translate failure"
+    );
+    expect(storage.updateGameDownloadStatus).not.toHaveBeenCalledWith("dl-1", "error");
   });
 
   it("throws when confirmImport download is missing", async () => {
@@ -334,7 +339,7 @@ describe("ImportManager", () => {
 
   // ─── confirmImport error paths ───────────────────────────────────────────────
 
-  it("confirmImport: originalPath provided but executeImport throws → sets error and re-throws", async () => {
+  it("confirmImport: originalPath provided but executeImport throws → flags manual review and re-throws", async () => {
     storage.getGameDownload.mockResolvedValue({
       id: "dl-1",
       gameId: "g1",
@@ -371,7 +376,12 @@ describe("ImportManager", () => {
       })
     ).rejects.toThrow("Source file not found");
 
-    expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith("dl-1", "error");
+    expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith(
+      "dl-1",
+      "manual_review_required",
+      "Source file not found"
+    );
+    expect(storage.updateGameDownloadStatus).not.toHaveBeenCalledWith("dl-1", "error");
   });
 
   it("confirmImport: game not found for download → throws with descriptive message", async () => {

--- a/server/__tests__/import_manager.test.ts
+++ b/server/__tests__/import_manager.test.ts
@@ -947,4 +947,28 @@ describe("ImportManager", () => {
       })
     );
   });
+
+  it("autoDeleteAfterImport: keeps status 'imported' when removeDownload throws instead of demoting to manual_review_required", async () => {
+    setupSuccessfulImport("copy");
+    downloadersMock.removeDownload.mockRejectedValue(new Error("downloader unreachable"));
+
+    const manager = new ImportManager(
+      storage as never, // NOSONAR
+      pathService as never, // NOSONAR
+      platformService as never, // NOSONAR
+      archiveService as never // NOSONAR
+    );
+    await manager.processImport("dl-1", "/remote/path");
+
+    // The import itself already succeeded and finalized before auto-delete ran —
+    // a post-finalization auto-delete failure must not re-route an
+    // already-completed download back into the retryable review flow, which
+    // would risk a duplicate transfer if the user clicks Confirm Import again.
+    expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith("dl-1", "imported");
+    expect(storage.updateGameDownloadStatus).not.toHaveBeenCalledWith(
+      "dl-1",
+      "manual_review_required",
+      expect.anything()
+    );
+  });
 });

--- a/server/__tests__/import_manager_additional.test.ts
+++ b/server/__tests__/import_manager_additional.test.ts
@@ -708,7 +708,11 @@ describe("ImportManager - confirmImport path resolution failures", () => {
     ).rejects.toThrow("disk full");
 
     expect(fsMock.remove).toHaveBeenCalledWith("/downloads/game.zip_extracted");
-    expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith("dl-1", "error");
+    expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith(
+      "dl-1",
+      "manual_review_required",
+      "disk full"
+    );
 
     execSpy.mockRestore();
   });

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -429,6 +429,7 @@ importRouter.get("/pending", async (req, res) => {
           status: d.status,
           downloaderId: d.downloaderId,
           createdAt: d.addedAt,
+          errorMessage: d.errorMessage,
         };
       })
     );

--- a/server/services/ImportManager.ts
+++ b/server/services/ImportManager.ts
@@ -411,7 +411,19 @@ export class ImportManager {
         config.autoDeleteAfterImport &&
         (config.transferMode === "copy" || config.transferMode === "move")
       ) {
-        await this.performAutoDelete(downloadId, download, game);
+        try {
+          await this.performAutoDelete(downloadId, download, game);
+        } catch (autoDeleteErr) {
+          // The import itself already succeeded and was finalized (status
+          // "imported", library path set) — a failure here must not fall
+          // through to the outer catch, which would demote the download
+          // back to manual_review_required and risk a duplicate transfer
+          // on retry.
+          logger.error(
+            { err: autoDeleteErr, downloadId },
+            "[ImportManager] Auto-delete after import failed unexpectedly"
+          );
+        }
       }
     } catch (err) {
       logger.error({ err, downloadId }, "[ImportManager] Import failed");

--- a/server/services/ImportManager.ts
+++ b/server/services/ImportManager.ts
@@ -419,7 +419,14 @@ export class ImportManager {
         await fs.remove(processingPath).catch(() => undefined);
       }
       try {
-        await this.storage.updateGameDownloadStatus(downloadId, "error");
+        // Route to manual review instead of a terminal "error" status so the
+        // download stays actionable — it surfaces under Pending Manual Imports
+        // where the user can adjust settings and re-attempt the import.
+        await this.storage.updateGameDownloadStatus(
+          downloadId,
+          "manual_review_required",
+          err instanceof Error ? err.message : String(err)
+        );
       } catch (statusErr) {
         logger.error({ statusErr, downloadId }, "[ImportManager] Failed to set error status");
       }
@@ -580,7 +587,13 @@ export class ImportManager {
     } catch (err) {
       logger.error({ err, downloadId }, "[ImportManager] confirmImport failed");
       try {
-        await this.storage.updateGameDownloadStatus(downloadId, "error");
+        // Keep the download in manual review rather than a terminal "error"
+        // status, so a failed retry attempt can itself be re-attempted.
+        await this.storage.updateGameDownloadStatus(
+          downloadId,
+          "manual_review_required",
+          err instanceof Error ? err.message : String(err)
+        );
       } catch (statusErr) {
         logger.error({ statusErr, downloadId }, "[ImportManager] Failed to set error status");
       }


### PR DESCRIPTION
## Description

Fixes #834. Users could not re-attempt post-processing/import after a failure.

Root cause: when an import failed — either in the automatic post-download pipeline (`ImportManager.processImport`) or during a user-triggered manual "Confirm Import" retry (`ImportManager.confirmImport`) — the download was permanently marked `error`. That status:

- Is excluded from the cron re-check loop (`getDownloadingGameDownloads` filters it out), so it's never automatically retried.
- Is excluded from the Pending Manual Imports list (`getPendingImportReviews` only selects `manual_review_required`), so it never shows up for the user to act on.
- Has no retry action anywhere on the Downloads page.

The result: a failed import became invisible and permanently unrecoverable — the only way out was deleting the download and re-downloading the game from scratch.

## Fix

Both failure paths now set the download to `manual_review_required` instead of `error`, storing the underlying error message. This keeps the download in the existing Pending Manual Imports flow (`PendingImportsCard` → `ImportReviewModal`), where the user can adjust the source/destination path or transfer mode and retry via **Confirm Import**, or give up via **Skip**. If a retry itself fails, it goes back to `manual_review_required` again rather than dead-ending, so the user can keep adjusting and retrying.

Also surfaced the stored error message in the `/api/imports/pending` response and in `PendingImportsCard`, so the user can see *why* an import needs attention instead of just that it does.

The "game deleted while its download was in flight" case still sets `error`, since there's no game left to import into or review against.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4yeu5t4jQEpuNEKyk4tti)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pending imports now display specific failure details when available.
  * Failed imports requiring attention remain available for manual review or retry.
  * Added a **Review** action for imports flagged for manual review.

* **Bug Fixes**
  * Import failures now preserve the original error message instead of being treated as terminal errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->