### PR TITLE
Stop logging idle download-status ticks so support logs don't evict real errors

### DIFF
--- a/server/cron.ts
+++ b/server/cron.ts
@@ -535,11 +535,11 @@ export async function checkGameUpdates() {
 export async function checkDownloadStatus() {
   const downloadingDownloads = await storage.getDownloadingGameDownloads();
 
-  igdbLogger.info({ downloadingCount: downloadingDownloads.length }, "Checking download status");
-
   if (downloadingDownloads.length === 0) {
     return;
   }
+
+  igdbLogger.info({ downloadingCount: downloadingDownloads.length }, "Checking download status");
 
   // Prune stale entries from downloadMissCount (e.g. downloads removed from DB while still downloading)
   const activeDownloadIds = new Set(downloadingDownloads.map((d) => d.id));


### PR DESCRIPTION
## Summary

Investigated why the support log attached to #802 (bsdtar re-test, [Questarr-logs#19](https://github.com/Doezer/questarr-logs/issues/19)) shows nothing useful — 186 straight lines of `"Checking download status"` / `"downloadingCount":0` spanning 03:35–06:41 UTC, and no import/extraction/error output at all.

**Root cause:** `checkDownloadStatus()` in `server/cron.ts` runs every 60 seconds (`DOWNLOAD_CHECK_INTERVAL_MS`) and unconditionally logged `"Checking download status"` at info level, even when there was nothing to check. `GET /api/logs` (used to build the support log) only returns the last 200 lines of `server.log` by default (`readLastLogLines`). At one heartbeat line per minute, that's just ~3.3 hours before the idle heartbeat alone fills the entire capture window and evicts everything before it — including whatever actually happened when the download completed and import/extraction ran overnight.

This means the support-log tool has effectively been useless for diagnosing anything that occurred more than ~3 hours before the log was pulled, which is exactly the failure mode blocking progress on #802: the reporter tests, the download finishes overnight, and by the time they grab logs in the morning the real evidence is long gone.

* **`server/cron.ts`** — move the `"Checking download status"` log line after the early-return for zero active downloads, so it only logs when there's actually something being tracked. Idle ticks (the overwhelming majority of the time on a self-hosted instance) no longer write anything.

## Test plan

- [x] `npx vitest run server/__tests__/cron_download_status.test.ts` — 8/8 passing
- [x] `npm run check` — clean
- [ ] Verify in the field that the next support log pulled for #802 retains useful history around the actual import/extraction attempt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTGVELAP495cMWBA836Rsr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status logging when no downloads are currently in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->