### PR TITLE
Fix NZBGet completed downloads reported as aborted

### DIFF
--- a/server/__tests__/downloaders_nzbget_remaining.test.ts
+++ b/server/__tests__/downloaders_nzbget_remaining.test.ts
@@ -202,6 +202,64 @@ describe("NZBGet remaining coverage", () => {
     await expect(privateClient.getFromHistory("6")).resolves.toBeNull();
   });
 
+  it.each(["SUCCESS/GOOD", "SUCCESS/UNPACK", "SUCCESS/HEALTH", "SUCCESS/ALL"])(
+    "treats history status %s as completed",
+    async (historyStatus) => {
+      const client = new NZBGetClient(createDownloader());
+      const privateClient = client as unknown as {
+        makeXMLRPCRequest: (method: string, params?: unknown[]) => Promise<unknown>;
+        getFromHistory: (id: string) => Promise<unknown>;
+      };
+      vi.spyOn(privateClient, "makeXMLRPCRequest").mockResolvedValueOnce([
+        {
+          NZBID: 7,
+          Name: "Finished Game",
+          Status: historyStatus,
+          FileSizeMB: 20,
+          Category: "games",
+          DownloadTimeSec: 90,
+          ParStatus: "NONE",
+          UnpackStatus: "NONE",
+          FailedArticles: 0,
+          DeleteStatus: "NONE",
+          DestDir: "/downloads",
+        },
+      ]);
+
+      await expect(privateClient.getFromHistory("7")).resolves.toMatchObject({
+        status: "completed",
+        progress: 100,
+      });
+    }
+  );
+
+  it("does not treat an unrelated overall status as completed", async () => {
+    const client = new NZBGetClient(createDownloader());
+    const privateClient = client as unknown as {
+      makeXMLRPCRequest: (method: string, params?: unknown[]) => Promise<unknown>;
+      getFromHistory: (id: string) => Promise<unknown>;
+    };
+    vi.spyOn(privateClient, "makeXMLRPCRequest").mockResolvedValueOnce([
+      {
+        NZBID: 8,
+        Name: "Unknown Status Game",
+        Status: "SUCCESSFUL/NOTAREALSTATUS",
+        FileSizeMB: 20,
+        Category: "games",
+        DownloadTimeSec: 90,
+        ParStatus: "NONE",
+        UnpackStatus: "NONE",
+        FailedArticles: 0,
+        DeleteStatus: "NONE",
+        DestDir: "/downloads",
+      },
+    ]);
+
+    await expect(privateClient.getFromHistory("8")).resolves.toMatchObject({
+      status: "error",
+    });
+  });
+
   it("covers detail and queue error fallbacks", async () => {
     const client = new NZBGetClient(createDownloader());
     const statusSpy = vi.spyOn(client, "getDownloadStatus");

--- a/server/downloaders/nzbget.ts
+++ b/server/downloaders/nzbget.ts
@@ -410,7 +410,7 @@ export class NZBGetClient implements DownloaderClient {
       // (e.g. "SUCCESS/ALL", "SUCCESS/GOOD", "SUCCESS/UNPACK", "SUCCESS/HEALTH",
       // "SUCCESS/COPY", "SUCCESS/MARK"). Matching only "SUCCESS/ALL" caused
       // legitimately completed downloads to be reported as failed/aborted.
-      if (item.Status.startsWith("SUCCESS")) {
+      if (item.Status.startsWith("SUCCESS/")) {
         status = "completed";
         repairStatus =
           item.ParStatus === "SUCCESS" || item.ParStatus === "NONE" ? "good" : "failed";

--- a/server/downloaders/nzbget.ts
+++ b/server/downloaders/nzbget.ts
@@ -405,7 +405,12 @@ export class NZBGetClient implements DownloaderClient {
       let repairStatus: DownloadStatus["repairStatus"];
       let unpackStatus: DownloadStatus["unpackStatus"];
 
-      if (item.Status === "SUCCESS/ALL") {
+      // NZBGet's history Status field is "<overall>/<detail>", where the detail
+      // suffix varies depending on which post-processing step it last reflects
+      // (e.g. "SUCCESS/ALL", "SUCCESS/GOOD", "SUCCESS/UNPACK", "SUCCESS/HEALTH",
+      // "SUCCESS/COPY", "SUCCESS/MARK"). Matching only "SUCCESS/ALL" caused
+      // legitimately completed downloads to be reported as failed/aborted.
+      if (item.Status.startsWith("SUCCESS")) {
         status = "completed";
         repairStatus =
           item.ParStatus === "SUCCESS" || item.ParStatus === "NONE" ? "good" : "failed";


### PR DESCRIPTION
## Description

NZBGet's history `Status` field is `<overall>/<detail>`, where the detail suffix varies depending on config and which post-processing step it last reflects (e.g. `SUCCESS/GOOD`, `SUCCESS/UNPACK`, `SUCCESS/HEALTH`, `SUCCESS/COPY`, `SUCCESS/MARK`, `SUCCESS/ALL`). `server/downloaders/nzbget.ts`'s `getFromHistory()` only recognized the exact string `SUCCESS/ALL` as a completed download, so any other successful status fell through to the `error` branch. `server/cron.ts` then reported these as failed with the message "Aborted by downloader (no details provided)", even though NZBGet had completed the download successfully.

Fixes #836.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [x] I have added tests that prove my fix is effective or that my feature works (existing NZBGet history tests in `server/__tests__/downloaders_clients_regression.test.ts` and `server/__tests__/downloaders_nzbget_remaining.test.ts` cover the success path)
- [x] New and existing unit tests pass locally with my changes

## Test plan

- `npx vitest run server/__tests__/downloaders_nzbget_remaining.test.ts server/__tests__/downloaders_clients_regression.test.ts server/__tests__/downloaders_comprehensive.test.ts` — 52 passed
- `npm run check` — clean
- `npx eslint server/downloaders/nzbget.ts` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_011GgdFiD9WkW44YfJqCu8j6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download completion detection for successful NZBGet jobs, including jobs with additional post-processing status details.
  * Prevented unrelated NZBGet statuses from being incorrectly reported as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->