### PR TITLE
Log failed login attempts (OWASP A09)

### DIFF
--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -31,6 +31,7 @@ import { torznabClient } from "../torznab.js";
 import { newznabClient } from "../newznab.js";
 import { rssService } from "../rss.js";
 import { comparePassword } from "../auth.js";
+import { routesLogger } from "../logger.js";
 import { db } from "../db.js";
 import { appriseClient } from "../apprise.js";
 import fsExtra from "fs-extra";
@@ -249,6 +250,20 @@ describe("API Routes - Extended Coverage", () => {
           .post("/api/auth/login")
           .send({ username: "testuser", password: "wrongpassword" });
         expect(res.status).toBe(401);
+      });
+
+      it("should log a warning with the trimmed username and IP on failed login", async () => {
+        vi.mocked(storage.getUserByUsername).mockResolvedValue(mockUserHashed);
+        vi.mocked(comparePassword).mockResolvedValue(false);
+
+        const res = await request(app)
+          .post("/api/auth/login")
+          .send({ username: "  testuser  ", password: "wrongpassword" });
+        expect(res.status).toBe(401);
+        expect(routesLogger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ username: "testuser", ip: expect.any(String) }),
+          "Failed login attempt"
+        );
       });
 
       it("should return 400 when username is missing", async () => {

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -79,6 +79,7 @@ describe("API Routes - Extended Coverage", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     app = express();
+    app.set("trust proxy", 1);
     app.use(express.json());
     await registerRoutes(app);
   });
@@ -258,10 +259,11 @@ describe("API Routes - Extended Coverage", () => {
 
         const res = await request(app)
           .post("/api/auth/login")
+          .set("X-Forwarded-For", "203.0.113.7")
           .send({ username: "  testuser  ", password: "wrongpassword" });
         expect(res.status).toBe(401);
         expect(routesLogger.warn).toHaveBeenCalledWith(
-          expect.objectContaining({ username: "testuser", ip: expect.any(String) }),
+          { username: "testuser", ip: "203.0.113.7" },
           "Failed login attempt"
         );
       });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -612,6 +612,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
 
     if (!user || !passwordMatches) {
+      routesLogger.warn({ username: trimmedUsername, ip: req.ip }, "Failed login attempt");
       return res.status(401).json({ error: "Invalid username or password" });
     }
 


### PR DESCRIPTION
## Summary

Follow-up from an OWASP Top 10:2025 review of Questarr. Most of the review's initial A01/A06 findings turned out to be false positives — `server/routes.ts:1063` already applies a blanket `app.use("/api", authenticateToken)` covering every route registered after it (indexers, downloaders, games, downloads, settings), so those endpoints were never actually unauthenticated. This PR addresses the one confirmed, actionable finding from the review:

- **A09 — Security Logging and Alerting Failures**: `/api/auth/login` failures were not logged anywhere, making credential-stuffing/brute-force activity undetectable even though rate limiting was already in place.

## Changes

- Log a `warn`-level entry (username, IP) on failed login attempts in `server/routes.ts`.

## Test plan

- [x] `tsc --noEmit` passes with no new errors
- [ ] Manual verification: attempt a login with a bad password and confirm a "Failed login attempt" warning appears in `server.log`


---
_Generated by [Claude Code](https://claude.ai/code/session_01CnewfcFwU31W9w5BWhU1Xk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved monitoring of failed login attempts by recording the trimmed submitted username and client IP address in warning logs.
  - The existing unauthorized response remains unchanged, so users continue to receive the same response when authentication fails.
  - Added coverage to verify that failed login details are logged consistently for troubleshooting and security monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->