### PR TITLE
Avoid release notifications for already-released games

### DIFF
--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -525,6 +525,86 @@ describe("API Routes - Extended Coverage", () => {
       );
     });
 
+    it("does not mark a game releasing in the future as released", async () => {
+      const tomorrow = new Date();
+      tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+      const futureDate = tomorrow.toISOString().split("T")[0];
+
+      const newGame = {
+        title: "Future Game",
+        igdbId: 12347,
+        platform: "PC",
+        releaseDate: futureDate,
+      };
+      const savedGame = {
+        ...newGame,
+        id: "game-future",
+        userId: "user-1",
+        releaseStatus: "upcoming",
+      };
+
+      vi.mocked(storage.getUserGames).mockResolvedValue([]);
+      vi.mocked(storage.addGame).mockResolvedValue(savedGame as unknown as Game);
+
+      const response = await request(app).post("/api/games").send(newGame);
+
+      expect(response.status).toBe(201);
+      expect(storage.addGame).not.toHaveBeenCalledWith(
+        expect.objectContaining({ releaseStatus: "released" })
+      );
+    });
+
+    it("does not force a release status when releaseDate is omitted", async () => {
+      const newGame = {
+        title: "Undated Game",
+        igdbId: 12348,
+        platform: "PC",
+      };
+      const savedGame = {
+        ...newGame,
+        id: "game-undated",
+        userId: "user-1",
+        releaseStatus: "upcoming",
+      };
+
+      vi.mocked(storage.getUserGames).mockResolvedValue([]);
+      vi.mocked(storage.addGame).mockResolvedValue(savedGame as unknown as Game);
+
+      const response = await request(app).post("/api/games").send(newGame);
+
+      expect(response.status).toBe(201);
+      expect(storage.addGame).not.toHaveBeenCalledWith(
+        expect.objectContaining({ releaseStatus: "released" })
+      );
+    });
+
+    it("marks a game releasing today as released in any timezone", async () => {
+      const today = new Date().toISOString().split("T")[0];
+
+      const newGame = {
+        title: "Releasing Today",
+        igdbId: 12349,
+        platform: "PC",
+        releaseDate: today,
+      };
+      const savedGame = {
+        ...newGame,
+        id: "game-today",
+        userId: "user-1",
+        releaseStatus: "released",
+      };
+
+      vi.mocked(storage.getUserGames).mockResolvedValue([]);
+      vi.mocked(storage.addGame).mockResolvedValue(savedGame as unknown as Game);
+
+      const response = await request(app).post("/api/games").send(newGame);
+
+      expect(response.status).toBe(201);
+      expect(storage.addGame).toHaveBeenCalledWith(
+        expect.objectContaining({ releaseStatus: "released" })
+      );
+    });
+
     it("should prevent duplicate games", async () => {
       const gameData = { title: "Dup Game", igdbId: 100, platform: "PC" };
       const existingGame = { ...gameData, id: "game-100", userId: "user-1" };

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -535,6 +535,7 @@ describe("API Routes - Extended Coverage", () => {
         igdbId: 12347,
         platform: "PC",
         releaseDate: futureDate,
+        releaseStatus: "upcoming",
       };
       const savedGame = {
         ...newGame,
@@ -549,8 +550,8 @@ describe("API Routes - Extended Coverage", () => {
       const response = await request(app).post("/api/games").send(newGame);
 
       expect(response.status).toBe(201);
-      expect(storage.addGame).not.toHaveBeenCalledWith(
-        expect.objectContaining({ releaseStatus: "released" })
+      expect(storage.addGame).toHaveBeenCalledWith(
+        expect.objectContaining({ releaseStatus: "upcoming" })
       );
     });
 
@@ -559,6 +560,7 @@ describe("API Routes - Extended Coverage", () => {
         title: "Undated Game",
         igdbId: 12348,
         platform: "PC",
+        releaseStatus: "upcoming",
       };
       const savedGame = {
         ...newGame,
@@ -573,8 +575,8 @@ describe("API Routes - Extended Coverage", () => {
       const response = await request(app).post("/api/games").send(newGame);
 
       expect(response.status).toBe(201);
-      expect(storage.addGame).not.toHaveBeenCalledWith(
-        expect.objectContaining({ releaseStatus: "released" })
+      expect(storage.addGame).toHaveBeenCalledWith(
+        expect.objectContaining({ releaseStatus: "upcoming" })
       );
     });
 

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -500,6 +500,31 @@ describe("API Routes - Extended Coverage", () => {
       expect(response.body).toEqual(savedGame);
     });
 
+    it("marks an already-released game as released when adding it", async () => {
+      const newGame = {
+        title: "Previously Released Game",
+        igdbId: 12346,
+        platform: "PC",
+        releaseDate: "2020-01-01",
+      };
+      const savedGame = {
+        ...newGame,
+        id: "game-released",
+        userId: "user-1",
+        releaseStatus: "released",
+      };
+
+      vi.mocked(storage.getUserGames).mockResolvedValue([]);
+      vi.mocked(storage.addGame).mockResolvedValue(savedGame as unknown as Game);
+
+      const response = await request(app).post("/api/games").send(newGame);
+
+      expect(response.status).toBe(201);
+      expect(storage.addGame).toHaveBeenCalledWith(
+        expect.objectContaining({ releaseStatus: "released" })
+      );
+    });
+
     it("should prevent duplicate games", async () => {
       const gameData = { title: "Dup Game", igdbId: 100, platform: "PC" };
       const existingGame = { ...gameData, id: "game-100", userId: "user-1" };

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -488,6 +488,7 @@ describe("API Routes - Extended Coverage", () => {
   });
 
   describe("POST /api/games", () => {
+    afterEach(() => vi.useRealTimers());
     it("should add a new game", async () => {
       const newGame = { title: "New Game", igdbId: 12345, platform: "PC" };
       const savedGame = { ...newGame, id: "game-new", userId: "user-1" };
@@ -526,9 +527,8 @@ describe("API Routes - Extended Coverage", () => {
     });
 
     it("does not mark a game releasing in the future as released", async () => {
-      const tomorrow = new Date();
-      tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
-      const futureDate = tomorrow.toISOString().split("T")[0];
+      vi.useFakeTimers({ now: new Date("2026-08-08T12:00:00Z") });
+      const futureDate = "2026-08-09";
 
       const newGame = {
         title: "Future Game",
@@ -579,7 +579,8 @@ describe("API Routes - Extended Coverage", () => {
     });
 
     it("marks a game releasing today as released in any timezone", async () => {
-      const today = new Date().toISOString().split("T")[0];
+      vi.useFakeTimers({ now: new Date("2026-08-08T12:00:00Z") });
+      const today = "2026-08-08";
 
       const newGame = {
         title: "Releasing Today",

--- a/server/__tests__/steam_wishlist.test.ts
+++ b/server/__tests__/steam_wishlist.test.ts
@@ -184,6 +184,7 @@ describe("syncUserSteamWishlist", () => {
         developers: ["Dev"],
         publishers: ["Pub"],
         screenshots: ["s1"],
+        isReleased: true,
       };
     });
 
@@ -194,6 +195,9 @@ describe("syncUserSteamWishlist", () => {
     expect(result?.addedCount).toBe(2);
     expect(igdbClient.getGameIdsBySteamAppIds).toHaveBeenCalledWith([101, 102]);
     expect(storage.addGame).toHaveBeenCalledTimes(2);
+    expect(storage.addGame).toHaveBeenCalledWith(
+      expect.objectContaining({ releaseStatus: "released" })
+    );
   });
 
   it("should skip Steam App IDs with no matching IGDB ID", async () => {

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -1407,6 +1407,7 @@ async function addNewSteamWishlistGames(
       screenshots: formatted.screenshots as string[],
       source: "steam",
       hidden: false,
+      releaseStatus: formatted.isReleased ? "released" : undefined,
     });
     addedGames.push({
       title: formatted.title as string,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1247,6 +1247,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         }
 
         // Always generate new UUID - never trust client-provided IDs
+        // Games already released when they are added should not trigger a
+        // misleading "Game has been released" notification on the next cron run.
+        if (gameData.releaseDate && new Date(gameData.releaseDate) <= new Date()) {
+          gameData.releaseStatus = "released";
+        }
         const game = await storage.addGame(gameData);
         res.status(201).json(game);
       } catch (error) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1249,7 +1249,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
         // Always generate new UUID - never trust client-provided IDs
         // Games already released when they are added should not trigger a
         // misleading "Game has been released" notification on the next cron run.
-        if (gameData.releaseDate && new Date(gameData.releaseDate) <= new Date()) {
+        // Compare calendar dates (YYYY-MM-DD) rather than UTC instants so a game
+        // releasing "today" is only marked released once that calendar day arrives.
+        if (
+          gameData.releaseDate &&
+          gameData.releaseDate <= new Date().toISOString().split("T")[0]
+        ) {
           gameData.releaseStatus = "released";
         }
         const game = await storage.addGame(gameData);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -80,6 +80,19 @@ import fs from "fs";
 import fsExtra from "fs-extra";
 import { readLastLogLines } from "./log-file.js";
 
+const normalizeInitialReleaseStatus = <
+  T extends { releaseDate?: string | null; releaseStatus?: string | null },
+>(
+  gameData: T
+): T => {
+  const releaseDate = gameData.releaseDate?.slice(0, 10);
+  const today = new Date().toISOString().slice(0, 10);
+  if (releaseDate && /^\d{4}-\d{2}-\d{2}$/.test(releaseDate) && releaseDate <= today) {
+    return { ...gameData, releaseStatus: "released" };
+  }
+  return gameData;
+};
+
 // Root directory for the file system browser; restrict browsing to this tree
 const FILE_BROWSER_ROOT = fs.realpathSync(process.cwd());
 
@@ -1246,18 +1259,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
           return res.status(409).json({ error: "Game already in collection", game: existingGame });
         }
 
-        // Always generate new UUID - never trust client-provided IDs
-        // Games already released when they are added should not trigger a
-        // misleading "Game has been released" notification on the next cron run.
-        // Compare calendar dates (YYYY-MM-DD) rather than UTC instants so a game
-        // releasing "today" is only marked released once that calendar day arrives.
-        if (
-          gameData.releaseDate &&
-          gameData.releaseDate <= new Date().toISOString().split("T")[0]
-        ) {
-          gameData.releaseStatus = "released";
-        }
-        const game = await storage.addGame(gameData);
+        // Avoid a misleading release notification for games already released at add time.
+        const normalizedGameData = normalizeInitialReleaseStatus(gameData);
+        const game = await storage.addGame(normalizedGameData);
         res.status(201).json(game);
       } catch (error) {
         if (error instanceof z.ZodError) {
@@ -2854,11 +2858,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
               : "wanted";
 
           const game = await storage.addGame(
-            insertGameSchema.parse({
-              ...newGame,
-              userId,
-              status: initialGameStatus,
-            })
+            normalizeInitialReleaseStatus(
+              insertGameSchema.parse({
+                ...newGame,
+                userId,
+                status: initialGameStatus,
+              })
+            )
           );
           resolvedGameId = game.id;
         }
@@ -3001,7 +3007,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
                   : "downloading"
                 : "wanted";
             const game = await storage.addGame(
-              insertGameSchema.parse({ ...item.newGame, userId, status: initialStatus })
+              normalizeInitialReleaseStatus(
+                insertGameSchema.parse({ ...item.newGame, userId, status: initialStatus })
+              )
             );
             resolvedGameId = game.id;
             if (item.newGame.igdbId != null) {
@@ -3851,7 +3859,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           return res.status(409).json({ error: "Game already in collection", game: existingGame });
         }
 
-        const game = await storage.addGame(gameData);
+        const game = await storage.addGame(normalizeInitialReleaseStatus(gameData));
         routesLogger.info(
           { userId, title: game.title, igdbId: game.igdbId },
           "Game quick-added from matching"


### PR DESCRIPTION
## Summary

- mark games whose release date is already in the past as released when they are added
- prevent the next cron cycle from emitting a misleading release notification
- leave future and undated games unchanged

## Verification

- focused POST /api/games release-status regression test
- npm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Games added with a release date of today or earlier are now automatically marked as released.
  * Games with future or omitted release dates retain their appropriate release status.
  * Release status is normalized consistently when claiming individual or batch downloads or using quick add.
  * Steam wishlist imports now correctly mark released games as released.
  * Game creation completes successfully across supported release-date scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->