### PR TITLE
Address review feedback on qBittorrent v5+ tracking fix (follow-up to #823)

### DIFF
--- a/server/__tests__/downloaders_qbittorrent_regression.test.ts
+++ b/server/__tests__/downloaders_qbittorrent_regression.test.ts
@@ -557,6 +557,81 @@ describe("qbittorrent regression coverage", () => {
     setTimeoutSpy.mockRestore();
   });
 
+  it("removes the correlation tag when a non-magnet URL add already existed", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: TimerHandler,
+      _delay?: number,
+      ...args: unknown[]
+    ) => {
+      if (typeof callback === "function") {
+        callback(...args);
+      }
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+
+    try {
+      const client = new QBittorrentClient(createDownloader());
+      const privateClient = client as unknown as {
+        authenticate(force?: boolean): Promise<void>;
+        makeRequest(
+          method: string,
+          path: string,
+          body?: string | Buffer,
+          additionalHeaders?: Record<string, string>
+        ): Promise<Response>;
+      };
+
+      vi.spyOn(privateClient, "authenticate").mockResolvedValue(undefined);
+      const makeRequestSpy = vi
+        .spyOn(privateClient, "makeRequest")
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: async () => "Fails.",
+          headers: emptyHeaders,
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [
+            {
+              hash: "existing-hash",
+              name: "Already queued",
+              added_on: Math.floor(Date.now() / 1000),
+            },
+          ],
+        } as Response)
+        .mockResolvedValueOnce({ ok: true, status: 200, text: async () => "" } as Response);
+
+      await expect(
+        client.addDownload({
+          url: "http://indexer.local/duplicate.torrent",
+          title: "Already queued",
+        })
+      ).resolves.toEqual({
+        success: true,
+        id: "existing-hash",
+        message: "Download already exists (qBittorrent)",
+      });
+
+      // The correlation tag is removed from the pre-existing torrent too,
+      // not just on the freshly-added path.
+      expect(makeRequestSpy).toHaveBeenCalledTimes(3);
+      const addCallBody = String(makeRequestSpy.mock.calls[0][2]);
+      const addTagMatch = addCallBody.match(/tags=(questarr-add-[^&]+)/);
+      expect(addTagMatch).not.toBeNull();
+      const addTag = addTagMatch![1];
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(
+        3,
+        "POST",
+        "/api/v2/torrents/removeTags",
+        `hashes=existing-hash&tags=${encodeURIComponent(addTag)}`,
+        expect.any(Object)
+      );
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("resolves the hash when qBittorrent v5+ accepts a URL add asynchronously", async () => {
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
       callback: TimerHandler,
@@ -569,56 +644,77 @@ describe("qbittorrent regression coverage", () => {
       return 0 as unknown as ReturnType<typeof setTimeout>;
     }) as typeof setTimeout);
 
-    const client = new QBittorrentClient(createDownloader());
-    const privateClient = client as unknown as {
-      authenticate(force?: boolean): Promise<void>;
-      makeRequest(
-        method: string,
-        path: string,
-        body?: string | Buffer,
-        additionalHeaders?: Record<string, string>
-      ): Promise<Response>;
-    };
+    try {
+      const client = new QBittorrentClient(createDownloader());
+      const privateClient = client as unknown as {
+        authenticate(force?: boolean): Promise<void>;
+        makeRequest(
+          method: string,
+          path: string,
+          body?: string | Buffer,
+          additionalHeaders?: Record<string, string>
+        ): Promise<Response>;
+      };
 
-    vi.spyOn(privateClient, "authenticate").mockResolvedValue(undefined);
-    vi.spyOn(privateClient, "makeRequest")
-      // qBittorrent >= 5.1 answers URL adds with HTTP 202 and JSON. The torrent
-      // file still has to be fetched, so added_torrent_ids is empty here.
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 202,
-        text: async () =>
-          JSON.stringify({
-            added_torrent_ids: [],
-            failure_count: 0,
-            pending_count: 1,
-            success_count: 0,
-          }),
-        headers: jsonHeaders,
-      } as unknown as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [
-          {
-            hash: "async-hash",
-            name: "Queued via URL",
-            added_on: Math.floor(Date.now() / 1000),
-          },
-        ],
-      } as Response);
+      vi.spyOn(privateClient, "authenticate").mockResolvedValue(undefined);
+      const makeRequestSpy = vi
+        .spyOn(privateClient, "makeRequest")
+        // qBittorrent >= 5.1 answers URL adds with HTTP 202 and JSON. The torrent
+        // file still has to be fetched, so added_torrent_ids is empty here.
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 202,
+          text: async () =>
+            JSON.stringify({
+              added_torrent_ids: [],
+              failure_count: 0,
+              pending_count: 1,
+              success_count: 0,
+            }),
+          headers: jsonHeaders,
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [
+            {
+              hash: "async-hash",
+              name: "Queued via URL",
+              added_on: Math.floor(Date.now() / 1000),
+            },
+          ],
+        } as Response)
+        .mockResolvedValueOnce({ ok: true, status: 200, text: async () => "" } as Response);
 
-    await expect(
-      client.addDownload({
-        url: "http://indexer.local/pending.torrent",
-        title: "Queued via URL",
-      })
-    ).resolves.toEqual({
-      success: true,
-      id: "async-hash",
-      message: "Download queued in qBittorrent",
-    });
+      await expect(
+        client.addDownload({
+          url: "http://indexer.local/pending.torrent",
+          title: "Queued via URL",
+        })
+      ).resolves.toEqual({
+        success: true,
+        id: "async-hash",
+        message: "Download queued in qBittorrent",
+      });
 
-    setTimeoutSpy.mockRestore();
+      // The initial add is tagged, and the poll looks the torrent up by that exact
+      // same tag rather than by fuzzy title/recency matching, so a concurrent add
+      // can't be mistaken for this one.
+      const addCallBody = String(makeRequestSpy.mock.calls[0][2]);
+      const addTagMatch = addCallBody.match(/tags=(questarr-add-[^&]+)/);
+      expect(addTagMatch).not.toBeNull();
+      const addTag = addTagMatch![1];
+
+      const pollCallPath = String(makeRequestSpy.mock.calls[1][1]);
+      expect(pollCallPath).toBe(`/api/v2/torrents/info?tag=${encodeURIComponent(addTag)}`);
+
+      // Cleanup removes that exact same tag from the resolved torrent.
+      const cleanupCallPath = String(makeRequestSpy.mock.calls[2][1]);
+      const cleanupCallBody = String(makeRequestSpy.mock.calls[2][2]);
+      expect(cleanupCallPath).toBe("/api/v2/torrents/removeTags");
+      expect(cleanupCallBody).toBe(`hashes=async-hash&tags=${encodeURIComponent(addTag)}`);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 
   it("uses added_torrent_ids when qBittorrent v5+ adds a torrent immediately", async () => {
@@ -634,18 +730,21 @@ describe("qbittorrent regression coverage", () => {
     };
 
     vi.spyOn(privateClient, "authenticate").mockResolvedValue(undefined);
-    const makeRequestSpy = vi.spyOn(privateClient, "makeRequest").mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      text: async () =>
-        JSON.stringify({
-          added_torrent_ids: ["immediate-hash"],
-          failure_count: 0,
-          pending_count: 0,
-          success_count: 1,
-        }),
-      headers: jsonHeaders,
-    } as unknown as Response);
+    const makeRequestSpy = vi
+      .spyOn(privateClient, "makeRequest")
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            added_torrent_ids: ["immediate-hash"],
+            failure_count: 0,
+            pending_count: 0,
+            success_count: 1,
+          }),
+        headers: jsonHeaders,
+      } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, text: async () => "" } as Response);
 
     await expect(
       client.addDownload({
@@ -658,8 +757,82 @@ describe("qbittorrent regression coverage", () => {
       message: "Download added successfully",
     });
 
-    // No polling needed when the hash is already known.
-    expect(makeRequestSpy).toHaveBeenCalledTimes(1);
+    // No polling needed when the hash is already known; the only extra call
+    // is removing the exact correlation tag that was set on the add request.
+    expect(makeRequestSpy).toHaveBeenCalledTimes(2);
+    const addCallBody = String(makeRequestSpy.mock.calls[0][2]);
+    const addTagMatch = addCallBody.match(/tags=(questarr-add-[^&]+)/);
+    expect(addTagMatch).not.toBeNull();
+    const addTag = addTagMatch![1];
+
+    expect(makeRequestSpy).toHaveBeenNthCalledWith(
+      2,
+      "POST",
+      "/api/v2/torrents/removeTags",
+      `hashes=immediate-hash&tags=${encodeURIComponent(addTag)}`,
+      expect.any(Object)
+    );
+  });
+
+  it("still reports success without falling back to upload when hash polling fails", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      callback: TimerHandler,
+      _delay?: number,
+      ...args: unknown[]
+    ) => {
+      if (typeof callback === "function") {
+        callback(...args);
+      }
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout);
+
+    try {
+      const client = new QBittorrentClient(createDownloader());
+      const privateClient = client as unknown as {
+        authenticate(force?: boolean): Promise<void>;
+        makeRequest(
+          method: string,
+          path: string,
+          body?: string | Buffer,
+          additionalHeaders?: Record<string, string>
+        ): Promise<Response>;
+      };
+
+      vi.spyOn(privateClient, "authenticate").mockResolvedValue(undefined);
+      const makeRequestSpy = vi
+        .spyOn(privateClient, "makeRequest")
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 202,
+          text: async () =>
+            JSON.stringify({
+              added_torrent_ids: [],
+              failure_count: 0,
+              pending_count: 1,
+              success_count: 0,
+            }),
+          headers: jsonHeaders,
+        } as unknown as Response)
+        // Every polling request fails; this must not fall through to the
+        // torrent-file upload fallback (that would resubmit an already-accepted
+        // download). It should still report success without a hash.
+        .mockRejectedValue(new Error("network unreachable"));
+
+      await expect(
+        client.addDownload({
+          url: "http://indexer.local/flaky-poll.torrent",
+          title: "Queued via URL",
+        })
+      ).resolves.toEqual({
+        success: true,
+        message: "Download queued in qBittorrent",
+      });
+
+      // 1 add request + 10 failed polling attempts, no upload fallback request.
+      expect(makeRequestSpy).toHaveBeenCalledTimes(11);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 
   it("covers torrent-download failure, free-space fallbacks, and request error branches", async () => {

--- a/server/__tests__/qbittorrent_features.test.ts
+++ b/server/__tests__/qbittorrent_features.test.ts
@@ -136,9 +136,13 @@ describe("QBittorrentClient - Advanced Features", () => {
       "http://tracker.example.com/download/123.torrent"
     );
 
-    // Verify info call (recently added)
+    // Verify info call (recently added) is correlated by the exact unique tag
+    // that was set on the add request, not just a matching prefix.
+    const addTagMatch = decodeURIComponent(urlAddBody).match(/tags=(questarr-add-[^&]+)/);
+    expect(addTagMatch).not.toBeNull();
+    const addTag = addTagMatch![1];
     expect(fetchMock.mock.calls[2][0]).toBe(
-      "http://localhost:8080/api/v2/torrents/info?sort=added_on&reverse=true"
+      `http://localhost:8080/api/v2/torrents/info?tag=${encodeURIComponent(addTag)}`
     );
 
     expect(result.success).toBe(true);

--- a/server/downloaders/qbittorrent.ts
+++ b/server/downloaders/qbittorrent.ts
@@ -6,6 +6,7 @@ import type {
   DownloadDetails,
 } from "../../shared/schema.js";
 import { downloadersLogger } from "../logger.js";
+import { randomUUID } from "node:crypto";
 import parseTorrent from "parse-torrent";
 import { isSafeUrl } from "../ssrf.js";
 import type { DownloadRequest, DownloaderClient } from "./types.js";
@@ -116,6 +117,21 @@ export class QBittorrentClient implements DownloaderClient {
       const pausedValue =
         qbSettings.initialState === "stopped" || this.downloader.addStopped ? "true" : "false";
 
+      const removeCorrelationTag = async (hash: string, tag: string) => {
+        try {
+          await this.makeRequest(
+            "POST",
+            "/api/v2/torrents/removeTags",
+            `hashes=${hash}&tags=${encodeURIComponent(tag)}`,
+            {
+              "Content-Type": "application/x-www-form-urlencoded",
+            }
+          );
+        } catch (error) {
+          downloadersLogger.warn({ hash, tag, error }, "Failed to remove correlation tag");
+        }
+      };
+
       const maybeSetForceStarted = async (hash: string) => {
         if (qbSettings.initialState !== "force-started") return;
         try {
@@ -139,12 +155,32 @@ export class QBittorrentClient implements DownloaderClient {
         added_on: number;
       }
 
-      const findRecentlyAddedDownload = async (): Promise<{
+      const findRecentlyAddedDownload = async (
+        options: { skipInitialWait?: boolean; correlationTag?: string } = {}
+      ): Promise<{
         hash: string;
         name?: string;
       } | null> => {
-        // Wait a bit for qBittorrent to process the add (URL add or torrent upload)
-        await new Promise((resolve) => setTimeout(resolve, 2000));
+        // Wait a bit for qBittorrent to process the add (URL add or torrent upload).
+        // Callers that already pace their own waits between attempts (e.g. a
+        // retry loop) can skip this to avoid stacking an extra delay on top.
+        if (!options.skipInitialWait) {
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+        }
+
+        // When the caller tagged this specific add request, qBittorrent's
+        // tag filter gives an exact match instead of guessing by title/recency,
+        // which matters most here since polling can now span several seconds
+        // during which other downloads may also be added.
+        if (options.correlationTag) {
+          const taggedResponse = await this.makeRequest(
+            "GET",
+            `/api/v2/torrents/info?tag=${encodeURIComponent(options.correlationTag)}`
+          );
+          const tagged = (await taggedResponse.json()) as QBittorrentTorrent[];
+          const match = tagged[0];
+          return match?.hash ? { hash: match.hash, name: match.name } : null;
+        }
 
         const allTorrentsResponse = await this.makeRequest(
           "GET",
@@ -212,11 +248,15 @@ export class QBittorrentClient implements DownloaderClient {
         // Prowlarr to redirect to a wrong or broken torrent/magnet.
         // For magnet links this is a no-op.
         const urlToAdd = isMagnet ? request.url : fixNzbUrlEncoding(request.url);
+        // Unique tag for this specific add request, so a delayed/async add can be
+        // correlated by an exact match instead of guessing by title or recency.
+        const correlationTag = `questarr-add-${randomUUID()}`;
         const params = new URLSearchParams();
         params.set("urls", urlToAdd);
         if (savepath) params.set("savepath", savepath);
         if (category) params.set("category", category);
         params.set("paused", pausedValue);
+        params.set("tags", correlationTag);
 
         downloadersLogger.info(
           { url: urlToAdd, isMagnet, savepath, category, paused: pausedValue },
@@ -266,19 +306,31 @@ export class QBittorrentClient implements DownloaderClient {
 
               // A pending URL add means qBittorrent still has to fetch the
               // .torrent itself, so added_torrent_ids is empty at this point.
-              // Without a hash the caller cannot link the download to a game
-              // (see routes.ts: `result.id` guard), so poll for it briefly.
+              // Callers need this hash to associate the download with a
+              // tracked game, so poll briefly for it to appear.
               let resolvedHash = parsed.added_torrent_ids?.[0];
               if (!resolvedHash) {
-                for (let attempt = 0; attempt < 10 && !resolvedHash; attempt++) {
+                const maxAttempts = 10;
+                for (let attempt = 0; attempt < maxAttempts && !resolvedHash; attempt++) {
                   await new Promise((resolve) => setTimeout(resolve, 1000));
-                  const recent = await findRecentlyAddedDownload();
-                  if (recent?.hash) resolvedHash = recent.hash;
+                  try {
+                    const recent = await findRecentlyAddedDownload({
+                      skipInitialWait: true,
+                      correlationTag,
+                    });
+                    if (recent?.hash) resolvedHash = recent.hash;
+                  } catch (error) {
+                    downloadersLogger.warn(
+                      { error, url: request.url },
+                      "Failed to poll qBittorrent for the newly added torrent; will retry"
+                    );
+                  }
                 }
               }
 
               if (resolvedHash) {
                 await maybeSetForceStarted(resolvedHash);
+                await removeCorrelationTag(resolvedHash, correlationTag);
               } else {
                 downloadersLogger.warn(
                   { url: request.url, title: request.title },
@@ -328,6 +380,7 @@ export class QBittorrentClient implements DownloaderClient {
 
             if (downloads && downloads.length > 0) {
               if (urlAddFails) {
+                await removeCorrelationTag(hashFromUrl, correlationTag);
                 return {
                   success: true,
                   id: hashFromUrl,
@@ -336,6 +389,7 @@ export class QBittorrentClient implements DownloaderClient {
               }
 
               await maybeSetForceStarted(hashFromUrl);
+              await removeCorrelationTag(hashFromUrl, correlationTag);
               return {
                 success: true,
                 id: hashFromUrl,
@@ -352,10 +406,12 @@ export class QBittorrentClient implements DownloaderClient {
               };
             }
           } else {
-            // For non-magnets, we can't verify by hash. Try to find the newly added item.
-            const recent = await findRecentlyAddedDownload();
+            // For non-magnets, we can't verify by hash. Try to find the newly added item,
+            // correlated by the unique tag on this add request.
+            const recent = await findRecentlyAddedDownload({ correlationTag });
             if (recent) {
               if (urlAddFails) {
+                await removeCorrelationTag(recent.hash, correlationTag);
                 return {
                   success: true,
                   id: recent.hash,
@@ -364,6 +420,7 @@ export class QBittorrentClient implements DownloaderClient {
               }
 
               await maybeSetForceStarted(recent.hash);
+              await removeCorrelationTag(recent.hash, correlationTag);
               return {
                 success: true,
                 id: recent.hash,


### PR DESCRIPTION
## Context

#823 (by @BastianLo) fixed qBittorrent v5+ downloads not being tracked and has been merged — thank you for the contribution! CodeRabbit and manual review left several follow-up comments on that PR that hadn't been addressed yet. This PR picks those up as a clean follow-on now that #823 is in `main`.

## What this fixes

- **Concurrent-add correlation**: the hash-resolution polling loop could span several seconds, during which `findRecentlyAddedDownload()`'s fuzzy title/recency matching could latch onto a different, concurrently-added torrent. Each URL add now gets a unique `questarr-add-*` tag; the poll resolves the hash via an exact tag match instead of guessing, and the tag is removed once resolved.
- **Timing bug**: `findRecentlyAddedDownload()` already sleeps 2s internally before its request. The original retry loop added its own 1s wait on top, making each attempt ~3s (not 1s) and the full loop ~30s (not the documented ~10s) — long enough to risk tripping reverse-proxy/frontend timeouts on the add request itself. Added a `skipInitialWait` option so the loop's own pacing isn't stacked on top of the helper's.
- **Error handling**: errors from the polling loop are now caught locally instead of escaping to the outer JSON-parse `catch`, which previously would fall through to re-uploading the torrent file for an add qBittorrent had already accepted.
- **Comment cleanup**: reworded a comment to state the invariant directly instead of pointing at `routes.ts`'s specific guard.
- **Test hygiene**: the mocked global `setTimeout` is now always restored via `try/finally`, and new regression tests cover the failed-polling and tag-cleanup paths with exact-tag assertions (not just prefix matches).

## Tests

`server/__tests__/downloaders_qbittorrent_regression.test.ts` and `server/__tests__/qbittorrent_features.test.ts` — full suite passes (1353 tests), `npm run check`, ESLint, and Prettier are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved qBittorrent URL-based torrent additions by recognizing immediately returned torrent IDs.
  - Added more reliable tracking for torrents queued asynchronously.
  - Uses unique correlation tags to identify the correct torrent and removes them after processing.
  - Applies force-start behavior once the torrent is identified.
  - Prevents upload fallback when qBittorrent accepts a download but tracking information is temporarily unavailable.
- **Tests**
  - Added regression coverage for immediate success, delayed hash discovery, tag-based tracking, cleanup, and polling failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->