### PR TITLE
Remove .github/wiki git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".github/wiki"]
-	path = .github/wiki
-	url = git@github.com:Doezer/Questarr.wiki.git


### PR DESCRIPTION
## Summary
- Removed the `.github/wiki` git submodule and its `.gitmodules` entry
- The submodule pointed at an SSH URL (`git@github.com:Doezer/Questarr.wiki.git`), which fails for clients (like Home Assistant) that clone the repo over HTTPS without SSH credentials configured

## Test plan
- [x] `git status` clean after removal, no leftover submodule references in `.github/workflows/`

Fixes #843


---
_Generated by [Claude Code](https://claude.ai/code/session_014UcXS1syYjUgAMgQvYN1y3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the obsolete wiki integration from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->