### PR TITLE
Fallback when hardlinks are unsupported

### DIFF
--- a/server/__tests__/import_strategies.test.ts
+++ b/server/__tests__/import_strategies.test.ts
@@ -21,6 +21,7 @@ afterEach(async () => {
   for (const dir of cleanup.splice(0, cleanup.length)) {
     await fs.remove(dir);
   }
+  vi.restoreAllMocks();
 });
 
 describe("ImportStrategies", () => {
@@ -50,9 +51,6 @@ describe("ImportStrategies", () => {
       expect(result.modeUsed).toBe("copy");
       expect(copySpy).toHaveBeenCalled();
       expect(await fs.pathExists(destination)).toBe(true);
-
-      linkSpy.mockRestore();
-      copySpy.mockRestore();
     }
   );
 
@@ -134,8 +132,6 @@ describe("ImportStrategies", () => {
           "copy"
         )
       ).rejects.toThrow("write error");
-
-      copySpy.mockRestore();
     });
   });
 

--- a/server/__tests__/import_strategies.test.ts
+++ b/server/__tests__/import_strategies.test.ts
@@ -24,36 +24,37 @@ afterEach(async () => {
 });
 
 describe("ImportStrategies", () => {
-  it("falls back to copy when hardlink fails with EXDEV", async () => {
-    const root = tempDir();
-    const source = path.join(root, "downloads", "cross-device.rom");
-    const destination = path.join(root, "library", "PC", "cross-device.rom");
-    await fs.ensureDir(path.dirname(source));
-    await fs.writeFile(source, "rom-bytes");
+  it.each(["EXDEV", "EPERM", "EACCES", "ENOTSUP", "EOPNOTSUPP"])(
+    "falls back to copy when hardlink fails with %s",
+    async (code) => {
+      const root = tempDir();
+      const source = path.join(root, "downloads", "cross-device.rom");
+      const destination = path.join(root, "library", "PC", "cross-device.rom");
+      await fs.ensureDir(path.dirname(source));
+      await fs.writeFile(source, "rom-bytes");
 
-    const linkSpy = vi
-      .spyOn(fs, "link")
-      .mockRejectedValueOnce({ code: "EXDEV" } as NodeJS.ErrnoException);
-    const copySpy = vi.spyOn(fs, "copy");
+      const linkSpy = vi.spyOn(fs, "link").mockRejectedValueOnce({ code } as NodeJS.ErrnoException);
+      const copySpy = vi.spyOn(fs, "copy");
 
-    const strategy = new PCImportStrategy();
-    const result = await strategy.executeImport(
-      {
-        needsReview: false,
-        originalPath: source,
-        proposedPath: destination,
-        strategy: "pc",
-      },
-      "hardlink"
-    );
+      const strategy = new PCImportStrategy();
+      const result = await strategy.executeImport(
+        {
+          needsReview: false,
+          originalPath: source,
+          proposedPath: destination,
+          strategy: "pc",
+        },
+        "hardlink"
+      );
 
-    expect(result.modeUsed).toBe("copy");
-    expect(copySpy).toHaveBeenCalled();
-    expect(await fs.pathExists(destination)).toBe(true);
+      expect(result.modeUsed).toBe("copy");
+      expect(copySpy).toHaveBeenCalled();
+      expect(await fs.pathExists(destination)).toBe(true);
 
-    linkSpy.mockRestore();
-    copySpy.mockRestore();
-  });
+      linkSpy.mockRestore();
+      copySpy.mockRestore();
+    }
+  );
 
   // ---------------------------------------------------------------------------
   // PCImportStrategy.executeImport() — single file vs directory source

--- a/server/services/ImportStrategies.ts
+++ b/server/services/ImportStrategies.ts
@@ -85,7 +85,7 @@ async function transferFile(
     ) {
       logger.warn(
         { source, destination, code },
-        "[ImportStrategies] Hardlink not supported, falling back to copy"
+        "[ImportStrategies] Hardlink failed, falling back to copy"
       );
       await fs.copy(source, destination, { overwrite: true });
       return "copy";

--- a/server/services/ImportStrategies.ts
+++ b/server/services/ImportStrategies.ts
@@ -76,10 +76,16 @@ async function transferFile(
     return "hardlink";
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
-    if (code === "EXDEV") {
+    if (
+      code === "EXDEV" ||
+      code === "EPERM" ||
+      code === "EACCES" ||
+      code === "ENOTSUP" ||
+      code === "EOPNOTSUPP"
+    ) {
       logger.warn(
-        { source, destination },
-        "[ImportStrategies] Hardlink not supported across devices, falling back to copy"
+        { source, destination, code },
+        "[ImportStrategies] Hardlink not supported, falling back to copy"
       );
       await fs.copy(source, destination, { overwrite: true });
       return "copy";


### PR DESCRIPTION
## Summary

- fall back from hardlink to copy for permission and unsupported-operation errors in addition to cross-device errors
- retain unexpected hardlink failures as errors
- include the operating-system error code in fallback logs

Handled codes: EXDEV, EPERM, EACCES, ENOTSUP, EOPNOTSUPP.

## Verification

- npx vitest run server/__tests__/import_strategies.test.ts
- npm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file importing when hardlinking is unavailable or denied.
  * Importing now falls back to copying files for a wider range of system errors, ensuring the destination is still created successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->