### PR TITLE
Fix 500 error importing single-file torrent downloads

### DIFF
--- a/server/__tests__/import_manager_additional.test.ts
+++ b/server/__tests__/import_manager_additional.test.ts
@@ -206,6 +206,57 @@ describe("ImportManager - planConfirmImport", () => {
     planSpy.mockRestore();
   });
 
+  it("uses the single file's own name, not the torrent name, when there's no subfolder", async () => {
+    const storage = makeStorage();
+    storage.getGameDownload.mockResolvedValue({
+      id: "dl-1",
+      gameId: "g1",
+      downloaderId: "d1",
+      downloadHash: "abc123",
+    });
+    storage.getGame.mockResolvedValue({
+      id: "g1",
+      title: "NAS Game",
+      userId: "u1",
+      status: "wanted",
+      platforms: [],
+    });
+    storage.getImportConfig.mockResolvedValue(makeImportConfig({ libraryRoot: "/games" }));
+    storage.getDownloader.mockResolvedValue({
+      id: "d1",
+      name: "qBit",
+      url: "http://nas.local:8080",
+    });
+    // qBittorrent dropped the single file directly into the category dir —
+    // no subfolder named after the torrent's display name exists.
+    downloadersMock.getDownloadDetails.mockResolvedValue({
+      downloadDir: "/remote/downloads",
+      name: "NAS.Game-GROUP",
+      files: [{ name: "NAS.Game-GROUP.iso" }],
+    });
+
+    const pathService = {
+      translatePath: vi.fn().mockResolvedValue("/local/downloads/NAS.Game-GROUP.iso"),
+    };
+    const planSpy = vi.spyOn(PCImportStrategy.prototype, "planImport").mockResolvedValue({
+      needsReview: false,
+      strategy: "pc",
+      originalPath: "/local/downloads/NAS.Game-GROUP.iso",
+      proposedPath: "/games/PC/NAS Game.iso",
+    });
+
+    const manager = makeManager(storage, { pathService });
+    const result = await manager.planConfirmImport("dl-1");
+
+    expect(result.originalPath).toBe("/local/downloads/NAS.Game-GROUP.iso");
+    expect(pathService.translatePath).toHaveBeenCalledWith(
+      "/remote/downloads/NAS.Game-GROUP.iso",
+      "nas.local"
+    );
+
+    planSpy.mockRestore();
+  });
+
   it("returns null originalPath when getDownloadDetails returns no downloadDir", async () => {
     const storage = makeStorage();
     storage.getGameDownload.mockResolvedValue({

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -3,6 +3,7 @@ import { igdbClient, IGDB_EARLY_ACCESS_STATUS } from "./igdb.js";
 import { igdbLogger } from "./logger.js";
 import { notifyUser } from "./socket.js";
 import { DownloaderManager } from "./downloaders.js";
+import { resolveDownloadRelativePath } from "./downloaders/utils.js";
 import { torznabClient } from "./torznab.js";
 import { newznabClient } from "./newznab.js";
 import { searchAllIndexers, filterBlacklistedReleases, type SearchItem } from "./search.js";
@@ -641,7 +642,10 @@ export async function checkDownloadStatus() {
                 download.downloadHash
               );
               if (details?.downloadDir) {
-                const remoteImportPath = buildRemoteImportPath(details.downloadDir, details.name);
+                const remoteImportPath = buildRemoteImportPath(
+                  details.downloadDir,
+                  resolveDownloadRelativePath(details)
+                );
                 try {
                   await importManager.processImport(download.id, remoteImportPath);
                 } catch (error) {

--- a/server/downloaders/utils.ts
+++ b/server/downloaders/utils.ts
@@ -1,5 +1,6 @@
 import { downloadersLogger } from "../logger.js";
 import { isSafeUrl, safeFetch } from "../ssrf.js";
+import type { DownloadFile } from "../../shared/schema.js";
 
 export const DOWNLOAD_CLIENT_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";
@@ -130,4 +131,24 @@ export async function fetchWithMagnetDetection(
   }
 
   throw new Error(`Too many redirects (max ${maxRedirects})`);
+}
+
+/**
+ * Resolves the path segment (relative to a download's downloadDir) that
+ * actually holds its content on disk.
+ *
+ * Torrent clients only create a subfolder named after the torrent for
+ * multi-file torrents. A single-file torrent (with "original" content
+ * layout) is saved directly in downloadDir under its own filename, which
+ * can differ from the torrent's display name — using the torrent name in
+ * that case points at a subfolder that never existed.
+ */
+export function resolveDownloadRelativePath(details: {
+  name: string;
+  files?: DownloadFile[];
+}): string {
+  if (details.files?.length === 1 && details.files[0].name) {
+    return details.files[0].name;
+  }
+  return details.name;
 }

--- a/server/downloaders/utils.ts
+++ b/server/downloaders/utils.ts
@@ -1,6 +1,6 @@
 import { downloadersLogger } from "../logger.js";
 import { isSafeUrl, safeFetch } from "../ssrf.js";
-import type { DownloadFile } from "../../shared/schema.js";
+import type { DownloadFile } from "@shared/schema.js";
 
 export const DOWNLOAD_CLIENT_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -469,9 +469,7 @@ importRouter.get("/:id/plan", async (req, res) => {
     if (error instanceof Error && error.message.includes("not found"))
       return res.status(404).json({ error: error.message });
     logger.error({ error }, "Error planning import");
-    res
-      .status(500)
-      .json({ error: error instanceof Error ? error.message : "Internal server error" });
+    res.status(500).json({ error: "Internal server error" });
   }
 });
 
@@ -525,8 +523,6 @@ importRouter.post("/:id/confirm", async (req, res) => {
       }
     }
     logger.error({ error }, "Error confirming import");
-    res
-      .status(500)
-      .json({ error: error instanceof Error ? error.message : "Internal server error" });
+    res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -469,7 +469,9 @@ importRouter.get("/:id/plan", async (req, res) => {
     if (error instanceof Error && error.message.includes("not found"))
       return res.status(404).json({ error: error.message });
     logger.error({ error }, "Error planning import");
-    res.status(500).json({ error: "Internal server error" });
+    res
+      .status(500)
+      .json({ error: error instanceof Error ? error.message : "Internal server error" });
   }
 });
 
@@ -523,6 +525,8 @@ importRouter.post("/:id/confirm", async (req, res) => {
       }
     }
     logger.error({ error }, "Error confirming import");
-    res.status(500).json({ error: "Internal server error" });
+    res
+      .status(500)
+      .json({ error: error instanceof Error ? error.message : "Internal server error" });
   }
 });

--- a/server/services/ImportManager.ts
+++ b/server/services/ImportManager.ts
@@ -9,6 +9,7 @@ import {
   sanitizeFsName,
 } from "./ImportStrategies.js";
 import { DownloaderManager } from "../downloaders.js";
+import { resolveDownloadRelativePath } from "../downloaders/utils.js";
 import fs from "fs-extra";
 import path from "node:path";
 import { parseReleaseMetadata } from "../../shared/title-utils.js";
@@ -457,7 +458,7 @@ export class ImportManager {
     const details = await DownloaderManager.getDownloadDetails(downloader, download.downloadHash);
     if (!details?.downloadDir) return undefined;
 
-    const remotePath = `${details.downloadDir}/${details.name}`;
+    const remotePath = `${details.downloadDir}/${resolveDownloadRelativePath(details)}`;
     const remoteHost = this.extractRemoteHost(downloader.url);
     return this.pathService.translatePath(remotePath, remoteHost);
   }


### PR DESCRIPTION
## Description

Fixes a 500 Internal Error when importing a completed qBittorrent download reported in #833. One of the two failure modes described there is addressed directly:

> The torrent has only one file and qbittorrent doesn't place it into a subfolder instead dropping it directly into the questarr category dir. The import tool cannot find any files since it is looking for a subdirectory equal to the name of the torrent

Torrent clients only create a subfolder named after the torrent for multi-file torrents. A single-file torrent saved with "original" content layout is dropped directly into the category directory under its own filename, which can differ from the torrent's display name (e.g. release-group naming quirks). Import path resolution assumed `downloadDir/<torrent display name>` always existed, so for these downloads it pointed at a path that never existed and the import failed.

Also improved: import failures now surface the actual underlying error message in the API response instead of a generic "Internal server error", so any remaining failure (e.g. the unpack failure also mentioned in the issue) is at least actionable/diagnosable instead of an opaque 500.

## Changes

- Added `resolveDownloadRelativePath()` in `server/downloaders/utils.ts`, which picks the actual file name from the download's file list when there is exactly one file, falling back to the torrent's display name otherwise (unchanged behavior for multi-file torrents).
- Used this helper in both the manual import-confirm flow (`ImportManager.resolveConfirmOriginalPath`) and the auto-import cron job (`cron.ts`).
- `server/routes/import.ts`: the `/plan` and `/confirm` endpoints now return the real error message on unexpected failures instead of a generic string.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (full suite: 2022 passed, 7 skipped)


---
_Generated by [Claude Code](https://claude.ai/code/session_01L8EWGgoNkPkcnSgFCkb5Kv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved importing for downloads containing a single file, ensuring the actual filename is used correctly.
  * Fixed source path resolution for confirmed downloads.
  * Improved error responses during import planning and confirmation by providing more specific messages when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->