### PR TITLE
Add reverse proxy subdirectory deployment support and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,7 @@
 # NODE_ENV=development
 # Optional: Database path (default: sqlite.db)
 # SQLITE_DB_PATH=data/sqlite.db
+# Optional: Serve the app from a subdirectory behind a reverse proxy
+# (e.g. https://xxx.domain.com/Questarr). Leading slash, no trailing slash.
+# See docs/REVERSE_PROXY.md for full setup instructions.
+# QUESTARR_BASE_PATH=/Questarr

--- a/README.md
+++ b/README.md
@@ -331,6 +331,14 @@ docker-compose build --no-cache
 docker-compose up -d
 ```
 
+### Reverse proxy / subdirectory deployment
+
+Want to serve Questarr from a path like `https://xxx.domain.com/Questarr`
+instead of its own subdomain? Set `QUESTARR_BASE_PATH=/Questarr` on the
+container (or in `.env` for npm installs) and point your reverse proxy at it
+— no rebuild required. See [docs/REVERSE_PROXY.md](docs/REVERSE_PROXY.md) for
+full setup instructions (nginx, Traefik, Caddy).
+
 </details>
 
 ## Roadmap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - PORT=${CONTAINER_INTERNAL_SIDE_PORT:-5000}
       # - SQLITE_DB_PATH=/app/data/sqlite.db  # Default path for sqlite db, uncomment and change if needed
+      # - QUESTARR_BASE_PATH=/Questarr  # Serve from a subdirectory behind a reverse proxy, see docs/REVERSE_PROXY.md
     volumes:
       # Persist SQLite database and other data
       - ./data:/app/data

--- a/docs/GITHUB_DOCUMENTATION.md
+++ b/docs/GITHUB_DOCUMENTATION.md
@@ -9,6 +9,7 @@ This file is the single entry point for GitHub-facing documentation in this repo
 - Architecture: [`docs/ARCHITECTURE.md`](./ARCHITECTURE.md), for a system architecture and actor overview
 - Changelog: [`docs/CHANGELOG.md`](./CHANGELOG.md)
 - Migration notes: [`docs/MIGRATION.md`](./MIGRATION.md), for migration from PostgreSQL to SQLite in v1.1
+- Reverse proxy / subdirectory deployment: [`docs/REVERSE_PROXY.md`](./REVERSE_PROXY.md), for serving Questarr from a path like `/Questarr` behind nginx/Traefik/Caddy
 - Security model and operations:
   - [`docs/THREAT_MODEL.md`](./THREAT_MODEL.md), for the attack surface analysis and security architecture
   - [`docs/SECURITY_ASSESSMENT.md`](./SECURITY_ASSESSMENT.md), security risk assessment.

--- a/docs/REVERSE_PROXY.md
+++ b/docs/REVERSE_PROXY.md
@@ -59,9 +59,18 @@ stripping the prefix** — Questarr expects to see it.
 
 ### nginx
 
+`app` below is the Compose service name from this repo's `docker-compose.yml`
+— substitute your own container/service name if it differs. nginx's prefix
+match only covers `/Questarr/...`, so add an exact-match redirect for the
+bare `/Questarr` (no trailing slash) case too:
+
 ```nginx
+location = /Questarr {
+    return 301 /Questarr/;
+}
+
 location /Questarr/ {
-    proxy_pass http://questarr:5000/Questarr/;
+    proxy_pass http://app:5000/Questarr/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -86,9 +95,13 @@ No `StripPrefix` middleware needed — Questarr handles the prefix itself.
 
 ### Caddy
 
+Caddy's `/Questarr/*` matcher is exact-prefix and won't match the bare
+`/Questarr` (no trailing slash) request, so redirect it explicitly:
+
 ```caddyfile
 xxx.domain.com {
-    reverse_proxy /Questarr/* questarr:5000
+    redir /Questarr /Questarr/ permanent
+    reverse_proxy /Questarr/* app:5000
 }
 ```
 

--- a/docs/REVERSE_PROXY.md
+++ b/docs/REVERSE_PROXY.md
@@ -1,0 +1,109 @@
+# Reverse Proxy & Subdirectory Deployment
+
+Questarr can be served from a subdirectory (e.g. `https://xxx.domain.com/Questarr`)
+behind a reverse proxy, instead of owning its own subdomain or root path.
+
+## How it works
+
+- The client build uses relative asset paths by default and detects its own
+  base path at runtime, so it doesn't need to know about the subdirectory in
+  advance.
+- The server understands an optional `QUESTARR_BASE_PATH` environment
+  variable. When set, it mounts the entire app (API, WebSocket, and static
+  assets) under that prefix, so a reverse proxy can forward requests straight
+  through without rewriting the path.
+
+Setting `QUESTARR_BASE_PATH` is only required if you want Questarr itself to
+own the prefix (recommended — see below). If you'd rather have your reverse
+proxy strip the prefix before forwarding to Questarr, you can leave
+`QUESTARR_BASE_PATH` unset; the client's runtime base-path detection adapts
+either way.
+
+## 1. Configure Questarr
+
+Set `QUESTARR_BASE_PATH` to the path you want to serve from (leading slash,
+no trailing slash — e.g. `/Questarr`):
+
+**Docker Compose:**
+
+```yaml
+services:
+  app:
+    image: ghcr.io/doezer/questarr:latest
+    environment:
+      - QUESTARR_BASE_PATH=/Questarr
+    # ...
+```
+
+**`docker run`:**
+
+```bash
+docker run -e QUESTARR_BASE_PATH=/Questarr ghcr.io/doezer/questarr:latest
+```
+
+**npm (non-Docker):** add `QUESTARR_BASE_PATH=/Questarr` to your `.env` file.
+
+With this set, Questarr:
+
+- Serves the app and all `/api/*` routes under `/Questarr/*`
+- Redirects the unprefixed root (`/`) to `/Questarr/`
+- Keeps `/api/health` reachable unprefixed too, so container healthchecks
+  (which talk to the container directly, not through the proxy) keep working
+  unmodified
+- Serves the WebSocket (Socket.IO) connection at `/Questarr/socket.io/`
+
+## 2. Configure your reverse proxy
+
+Point requests under the prefix at the Questarr container/process, **without
+stripping the prefix** — Questarr expects to see it.
+
+### nginx
+
+```nginx
+location /Questarr/ {
+    proxy_pass http://questarr:5000/Questarr/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Required for Socket.IO (real-time download/notification updates)
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+}
+```
+
+### Traefik (labels)
+
+```yaml
+labels:
+  - "traefik.http.routers.questarr.rule=Host(`xxx.domain.com`) && PathPrefix(`/Questarr`)"
+  - "traefik.http.services.questarr.loadbalancer.server.port=5000"
+```
+
+No `StripPrefix` middleware needed — Questarr handles the prefix itself.
+
+### Caddy
+
+```caddyfile
+xxx.domain.com {
+    reverse_proxy /Questarr/* questarr:5000
+}
+```
+
+## 3. Verify
+
+Visit `https://xxx.domain.com/Questarr/`. Login, navigation, API calls, and
+real-time download/notification updates should all work normally under the
+prefix.
+
+## Notes
+
+- `QUESTARR_BASE_PATH` accepts letters, numbers, hyphens, underscores, and
+  slashes only (e.g. `/Questarr`, `/games/questarr`). Invalid values fail
+  startup with a clear error, the same way other misconfigured environment
+  variables do.
+- Changing `QUESTARR_BASE_PATH` only affects the running server — no rebuild
+  is required, since the pre-built Docker image resolves the base path at
+  runtime rather than baking it into the client bundle at build time.

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import express from "express";
 import request from "supertest";
 import path from "path";
@@ -2857,5 +2857,58 @@ describe("API Routes - Extended Coverage", () => {
       expect(response.status).toBe(502);
       expect(response.body.error).toBe("CLI timed out");
     });
+  });
+});
+
+describe("QUESTARR_BASE_PATH subdirectory mounting", () => {
+  afterEach(() => {
+    mockConfig.server.basePath = "";
+  });
+
+  it("serves the app under the configured base path", async () => {
+    mockConfig.server.basePath = "/Questarr";
+
+    const prefixedApp = express();
+    prefixedApp.use(express.json());
+    const httpServer = await registerRoutes(prefixedApp);
+
+    const response = await request(httpServer).get("/Questarr/api/health");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ status: "ok" });
+  });
+
+  it("keeps /api/health reachable unprefixed for container healthchecks", async () => {
+    mockConfig.server.basePath = "/Questarr";
+
+    const prefixedApp = express();
+    prefixedApp.use(express.json());
+    const httpServer = await registerRoutes(prefixedApp);
+
+    const response = await request(httpServer).get("/api/health");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ status: "ok" });
+  });
+
+  it("redirects the unprefixed root to the base path", async () => {
+    mockConfig.server.basePath = "/Questarr";
+
+    const prefixedApp = express();
+    prefixedApp.use(express.json());
+    const httpServer = await registerRoutes(prefixedApp);
+
+    const response = await request(httpServer).get("/").redirects(0);
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe("/Questarr/");
+  });
+
+  it("does not serve API routes unprefixed when a base path is configured", async () => {
+    mockConfig.server.basePath = "/Questarr";
+
+    const prefixedApp = express();
+    prefixedApp.use(express.json());
+    const httpServer = await registerRoutes(prefixedApp);
+
+    const response = await request(httpServer).post("/api/settings/apprise/test").send();
+    expect(response.status).toBe(404);
   });
 });

--- a/server/__tests__/config.test.ts
+++ b/server/__tests__/config.test.ts
@@ -15,6 +15,7 @@ describe("Config Module", () => {
     delete process.env.PORT;
     delete process.env.HOST;
     delete process.env.NODE_ENV;
+    delete process.env.QUESTARR_BASE_PATH;
   });
 
   afterEach(() => {
@@ -124,6 +125,58 @@ describe("Config Module", () => {
       expect(config.server.isTest).toBe(true);
       expect(config.server.isDevelopment).toBe(false);
       expect(config.server.isProduction).toBe(false);
+    });
+  });
+
+  describe("QUESTARR_BASE_PATH", () => {
+    it("defaults to the root when unset", async () => {
+      process.env.SQLITE_DB_PATH = "test.db";
+
+      const { config } = await import("../config.js");
+
+      expect(config.server.basePath).toBe("");
+    });
+
+    it("normalizes a bare segment to a leading-slash form", async () => {
+      process.env.SQLITE_DB_PATH = "test.db";
+      process.env.QUESTARR_BASE_PATH = "Questarr";
+
+      const { config } = await import("../config.js");
+
+      expect(config.server.basePath).toBe("/Questarr");
+    });
+
+    it("strips a trailing slash", async () => {
+      process.env.SQLITE_DB_PATH = "test.db";
+      process.env.QUESTARR_BASE_PATH = "/Questarr/";
+
+      const { config } = await import("../config.js");
+
+      expect(config.server.basePath).toBe("/Questarr");
+    });
+
+    it("treats a bare slash as the root", async () => {
+      process.env.SQLITE_DB_PATH = "test.db";
+      process.env.QUESTARR_BASE_PATH = "/";
+
+      const { config } = await import("../config.js");
+
+      expect(config.server.basePath).toBe("");
+    });
+
+    it("rejects values with invalid characters", async () => {
+      process.env.SQLITE_DB_PATH = "test.db";
+      process.env.QUESTARR_BASE_PATH = "/questarr?evil=1";
+
+      const mockProcessExit = vi.spyOn(process, "exit").mockImplementation((code) => {
+        throw new Error(`process.exit called with code ${code}`);
+      });
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      await expect(import("../config.js")).rejects.toThrow("process.exit called with code 1");
+
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/server/__tests__/fixtures/common-route-mocks.ts
+++ b/server/__tests__/fixtures/common-route-mocks.ts
@@ -17,6 +17,7 @@ export const mockConfig = {
   server: {
     isProduction: false,
     allowedOrigins: [] as string[],
+    basePath: "" as string,
   },
   igdb: {
     isConfigured: true,

--- a/server/config.ts
+++ b/server/config.ts
@@ -56,7 +56,33 @@ const envSchema = z.object({
     .transform((val) => val === "true")
     .optional(),
   APP_URL: z.string().url().optional(),
+
+  // URL base for reverse-proxy subdirectory deployments (e.g. "/Questarr" for
+  // https://host/Questarr/). Optional; defaults to serving from the root.
+  QUESTARR_BASE_PATH: z
+    .string()
+    .optional()
+    .refine(
+      (value) =>
+        !value || value === "/" || /^\/?[a-zA-Z0-9](?:[a-zA-Z0-9/_-]*[a-zA-Z0-9])?\/?$/.test(value),
+      {
+        message:
+          "QUESTARR_BASE_PATH must contain only letters, numbers, hyphens, underscores, and slashes (e.g. /Questarr).",
+      }
+    ),
 });
+
+/**
+ * Normalizes a configured base path to a form with a leading slash and no
+ * trailing slash (e.g. "Questarr/" -> "/Questarr"), or "" for the root.
+ */
+function normalizeBasePath(value: string | undefined): string {
+  if (!value) return "";
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "/") return "";
+  const withLeadingSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.endsWith("/") ? withLeadingSlash.slice(0, -1) : withLeadingSlash;
+}
 
 /**
  * Validate environment variables and fail cleanly with descriptive errors if required variables are missing.
@@ -117,6 +143,7 @@ export const config = {
     allowedOrigins: env.ALLOWED_ORIGINS
       ? env.ALLOWED_ORIGINS.split(",").map((origin) => origin.trim())
       : ["http://localhost:port".replace("port", env.PORT.toString())],
+    basePath: normalizeBasePath(env.QUESTARR_BASE_PATH),
   },
   ssl: configLoader.getSslConfig(),
 } as const;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,4 +1,4 @@
-import type { Express, Request, Response } from "express";
+import express, { type Express, type Request, type Response } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage.js";
 import { igdbClient } from "./igdb.js";
@@ -4048,6 +4048,25 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  const httpServer = createServer(app);
+  // Reverse-proxy subdirectory support: when QUESTARR_BASE_PATH is set
+  // (e.g. "/Questarr"), mount the whole app under that prefix so it can be
+  // served from https://host/Questarr/ without the reverse proxy needing to
+  // rewrite the path. Health checks stay reachable at the unprefixed
+  // /api/health too, since Docker/orchestrator healthchecks hit the
+  // container directly rather than through the proxy.
+  const basePath = appConfig.server.basePath;
+  let rootApp: Express = app;
+  if (basePath) {
+    rootApp = express();
+    rootApp.use(basePath, app);
+    rootApp.get("/api/health", (_req, res) => {
+      res.status(200).json({ status: "ok" });
+    });
+    rootApp.get("/", (_req, res) => {
+      res.redirect(302, `${basePath}/`);
+    });
+  }
+
+  const httpServer = createServer(rootApp);
   return httpServer;
 }

--- a/server/socket.ts
+++ b/server/socket.ts
@@ -9,6 +9,7 @@ let io: Server | undefined;
 export function setupSocketIO(httpServer: HttpServer) {
   if (!io) {
     io = new Server({
+      path: `${config.server.basePath}/socket.io/`,
       cors: {
         origin:
           config.server.allowedOrigins.length === 1 && config.server.allowedOrigins[0] === "*"


### PR DESCRIPTION
## Summary

- Makes `QUESTARR_BASE_PATH` a **runtime server config**, settable as a normal Docker/env var (`docker-compose.yml`, `docker run -e`, or `.env`), instead of only a client build-time Vite setting. No image rebuild required.
- When set (e.g. `/Questarr`), the server mounts the app, `/api/*`, and Socket.IO under that prefix, so a reverse proxy can forward requests straight through without rewriting the path.
- Keeps `/api/health` reachable **unprefixed** too, so container healthchecks (which talk to the container directly, not through the proxy) keep working unmodified.
- Redirects the bare root (`/`) to the prefixed path for convenience.
- Adds `docs/REVERSE_PROXY.md` with full setup instructions and example nginx/Traefik/Caddy configs, linked from the README and `docs/GITHUB_DOCUMENTATION.md`.
- Documents `QUESTARR_BASE_PATH` in `.env.example` and `docker-compose.yml`.

Invalid values (anything outside letters/numbers/hyphens/underscores/slashes) fail startup with a clear error, consistent with how other misconfigured env vars are handled.

## Test plan

- [x] `npm run check` (TypeScript)
- [x] `npm run lint`
- [x] `npx vitest run` — full suite (2018 tests passed)
- [x] Added unit tests: `server/__tests__/config.test.ts` (base path normalization/validation) and `server/__tests__/api_routes.test.ts` (prefix mounting, unprefixed `/api/health` passthrough, root redirect, unprefixed API routes 404 when a base path is set)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013BGtyTHvT9o7prMW1y5Soo

---
_Generated by [Claude Code](https://claude.ai/code/session_013BGtyTHvT9o7prMW1y5Soo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for serving Questarr from a subdirectory behind a reverse proxy.
  * Configurable base paths apply to web pages, APIs, static assets, and WebSocket connections.
  * The root URL redirects automatically to the configured subdirectory.
  * API health checks remain accessible during subdirectory deployments.

* **Documentation**
  * Added setup guidance for Docker, npm, nginx, Traefik, and Caddy.
  * Included configuration validation and verification steps, with no rebuild required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->