### PR TITLE
🎨 Palette: Add dynamic ARIA labels and tooltips to download action buttons

### DIFF
--- a/client/__tests__/DiscoverPage.test.tsx
+++ b/client/__tests__/DiscoverPage.test.tsx
@@ -120,7 +120,7 @@ describe("DiscoverPage", () => {
     expect(await screen.findByText("Discover")).toBeInTheDocument();
 
     // Give some time for queries to settle to hit coverage on our new hook
-    await new Promise(resolve => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 50));
   });
 
   it("renders when fetching fails", async () => {

--- a/client/__tests__/DownloadsPage.test.tsx
+++ b/client/__tests__/DownloadsPage.test.tsx
@@ -1,3 +1,4 @@
+import { TooltipProvider } from "@/components/ui/tooltip";
 /** @vitest-environment jsdom */
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -91,7 +92,9 @@ describe("Downloads page", () => {
   const renderPage = () =>
     render(
       <QueryClientProvider client={createTestQueryClient()}>
-        <Downloads />
+        <TooltipProvider>
+          <Downloads />
+        </TooltipProvider>
       </QueryClientProvider>
     );
 

--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -1,4 +1,3 @@
-import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { useState, useEffect, useMemo, useRef, lazy, Suspense } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { queryClient } from "@/lib/queryClient";
@@ -49,6 +48,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/client/src/pages/downloads.tsx
+++ b/client/src/pages/downloads.tsx
@@ -1,3 +1,4 @@
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { useState, useEffect, useMemo, useRef, lazy, Suspense } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { queryClient } from "@/lib/queryClient";
@@ -808,25 +809,41 @@ export default function Downloads() {
                     {ACTIVE_DOWNLOAD_STATUSES.includes(download.status) && (
                       <>
                         {download.status === "paused" ? (
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            onClick={() => handleResume(download)}
-                            disabled={resumeMutation.isPending}
-                            data-testid={`button-resume-${download.id}`}
-                          >
-                            <Play className="h-4 w-4" />
-                          </Button>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="outline"
+                                size="icon"
+                                aria-label={`Resume ${download.name || "download"}`}
+                                onClick={() => handleResume(download)}
+                                disabled={resumeMutation.isPending}
+                                data-testid={`button-resume-${download.id}`}
+                              >
+                                <Play className="h-4 w-4" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Resume</p>
+                            </TooltipContent>
+                          </Tooltip>
                         ) : (
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            onClick={() => handlePause(download)}
-                            disabled={pauseMutation.isPending}
-                            data-testid={`button-pause-${download.id}`}
-                          >
-                            <Pause className="h-4 w-4" />
-                          </Button>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="outline"
+                                size="icon"
+                                aria-label={`Pause ${download.name || "download"}`}
+                                onClick={() => handlePause(download)}
+                                disabled={pauseMutation.isPending}
+                                data-testid={`button-pause-${download.id}`}
+                              >
+                                <Pause className="h-4 w-4" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Pause</p>
+                            </TooltipContent>
+                          </Tooltip>
                         )}
                       </>
                     )}

--- a/client/src/pages/search.tsx
+++ b/client/src/pages/search.tsx
@@ -627,7 +627,7 @@ export default function SearchPage() {
                                 disabled={downloaders.length === 0}
                                 className="h-8 w-8"
                                 data-testid={`button-download-${index}`}
-                                aria-label="Start download"
+                                aria-label={`Start download for ${download.title}`}
                               >
                                 <Download className="h-4 w-4" />
                               </Button>


### PR DESCRIPTION
### 💡 What
Added dynamic `aria-label` attributes to the Pause, Resume, and Start Download action buttons in the Downloads and Search pages. Additionally, wrapped the Pause and Resume buttons with `Tooltip` components from Shadcn UI to display visual context on hover. Ensure tests pass correctly by wrapping component test renders with a `<TooltipProvider>`.

### 🎯 Why
Icon-only buttons within repeating lists (like lists of active downloads or search results) create an ambiguous experience for screen reader users when their `aria-label` is generic (e.g., "Resume"). By incorporating the item's specific name or title (e.g., "Resume [Game Name]"), screen readers can announce the exact action's target. Adding visual tooltips similarly assists sighted users in quickly identifying the button's purpose without guesswork.

### 📸 Before/After
**Before:**
- Downloads page: Icon-only Resume/Pause buttons had no visual tooltips and lacked `aria-label`s.
- Search page: Download button used a generic `aria-label="Start download"`.

**After:**
- Downloads page: Hovering over the Pause or Resume buttons now displays a "Pause" or "Resume" tooltip. Screen readers announce, for example, "Pause Grand Theft Auto V".
- Search page: Screen readers announce, for example, "Start download for Grand Theft Auto V" instead of just "Start download".

### ♿ Accessibility
- Provides context-rich screen reader announcements for repetitive icon-only buttons in list items.
- Provides visual tooltips for icon-only action buttons.

---
*PR created automatically by Jules for task [14753702386396286693](https://jules.google.com/task/14753702386396286693) started by @Doezer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tooltips to download pause and resume controls.
  * Improved accessibility labels for search result “Start download” actions by including the item title.
* **Tests**
  * Updated Discover page tests to improve reliability of asynchronous rendering.
  * Updated Downloads page tests to include tooltip context during rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->