### PR TITLE
Fix NZBGet category not applied when starting a download

### DIFF
--- a/server/__tests__/downloaders_comprehensive.test.ts
+++ b/server/__tests__/downloaders_comprehensive.test.ts
@@ -698,6 +698,36 @@ describe("Downloader Comprehensive Tests", () => {
       expect(result.success).toBe(false);
       expect(result.message).toContain("Failed to fetch NZB");
     });
+
+    it("should fall back to the downloader's configured category when the request has none", async () => {
+      const downloaderWithCategory: Downloader = { ...downloader, category: "questarr" };
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        text: async () => "nzb content",
+      });
+
+      const xmlResponse = `
+        <?xml version="1.0"?>
+        <methodResponse>
+          <params><param><value><i4>456</i4></value></param></params>
+        </methodResponse>
+      `;
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        text: async () => xmlResponse,
+      });
+
+      const result = await DownloaderManager.addDownload(downloaderWithCategory, {
+        url: "http://example.com/test.nzb",
+        title: "Test NZB",
+        downloadType: "usenet",
+      });
+
+      expect(result.success).toBe(true);
+      expect(fetchMock.mock.calls[1][1].body).toContain("<string>questarr</string>");
+    });
   });
 
   // ==================== addDownloadWithFallback Tests ====================

--- a/server/downloaders/nzbget.ts
+++ b/server/downloaders/nzbget.ts
@@ -288,10 +288,12 @@ export class NZBGetClient implements DownloaderClient {
       const nzbContent = await nzbResponse.text();
       const base64Content = Buffer.from(nzbContent).toString("base64");
 
+      const category = request.category || this.downloader.category || "";
+
       const nzbId = (await this.makeXMLRPCRequest("append", [
         request.title || "download.nzb",
         base64Content,
-        request.category || "",
+        category,
         request.priority || 0,
         false, // AddToTop
         false, // AddPaused


### PR DESCRIPTION
## Description

`NZBGetClient.addDownload` (`server/downloaders/nzbget.ts`) only used `request.category` when building the XML-RPC `append` call, unlike every other downloader client (qBittorrent, Transmission, Deluge, rTorrent), which all fall back to the downloader's configured category via `request.category || this.downloader.category`. As a result, the configured "questarr" category was never applied to NZBGet downloads unless a caller happened to pass a category explicitly on the request.

Fixes #832.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


---
_Generated by [Claude Code](https://claude.ai/code/session_01QFirr1b1bWWpTj3nK3GvNx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NZBGet downloads now use the downloader’s configured category when no category is specified in the request.
  * Requests without either category continue to work without adding a category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->