### PR TITLE
Link download results to indexer sources

### DIFF
--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -111,6 +111,7 @@ type TorrentItemOverrides = {
   seeders?: number;
   leechers?: number;
   indexerName?: string;
+  comments?: string;
   group?: string;
   downloadVolumeFactor?: number;
   uploadVolumeFactor?: number;
@@ -138,6 +139,7 @@ const makeTorrentItem = (overrides: TorrentItemOverrides = {}) => ({
   seeders: overrides.seeders ?? 10,
   leechers: overrides.leechers ?? 2,
   indexerName: overrides.indexerName ?? "Indexer A",
+  ...(overrides.comments !== undefined && { comments: overrides.comments }),
   ...(overrides.group !== undefined && { group: overrides.group }),
   ...(overrides.downloadVolumeFactor !== undefined && {
     downloadVolumeFactor: overrides.downloadVolumeFactor,
@@ -287,6 +289,28 @@ describe("GameDownloadDialog", () => {
       { timeout: 3000 }
     );
   });
+
+  it.each([false, true])(
+    "links release titles to their indexer source when mobile is %s",
+    async (isMobile) => {
+      mockIsMobile = isMobile;
+      globalThis.fetch = createFetchMock({
+        search: makeSearchResult([
+          makeTorrentItem({
+            title: "Linked Release",
+            comments: "https://indexer.example/releases/123",
+          }),
+        ]),
+      });
+
+      renderComponent();
+
+      const link = await screen.findByRole("link", { name: "Linked Release" });
+      expect(link).toHaveAttribute("href", "https://indexer.example/releases/123");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  );
 
   it("identifies Usenet vs Torrent items", async () => {
     renderComponent();

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -1137,9 +1137,21 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                   <div className="flex items-start justify-between gap-2">
                                     <div className="flex-1 min-w-0">
                                       <div className="flex items-start gap-1.5 min-w-0">
-                                        <h4 className="font-semibold text-sm leading-snug break-all line-clamp-2 min-w-0 flex-1">
-                                          {download.title}
-                                        </h4>
+                                        {download.comments ? (
+                                          <a
+                                            href={download.comments}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="font-semibold text-sm leading-snug break-all line-clamp-2 min-w-0 flex-1 hover:underline cursor-pointer"
+                                            onClick={(event) => event.stopPropagation()}
+                                          >
+                                            {download.title}
+                                          </a>
+                                        ) : (
+                                          <h4 className="font-semibold text-sm leading-snug break-all line-clamp-2 min-w-0 flex-1">
+                                            {download.title}
+                                          </h4>
+                                        )}
                                         {isNew && (
                                           <Badge
                                             variant="default"
@@ -1241,9 +1253,21 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                     </TooltipContent>
                                   </Tooltip>
 
-                                  <h4 className="font-bold text-base leading-tight break-words min-w-0">
-                                    {download.title}
-                                  </h4>
+                                  {download.comments ? (
+                                    <a
+                                      href={download.comments}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="font-bold text-base leading-tight break-words min-w-0 hover:underline cursor-pointer"
+                                      onClick={(event) => event.stopPropagation()}
+                                    >
+                                      {download.title}
+                                    </a>
+                                  ) : (
+                                    <h4 className="font-bold text-base leading-tight break-words min-w-0">
+                                      {download.title}
+                                    </h4>
+                                  )}
 
                                   {isNew && (
                                     <Badge

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -1137,21 +1137,21 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                   <div className="flex items-start justify-between gap-2">
                                     <div className="flex-1 min-w-0">
                                       <div className="flex items-start gap-1.5 min-w-0">
-                                        {download.comments ? (
-                                          <a
-                                            href={download.comments}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="font-semibold text-sm leading-snug break-all line-clamp-2 min-w-0 flex-1 hover:underline cursor-pointer"
-                                            onClick={(event) => event.stopPropagation()}
-                                          >
-                                            {download.title}
-                                          </a>
-                                        ) : (
-                                          <h4 className="font-semibold text-sm leading-snug break-all line-clamp-2 min-w-0 flex-1">
-                                            {download.title}
-                                          </h4>
-                                        )}
+                                        <h4 className="font-semibold text-sm leading-snug break-all line-clamp-2 min-w-0 flex-1">
+                                          {download.comments ? (
+                                            <a
+                                              href={download.comments}
+                                              target="_blank"
+                                              rel="noopener noreferrer"
+                                              className="hover:underline cursor-pointer"
+                                              onClick={(event) => event.stopPropagation()}
+                                            >
+                                              {download.title}
+                                            </a>
+                                          ) : (
+                                            <span>{download.title}</span>
+                                          )}
+                                        </h4>
                                         {isNew && (
                                           <Badge
                                             variant="default"
@@ -1253,21 +1253,21 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                     </TooltipContent>
                                   </Tooltip>
 
-                                  {download.comments ? (
-                                    <a
-                                      href={download.comments}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="font-bold text-base leading-tight break-words min-w-0 hover:underline cursor-pointer"
-                                      onClick={(event) => event.stopPropagation()}
-                                    >
-                                      {download.title}
-                                    </a>
-                                  ) : (
-                                    <h4 className="font-bold text-base leading-tight break-words min-w-0">
-                                      {download.title}
-                                    </h4>
-                                  )}
+                                  <h4 className="font-bold text-base leading-tight break-words min-w-0">
+                                    {download.comments ? (
+                                      <a
+                                        href={download.comments}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="hover:underline cursor-pointer"
+                                        onClick={(event) => event.stopPropagation()}
+                                      >
+                                        {download.title}
+                                      </a>
+                                    ) : (
+                                      <span>{download.title}</span>
+                                    )}
+                                  </h4>
 
                                   {isNew && (
                                     <Badge


### PR DESCRIPTION
## Summary

- link release titles to the indexer source when a comments URL is available
- open source pages in a new tab with noopener/noreferrer protection
- keep plain text titles when no source URL exists
- cover both desktop and mobile result layouts

## Verification

- npx vitest run client/__tests__/GameDownloadDialog.test.tsx
- npm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release titles now link to available external comments or source pages.
  * Links open in a new browser tab with appropriate security protections.
  * Titles remain non-clickable when no link is available.
  * Works consistently across mobile and desktop views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->