### PR TITLE
Add Packs/Addons download category

### DIFF
--- a/client/src/components/AutoDownloadRulesSettings.tsx
+++ b/client/src/components/AutoDownloadRulesSettings.tsx
@@ -37,6 +37,11 @@ const CATEGORY_DEFINITIONS = [
     description: "Downloadable content and season passes",
   },
   {
+    value: "packs",
+    label: "Packs/Addons",
+    description: "Game packs, add-ons, and compilations",
+  },
+  {
     value: "extra",
     label: "Extras",
     description: "Soundtracks, artbooks, and bonus content",
@@ -46,7 +51,7 @@ const CATEGORY_DEFINITIONS = [
 const DEFAULT_RULES: DownloadRules = {
   minSeeders: 0,
   sortBy: "seeders",
-  visibleCategories: ["main", "update", "dlc", "extra"],
+  visibleCategories: ["main", "update", "dlc", "extra", "packs"],
 };
 
 export default function AutoDownloadRulesSettings({
@@ -60,7 +65,15 @@ export default function AutoDownloadRulesSettings({
   const [minSeeders, setMinSeeders] = useState<number>(rules?.minSeeders ?? 0);
   const [sortBy, setSortBy] = useState<"seeders" | "date" | "size">(rules?.sortBy ?? "seeders");
   const [visibleCategories, setVisibleCategories] = useState<Set<DownloadCategory>>(
-    new Set((rules?.visibleCategories ?? ["main", "update", "dlc", "extra"]) as DownloadCategory[])
+    new Set(
+      (rules?.visibleCategories ?? [
+        "main",
+        "update",
+        "dlc",
+        "extra",
+        "packs",
+      ]) as DownloadCategory[]
+    )
   );
 
   const saveRulesMutation = useMutation({
@@ -216,7 +229,7 @@ export default function AutoDownloadRulesSettings({
               ))}
             </div>
             <p className="text-xs text-muted-foreground mt-2">
-              {visibleCategories.size} of 4 categories enabled
+              {visibleCategories.size} of {CATEGORY_DEFINITIONS.length} categories enabled
             </p>
           </div>
         </div>

--- a/client/src/components/AutoDownloadRulesSettings.tsx
+++ b/client/src/components/AutoDownloadRulesSettings.tsx
@@ -39,7 +39,7 @@ const CATEGORY_DEFINITIONS = [
   {
     value: "packs",
     label: "Packs/Addons",
-    description: "Game packs, add-ons, and compilations",
+    description: "Game packs and add-ons",
   },
   {
     value: "extra",

--- a/client/src/components/ClaimBatchModal.tsx
+++ b/client/src/components/ClaimBatchModal.tsx
@@ -59,6 +59,7 @@ const CATEGORY_LABELS: Record<DownloadCategory, string> = {
   main: "Main",
   update: "Update",
   dlc: "DLC",
+  packs: "Packs/Addons",
   extra: "Extra",
 };
 
@@ -66,6 +67,7 @@ const CATEGORY_COLORS: Record<DownloadCategory, string> = {
   main: "bg-blue-500/20 text-blue-400",
   update: "bg-yellow-500/20 text-yellow-400",
   dlc: "bg-purple-500/20 text-purple-400",
+  packs: "bg-green-500/20 text-green-400",
   extra: "bg-gray-500/20 text-gray-400",
 };
 

--- a/client/src/components/ClaimDownloadModal.tsx
+++ b/client/src/components/ClaimDownloadModal.tsx
@@ -189,6 +189,7 @@ export default function ClaimDownloadModal({
               <SelectItem value="main">Main</SelectItem>
               <SelectItem value="update">Update</SelectItem>
               <SelectItem value="dlc">DLC</SelectItem>
+              <SelectItem value="packs">Packs/Addons</SelectItem>
               <SelectItem value="extra">Extra</SelectItem>
             </SelectContent>
           </Select>

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -75,7 +75,11 @@ import {
   type Downloader,
   downloadRulesSchema,
 } from "@shared/schema";
-import { groupDownloadsByCategory, type DownloadCategory } from "@shared/download-categorizer";
+import {
+  getCategoryLabel,
+  groupDownloadsByCategory,
+  type DownloadCategory,
+} from "@shared/download-categorizer";
 import {
   parseReleaseMetadata,
   parseJsonStringArray,
@@ -846,15 +850,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                 onCheckedChange={() => toggleCategory(cat)}
               />
               <label htmlFor={`cat-${cat}`} className="ml-2 text-sm cursor-pointer capitalize">
-                {cat === "main"
-                  ? "Main Game"
-                  : cat === "update"
-                    ? "Updates"
-                    : cat === "dlc"
-                      ? "DLC"
-                      : cat === "packs"
-                        ? "Packs/Addons"
-                        : "Extras"}
+                {getCategoryLabel(cat)}
               </label>
             </div>
           ))}
@@ -977,15 +973,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                   <div key={category} className="relative">
                     <div className="flex items-center gap-2 mb-3 px-1">
                       <h3 className="font-bold text-lg capitalize tracking-tight">
-                        {category === "main"
-                          ? "Main Game"
-                          : category === "update"
-                            ? "Updates & Patches"
-                            : category === "dlc"
-                              ? "DLC & Expansions"
-                              : category === "packs"
-                                ? "Packs/Addons"
-                                : "Extras"}
+                        {getCategoryLabel(category)}
                       </h3>
                       <Badge variant="secondary" className="text-xs font-semibold">
                         {downloadsInCategory.length}

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -240,7 +240,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [showFilters, setShowFilters] = useState(false);
   const [visibleCategories, setVisibleCategories] = useState<Set<DownloadCategory>>(
-    new Set(["main", "update", "dlc", "extra"] as DownloadCategory[])
+    new Set(["main", "update", "dlc", "extra", "packs"] as DownloadCategory[])
   );
   const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
   const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>([]);
@@ -265,7 +265,9 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     setSortBy("seeders");
     setSortOrder("desc");
     setShowFilters(false);
-    setVisibleCategories(new Set(["main", "update", "dlc", "extra"] as DownloadCategory[]));
+    setVisibleCategories(
+      new Set(["main", "update", "dlc", "extra", "packs"] as DownloadCategory[])
+    );
     setSelectedGroups([]);
     setSelectedPlatforms([]);
     defaultsAppliedRef.current = false;
@@ -359,7 +361,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
 
   // Categorize downloads
   const categorizedDownloads = useMemo(() => {
-    if (!searchResults?.items) return { main: [], update: [], dlc: [], extra: [] };
+    if (!searchResults?.items) return { main: [], update: [], dlc: [], extra: [], packs: [] };
     return groupDownloadsByCategory(searchResults.items);
   }, [searchResults?.items]);
 
@@ -425,6 +427,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
       update: [],
       dlc: [],
       extra: [],
+      packs: [],
     };
 
     for (const [category, downloads] of Object.entries(categorizedDownloads) as [
@@ -835,7 +838,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
       <div className={cn("space-y-2", !isMobile && "col-span-4")}>
         <Label className="text-sm">Categories</Label>
         <div className="flex flex-wrap gap-2">
-          {(["main", "update", "dlc", "extra"] as const).map((cat) => (
+          {(["main", "update", "dlc", "packs", "extra"] as const).map((cat) => (
             <div key={cat} className="flex items-center">
               <Checkbox
                 id={`cat-${cat}`}
@@ -849,7 +852,9 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                     ? "Updates"
                     : cat === "dlc"
                       ? "DLC"
-                      : "Extras"}
+                      : cat === "packs"
+                        ? "Packs/Addons"
+                        : "Extras"}
               </label>
             </div>
           ))}
@@ -964,7 +969,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                 </div>
               )}
 
-              {(["main", "update", "dlc", "extra"] as const).map((category) => {
+              {(["main", "update", "dlc", "packs", "extra"] as const).map((category) => {
                 const downloadsInCategory = filteredCategorizedDownloads[category] || [];
                 if (downloadsInCategory.length === 0) return null;
 
@@ -978,7 +983,9 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                             ? "Updates & Patches"
                             : category === "dlc"
                               ? "DLC & Expansions"
-                              : "Extras"}
+                              : category === "packs"
+                                ? "Packs/Addons"
+                                : "Extras"}
                       </h3>
                       <Badge variant="secondary" className="text-xs font-semibold">
                         {downloadsInCategory.length}

--- a/migrations/0026_aberrant_quentin_quire.sql
+++ b/migrations/0026_aberrant_quentin_quire.sql
@@ -1,3 +1,3 @@
 ALTER TABLE `games` ADD `update_search_results_available` integer DEFAULT false NOT NULL;--> statement-breakpoint
 ALTER TABLE `games` ADD `packs_search_results_available` integer DEFAULT false NOT NULL;--> statement-breakpoint
-UPDATE games SET update_search_results_available = search_results_available;
+UPDATE games SET update_search_results_available = search_results_available WHERE id IS NOT NULL;

--- a/migrations/0026_aberrant_quentin_quire.sql
+++ b/migrations/0026_aberrant_quentin_quire.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `games` ADD `update_search_results_available` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `games` ADD `packs_search_results_available` integer DEFAULT false NOT NULL;--> statement-breakpoint
+UPDATE games SET update_search_results_available = search_results_available;

--- a/migrations/0026_aberrant_quentin_quire.sql
+++ b/migrations/0026_aberrant_quentin_quire.sql
@@ -1,3 +1,3 @@
 ALTER TABLE `games` ADD `update_search_results_available` integer DEFAULT false NOT NULL;--> statement-breakpoint
 ALTER TABLE `games` ADD `packs_search_results_available` integer DEFAULT false NOT NULL;--> statement-breakpoint
-UPDATE games SET update_search_results_available = search_results_available WHERE id IS NOT NULL;
+UPDATE games SET update_search_results_available = search_results_available WHERE update_search_results_available <> search_results_available;

--- a/migrations/meta/0026_snapshot.json
+++ b/migrations/meta/0026_snapshot.json
@@ -1,0 +1,1654 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "38bed938-b596-4db7-b378-ec05e0ca8874",
+  "prevId": "b8506e7a-cf45-4086-9f0f-135a115f9f8e",
+  "tables": {
+    "downloaders": {
+      "name": "downloaders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "url_path": {
+          "name": "url_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "download_path": {
+          "name": "download_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'games'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Questarr'"
+        },
+        "add_stopped": {
+          "name": "add_stopped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "remove_completed": {
+          "name": "remove_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "post_import_category": {
+          "name": "post_import_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_downloads": {
+      "name": "game_downloads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "downloader_id": {
+          "name": "downloader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_type": {
+          "name": "download_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torrent'"
+        },
+        "download_hash": {
+          "name": "download_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_title": {
+          "name": "download_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'downloading'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "game_downloads_downloader_hash_idx": {
+          "name": "game_downloads_downloader_hash_idx",
+          "columns": ["downloader_id", "download_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "game_downloads_game_id_games_id_fk": {
+          "name": "game_downloads_game_id_games_id_fk",
+          "tableFrom": "game_downloads",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_downloads_downloader_id_downloaders_id_fk": {
+          "name": "game_downloads_downloader_id_downloaders_id_fk",
+          "tableFrom": "game_downloads",
+          "tableTo": "downloaders",
+          "columnsFrom": ["downloader_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "games": {
+      "name": "games",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steam_appid": {
+          "name": "steam_appid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "themes": {
+          "name": "themes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publishers": {
+          "name": "publishers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "developers": {
+          "name": "developers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "igdb_websites": {
+          "name": "igdb_websites",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "original_release_date": {
+          "name": "original_release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_status": {
+          "name": "release_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'upcoming'"
+        },
+        "early_access": {
+          "name": "early_access",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_adult_content": {
+          "name": "is_adult_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_age_restricted": {
+          "name": "is_age_restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "user_rating": {
+          "name": "user_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_path": {
+          "name": "library_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_results_available": {
+          "name": "search_results_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "update_search_results_available": {
+          "name": "update_search_results_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "packs_search_results_available": {
+          "name": "packs_search_results_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_user_id_users_id_fk": {
+          "name": "games_user_id_users_id_fk",
+          "tableFrom": "games",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_task_items": {
+      "name": "import_task_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "game_title": {
+          "name": "game_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "import_task_items_task_id_idx": {
+          "name": "import_task_items_task_id_idx",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "import_task_items_task_id_import_tasks_id_fk": {
+          "name": "import_task_items_task_id_import_tasks_id_fk",
+          "tableFrom": "import_task_items",
+          "tableTo": "import_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_tasks": {
+      "name": "import_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "added_items": {
+          "name": "added_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_items": {
+          "name": "skipped_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_items": {
+          "name": "failed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "import_tasks_user_id_users_id_fk": {
+          "name": "import_tasks_user_id_users_id_fk",
+          "tableFrom": "import_tasks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexers": {
+      "name": "indexers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torznab'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "rss_enabled": {
+          "name": "rss_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_search_enabled": {
+          "name": "auto_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read": {
+          "name": "read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "path_mappings": {
+      "name": "path_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_path": {
+          "name": "remote_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_host": {
+          "name": "remote_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "platform_mappings": {
+      "name": "platform_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "igdb_platform_id": {
+          "name": "igdb_platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_platform_name": {
+          "name": "source_platform_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "release_blacklist": {
+      "name": "release_blacklist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_title": {
+          "name": "release_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexer_name": {
+          "name": "indexer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "release_blacklist_game_title_idx": {
+          "name": "release_blacklist_game_title_idx",
+          "columns": ["game_id", "release_title"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "release_blacklist_game_id_games_id_fk": {
+          "name": "release_blacklist_game_id_games_id_fk",
+          "tableFrom": "release_blacklist",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_feed_items": {
+      "name": "rss_feed_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pub_date": {
+          "name": "pub_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_game_id": {
+          "name": "igdb_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_game_name": {
+          "name": "igdb_game_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rss_feed_items_feed_id_rss_feeds_id_fk": {
+          "name": "rss_feed_items_feed_id_rss_feeds_id_fk",
+          "tableFrom": "rss_feed_items",
+          "tableTo": "rss_feeds",
+          "columnsFrom": ["feed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_feeds": {
+      "name": "rss_feeds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "mapping": {
+          "name": "mapping",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_config": {
+      "name": "system_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auto_search_enabled": {
+          "name": "auto_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_download_enabled": {
+          "name": "auto_download_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_interval_hours": {
+          "name": "search_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 6
+        },
+        "igdb_rate_limit_per_second": {
+          "name": "igdb_rate_limit_per_second",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "download_rules": {
+          "name": "download_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_auto_search": {
+          "name": "last_auto_search",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "xrel_scene_releases": {
+          "name": "xrel_scene_releases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "xrel_p2p_releases": {
+          "name": "xrel_p2p_releases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_search_unreleased": {
+          "name": "auto_search_unreleased",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "steam_sync_failures": {
+          "name": "steam_sync_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "steam_sync_enabled": {
+          "name": "steam_sync_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "steam_sync_interval_hours": {
+          "name": "steam_sync_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "last_steam_sync": {
+          "name": "last_steam_sync",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_release_groups": {
+          "name": "preferred_release_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filter_by_preferred_groups": {
+          "name": "filter_by_preferred_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preferred_platform": {
+          "name": "preferred_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_adult_content": {
+          "name": "hide_adult_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "hide_age_restricted_content": {
+          "name": "hide_age_restricted_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "enable_post_processing": {
+          "name": "enable_post_processing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_unpack": {
+          "name": "auto_unpack",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rename_pattern": {
+          "name": "rename_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{Title} ({Region})'"
+        },
+        "overwrite_existing": {
+          "name": "overwrite_existing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "transfer_mode": {
+          "name": "transfer_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'hardlink'"
+        },
+        "import_platform_ids": {
+          "name": "import_platform_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "ignored_extensions": {
+          "name": "ignored_extensions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "min_file_size": {
+          "name": "min_file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "library_root": {
+          "name": "library_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'/data'"
+        },
+        "auto_delete_after_import": {
+          "name": "auto_delete_after_import",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "steam_id_64": {
+          "name": "steam_id_64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "xrel_notified_releases": {
+      "name": "xrel_notified_releases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "xrel_release_id": {
+          "name": "xrel_release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "xrel_notified_releases_game_id_games_id_fk": {
+          "name": "xrel_notified_releases_game_id_games_id_fk",
+          "tableFrom": "xrel_notified_releases",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1784581013215,
       "tag": "0025_damp_storm",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1786221915267,
+      "tag": "0026_aberrant_quentin_quire",
+      "breakpoints": true
     }
   ]
 }

--- a/server/__tests__/cron_autosearch.test.ts
+++ b/server/__tests__/cron_autosearch.test.ts
@@ -27,6 +27,7 @@ const mockGetUserSettings = vi.fn();
 const mockUpdateUserSettings = vi.fn();
 const mockAddNotification = vi.fn();
 const mockUpdateGameSearchResultsAvailable = vi.fn();
+const mockUpdateGameSearchResultsByCategory = vi.fn();
 const mockUpdateGameStatus = vi.fn();
 const mockAddGameDownload = vi.fn();
 const mockGetEnabledDownloaders = vi.fn().mockResolvedValue([]);
@@ -41,6 +42,7 @@ vi.mock("../storage.js", () => ({
     updateUserSettings: mockUpdateUserSettings,
     addNotification: mockAddNotification,
     updateGameSearchResultsAvailable: mockUpdateGameSearchResultsAvailable,
+    updateGameSearchResultsByCategory: mockUpdateGameSearchResultsByCategory,
     updateGameStatus: mockUpdateGameStatus,
     addGameDownload: mockAddGameDownload,
     getEnabledDownloaders: mockGetEnabledDownloaders,
@@ -115,6 +117,9 @@ describe("Cron - checkAutoSearch", () => {
     developers: [],
     screenshots: [],
     originalReleaseDate: null,
+    searchResultsAvailable: false,
+    updateSearchResultsAvailable: false,
+    packsSearchResultsAvailable: false,
   };
 
   const baseSettings: UserSettings = {
@@ -1268,7 +1273,11 @@ describe("Cron - checkAutoSearch", () => {
       );
       mockAddNotification.mockClear();
 
-      const stillAvailable = { ...ownedGame, searchResultsAvailable: true };
+      const stillAvailable = {
+        ...ownedGame,
+        searchResultsAvailable: true,
+        updateSearchResultsAvailable: true,
+      };
       mockGetUserGames.mockResolvedValue([stillAvailable]);
 
       await checkAutoSearch();
@@ -1277,6 +1286,86 @@ describe("Cron - checkAutoSearch", () => {
       );
     });
 
+    it("notifies independently when an update is followed by a pack", async () => {
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, []]]));
+      const updateResult = { items: [UPDATE_ITEM], errors: [], total: 1 };
+      const packResult = {
+        items: [{ ...UPDATE_ITEM, title: "Test Game Content Pack" }],
+        errors: [],
+        total: 1,
+      };
+      let game = {
+        ...baseGame,
+        status: "owned" as const,
+        releaseStatus: "released" as const,
+        searchResultsAvailable: false,
+        updateSearchResultsAvailable: false,
+        packsSearchResultsAvailable: false,
+      };
+      mockGetUserGames.mockResolvedValue([game]);
+
+      mockSearchAllIndexers.mockResolvedValue(updateResult);
+      await checkAutoSearch();
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Updates Available" })
+      );
+      mockAddNotification.mockClear();
+
+      game = { ...game, searchResultsAvailable: true, updateSearchResultsAvailable: true };
+      mockGetUserGames.mockResolvedValue([game]);
+      mockSearchAllIndexers.mockResolvedValue(packResult);
+      await checkAutoSearch();
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Packs Available" })
+      );
+      expect(mockAddNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Updates Available" })
+      );
+
+      mockAddNotification.mockClear();
+      game = { ...game, searchResultsAvailable: true, packsSearchResultsAvailable: true };
+      mockGetUserGames.mockResolvedValue([game]);
+      await checkAutoSearch();
+      expect(mockAddNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Packs Available" })
+      );
+    });
+    it("notifies independently when a pack is followed by an update", async () => {
+      mockGetWantedGamesGroupedByUser.mockResolvedValue(new Map([[userId, []]]));
+      const packResult = {
+        items: [{ ...UPDATE_ITEM, title: "Test Game Content Pack" }],
+        errors: [],
+        total: 1,
+      };
+      const updateResult = { items: [UPDATE_ITEM], errors: [], total: 1 };
+      let game = {
+        ...baseGame,
+        status: "owned" as const,
+        releaseStatus: "released" as const,
+        searchResultsAvailable: false,
+        updateSearchResultsAvailable: false,
+        packsSearchResultsAvailable: false,
+      };
+      mockGetUserGames.mockResolvedValue([game]);
+
+      mockSearchAllIndexers.mockResolvedValue(packResult);
+      await checkAutoSearch();
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Packs Available" })
+      );
+      mockAddNotification.mockClear();
+
+      game = { ...game, searchResultsAvailable: true, packsSearchResultsAvailable: true };
+      mockGetUserGames.mockResolvedValue([game]);
+      mockSearchAllIndexers.mockResolvedValue(updateResult);
+      await checkAutoSearch();
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Updates Available" })
+      );
+      expect(mockAddNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Game Packs Available" })
+      );
+    });
     it("re-notifies 'Game Available' after a false→true→false→true flap", async () => {
       let game = {
         ...baseGame,

--- a/server/__tests__/helpers/import-test-helpers.ts
+++ b/server/__tests__/helpers/import-test-helpers.ts
@@ -35,6 +35,8 @@ export function makeGame(overrides: Partial<Game> = {}): Game {
     earlyAccess: false,
     userRating: null,
     searchResultsAvailable: false,
+    updateSearchResultsAvailable: false,
+    packsSearchResultsAvailable: false,
     ...overrides,
   };
 }

--- a/server/__tests__/storage_mem_coverage.test.ts
+++ b/server/__tests__/storage_mem_coverage.test.ts
@@ -275,6 +275,19 @@ describe("MemStorage - Game update methods", () => {
     expect(game?.searchResultsAvailable).toBe(true);
   });
 
+  it("tracks update and pack availability independently", async () => {
+    await storage.updateGameSearchResultsByCategory(gameId, { updates: true, packs: false });
+    let game = await storage.getGame(gameId);
+    expect(game?.updateSearchResultsAvailable).toBe(true);
+    expect(game?.packsSearchResultsAvailable).toBe(false);
+    expect(game?.searchResultsAvailable).toBe(true);
+
+    await storage.updateGameSearchResultsByCategory(gameId, { updates: false, packs: true });
+    game = await storage.getGame(gameId);
+    expect(game?.updateSearchResultsAvailable).toBe(false);
+    expect(game?.packsSearchResultsAvailable).toBe(true);
+    expect(game?.searchResultsAvailable).toBe(true);
+  });
   it("updateGame applies partial updates", async () => {
     const updated = await storage.updateGame(gameId, { title: "Updated Title" });
     expect(updated?.title).toBe("Updated Title");

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -84,6 +84,7 @@ interface AutoSearchRules {
 interface AutoSearchCategorizedItems {
   mainItems: SearchItem[];
   updateItems: SearchItem[];
+  packsItems: SearchItem[];
 }
 
 function getAutoSearchRules(downloadRules: string | null): AutoSearchRules {
@@ -133,11 +134,13 @@ function categorizeSearchItems(
         acc.mainItems.push(item);
       } else if (category === "update") {
         acc.updateItems.push(item);
+      } else if (category === "packs") {
+        acc.packsItems.push(item);
       }
 
       return acc;
     },
-    { mainItems: [], updateItems: [] }
+    { mainItems: [], updateItems: [], packsItems: [] }
   );
 }
 
@@ -1135,7 +1138,22 @@ export async function checkAutoSearch() {
             );
             const updateItems = deduplicateByTitle(groupFilteredUpdate, indexerPriorityMap);
 
-            await storage.updateGameSearchResultsAvailable(game.id, updateItems.length > 0);
+            // Packs/add-ons are content for owned games, surfaced like updates.
+            const platformFilteredPacks = applyPreferredPlatformFilter(
+              searchResult.packsItems,
+              preferredPlatform
+            );
+            const groupFilteredPacks = applyPreferredGroupsFilter(
+              platformFilteredPacks,
+              preferredGroups,
+              settings.filterByPreferredGroups ?? false
+            );
+            const packsItems = deduplicateByTitle(groupFilteredPacks, indexerPriorityMap);
+
+            await storage.updateGameSearchResultsAvailable(
+              game.id,
+              updateItems.length > 0 || packsItems.length > 0
+            );
 
             if (updateItems.length > 0 && !wasUpdateAvailable && prefs.gameUpdates.inApp) {
               const notification = await storage.addNotification({
@@ -1143,6 +1161,18 @@ export async function checkAutoSearch() {
                 type: "info",
                 title: "Game Updates Available",
                 message: `${updateItems.length} update(s) found for ${game.title}`,
+                link: `modal:game:${game.id}`,
+              });
+              notifyUser("notification", notification);
+              if (prefs.gameUpdates.apprise) appriseClient.send(notification);
+            }
+
+            if (packsItems.length > 0 && !wasUpdateAvailable && prefs.gameUpdates.inApp) {
+              const notification = await storage.addNotification({
+                userId,
+                type: "info",
+                title: "Packs/Add-ons Available",
+                message: `${packsItems.length} pack(s)/add-on(s) found for ${game.title}`,
                 link: `modal:game:${game.id}`,
               });
               notifyUser("notification", notification);

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -1125,7 +1125,8 @@ export async function checkAutoSearch() {
               continue;
             }
 
-            const wasUpdateAvailable = game.searchResultsAvailable;
+            const wasUpdateAvailable = game.updateSearchResultsAvailable;
+            const wasPacksAvailable = game.packsSearchResultsAvailable;
 
             const platformFilteredUpdate = applyPreferredPlatformFilter(
               searchResult.updateItems,
@@ -1150,10 +1151,10 @@ export async function checkAutoSearch() {
             );
             const packsItems = deduplicateByTitle(groupFilteredPacks, indexerPriorityMap);
 
-            await storage.updateGameSearchResultsAvailable(
-              game.id,
-              updateItems.length > 0 || packsItems.length > 0
-            );
+            await storage.updateGameSearchResultsByCategory(game.id, {
+              updates: updateItems.length > 0,
+              packs: packsItems.length > 0,
+            });
 
             if (updateItems.length > 0 && !wasUpdateAvailable && prefs.gameUpdates.inApp) {
               const notification = await storage.addNotification({
@@ -1161,6 +1162,18 @@ export async function checkAutoSearch() {
                 type: "info",
                 title: "Game Updates Available",
                 message: `${updateItems.length} update(s) found for ${game.title}`,
+                link: `modal:game:${game.id}`,
+              });
+              notifyUser("notification", notification);
+              if (prefs.gameUpdates.apprise) appriseClient.send(notification);
+            }
+
+            if (packsItems.length > 0 && !wasPacksAvailable && prefs.gameUpdates.inApp) {
+              const notification = await storage.addNotification({
+                userId,
+                type: "info",
+                title: "Game Packs Available",
+                message: `${packsItems.length} pack/add-on result(s) found for ${game.title}`,
                 link: `modal:game:${game.id}`,
               });
               notifyUser("notification", notification);

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -1166,18 +1166,6 @@ export async function checkAutoSearch() {
               notifyUser("notification", notification);
               if (prefs.gameUpdates.apprise) appriseClient.send(notification);
             }
-
-            if (packsItems.length > 0 && !wasUpdateAvailable && prefs.gameUpdates.inApp) {
-              const notification = await storage.addNotification({
-                userId,
-                type: "info",
-                title: "Packs/Add-ons Available",
-                message: `${packsItems.length} pack(s)/add-on(s) found for ${game.title}`,
-                link: `modal:game:${game.id}`,
-              });
-              notifyUser("notification", notification);
-              if (prefs.gameUpdates.apprise) appriseClient.send(notification);
-            }
           } catch (error) {
             igdbLogger.error(
               { gameTitle: game.title, error },

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -89,7 +89,7 @@ interface AutoSearchCategorizedItems {
 function getAutoSearchRules(downloadRules: string | null): AutoSearchRules {
   let minSeeders = 0;
   let sortBy: DownloadSortBy = "seeders";
-  let visibleCategoriesSet = new Set(["main", "update", "dlc", "extra"]);
+  let visibleCategoriesSet = new Set(["main", "update", "dlc", "extra", "packs"]);
 
   if (downloadRules) {
     const parsed = JSON.parse(downloadRules);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -168,6 +168,10 @@ export interface IStorage {
   ): Promise<Game | undefined>;
   updateGameNotes(id: string, userId: string, notes: string | null): Promise<Game | undefined>;
   updateGameSearchResultsAvailable(gameId: string, available: boolean): Promise<void>;
+  updateGameSearchResultsByCategory(
+    gameId: string,
+    availability: { updates: boolean; packs: boolean }
+  ): Promise<void>;
   updateGame(id: string, updates: Partial<Game>): Promise<Game | undefined>;
   updateGamesBatch(updates: { id: string; data: Partial<Game> }[]): Promise<void>;
   removeGame(id: string): Promise<boolean>;
@@ -467,6 +471,8 @@ export class MemStorage implements IStorage {
       releaseStatus: insertGame.releaseStatus || "upcoming",
       earlyAccess: insertGame.earlyAccess ?? false,
       searchResultsAvailable: false,
+      updateSearchResultsAvailable: false,
+      packsSearchResultsAvailable: false,
       userRating: null,
       notes: null,
       libraryPath: null,
@@ -487,7 +493,13 @@ export class MemStorage implements IStorage {
       ...game,
       status: statusUpdate.status,
       completedAt: statusUpdate.status === "completed" ? new Date() : null,
-      ...(leavingWanted ? { searchResultsAvailable: false } : {}),
+      ...(leavingWanted
+        ? {
+            searchResultsAvailable: false,
+            updateSearchResultsAvailable: false,
+            packsSearchResultsAvailable: false,
+          }
+        : {}),
     };
 
     this.games.set(id, updatedGame);
@@ -537,6 +549,19 @@ export class MemStorage implements IStorage {
     const game = this.games.get(gameId);
     if (game) {
       game.searchResultsAvailable = available;
+      this.games.set(gameId, game);
+    }
+  }
+
+  async updateGameSearchResultsByCategory(
+    gameId: string,
+    availability: { updates: boolean; packs: boolean }
+  ): Promise<void> {
+    const game = this.games.get(gameId);
+    if (game) {
+      game.updateSearchResultsAvailable = availability.updates;
+      game.packsSearchResultsAvailable = availability.packs;
+      game.searchResultsAvailable = availability.updates || availability.packs;
       this.games.set(gameId, game);
     }
   }
@@ -1626,7 +1651,13 @@ export class DatabaseStorage implements IStorage {
       .set({
         status: statusUpdate.status,
         completedAt: statusUpdate.status === "completed" ? new Date() : null,
-        ...(leavingWanted ? { searchResultsAvailable: false } : {}),
+        ...(leavingWanted
+          ? {
+              searchResultsAvailable: false,
+              updateSearchResultsAvailable: false,
+              packsSearchResultsAvailable: false,
+            }
+          : {}),
       })
       .where(eq(games.id, id))
       .returning();
@@ -1670,7 +1701,32 @@ export class DatabaseStorage implements IStorage {
   }
 
   async updateGameSearchResultsAvailable(gameId: string, available: boolean): Promise<void> {
-    await db.update(games).set({ searchResultsAvailable: available }).where(eq(games.id, gameId));
+    await db
+      .update(games)
+      .set(
+        available
+          ? { searchResultsAvailable: true }
+          : {
+              searchResultsAvailable: false,
+              updateSearchResultsAvailable: false,
+              packsSearchResultsAvailable: false,
+            }
+      )
+      .where(eq(games.id, gameId));
+  }
+
+  async updateGameSearchResultsByCategory(
+    gameId: string,
+    availability: { updates: boolean; packs: boolean }
+  ): Promise<void> {
+    await db
+      .update(games)
+      .set({
+        updateSearchResultsAvailable: availability.updates,
+        packsSearchResultsAvailable: availability.packs,
+        searchResultsAvailable: availability.updates || availability.packs,
+      })
+      .where(eq(games.id, gameId));
   }
 
   async updateGame(id: string, updates: Partial<Game>): Promise<Game | undefined> {

--- a/shared/__tests__/download-categorizer.test.ts
+++ b/shared/__tests__/download-categorizer.test.ts
@@ -77,10 +77,12 @@ describe("download-categorizer", () => {
         category: "packs",
         confidence: 0.85,
       });
+      expect(categorizeDownload("Game.Addon-GROUP").category).toBe("packs");
     });
 
     it("keeps explicit DLC and expansion packs in the DLC category", () => {
       expect(categorizeDownload("Game.DLC.Pack-GROUP").category).toBe("dlc");
+      expect(categorizeDownload("Game.DLC.Add-On-GROUP").category).toBe("dlc");
       expect(categorizeDownload("Game.Expansion.Pack-GROUP").category).toBe("dlc");
     });
 

--- a/shared/__tests__/download-categorizer.test.ts
+++ b/shared/__tests__/download-categorizer.test.ts
@@ -68,6 +68,22 @@ describe("download-categorizer", () => {
       expect(result.confidence).toBe(0.85);
     });
 
+    it("detects standalone packs and add-ons as packs", () => {
+      expect(categorizeDownload("Game.Content.Pack-GROUP")).toEqual({
+        category: "packs",
+        confidence: 0.85,
+      });
+      expect(categorizeDownload("Game.Add-On-GROUP")).toEqual({
+        category: "packs",
+        confidence: 0.85,
+      });
+    });
+
+    it("keeps explicit DLC and expansion packs in the DLC category", () => {
+      expect(categorizeDownload("Game.DLC.Pack-GROUP").category).toBe("dlc");
+      expect(categorizeDownload("Game.Expansion.Pack-GROUP").category).toBe("dlc");
+    });
+
     it("detects DLC via 'season pass' keyword", () => {
       const result = categorizeDownload("Game Season Pass-GROUP");
       expect(result.category).toBe("dlc");
@@ -130,6 +146,7 @@ describe("download-categorizer", () => {
         { title: "Game.Update.v2-GROUP" },
         { title: "Game.DLC-GROUP" },
         { title: "Game.OST-GROUP" },
+        { title: "Game.Content.Pack-GROUP" },
       ];
 
       const groups = groupDownloadsByCategory(downloads);
@@ -138,6 +155,7 @@ describe("download-categorizer", () => {
       expect(groups.update).toHaveLength(1);
       expect(groups.dlc).toHaveLength(1);
       expect(groups.extra).toHaveLength(1);
+      expect(groups.packs).toHaveLength(1);
     });
 
     it("returns all empty arrays for empty input", () => {
@@ -146,6 +164,7 @@ describe("download-categorizer", () => {
       expect(groups.update).toEqual([]);
       expect(groups.dlc).toEqual([]);
       expect(groups.extra).toEqual([]);
+      expect(groups.packs).toEqual([]);
     });
 
     it("preserves original download objects in groups", () => {
@@ -171,6 +190,7 @@ describe("download-categorizer", () => {
       expect(getCategoryLabel("update")).toBe("Updates & Patches");
       expect(getCategoryLabel("dlc")).toBe("DLC & Expansions");
       expect(getCategoryLabel("extra")).toBe("Extras");
+      expect(getCategoryLabel("packs")).toBe("Packs/Addons");
     });
   });
 });

--- a/shared/download-categorizer.ts
+++ b/shared/download-categorizer.ts
@@ -5,7 +5,7 @@
  * based on common naming patterns in titles.
  */
 
-export type DownloadCategory = "main" | "update" | "dlc" | "extra";
+export type DownloadCategory = "main" | "update" | "dlc" | "extra" | "packs";
 
 export interface CategorizedDownload {
   category: DownloadCategory;
@@ -15,11 +15,12 @@ export interface CategorizedDownload {
 // Patterns for different download types
 const UPDATE_PATTERNS = [/\bupdate\b/i, /\bpatch\b/i, /\bhotfix\b/i, /\bcrackfix\b/i, /\bfix\b/i];
 
+const PACKS_PATTERNS = [/\bpack\b/i, /\badd-?on\b/i];
+
 const DLC_PATTERNS = [
   /\bDLC\b/i,
   /\bdownloadable content\b/i,
   /\bexpansion\b/i,
-  /\badd-?on\b/i,
   /\bseason pass\b/i,
   /\bdeluxe\b/i,
   /\bgoty\b/i, // Game of the Year editions often include DLC
@@ -58,6 +59,13 @@ export function categorizeDownload(title: string): CategorizedDownload {
     }
   }
 
+  // Specific DLC/expansion keywords take priority over the more general pack/add-on terms.
+  for (const pattern of PACKS_PATTERNS) {
+    if (pattern.test(title)) {
+      return { category: "packs", confidence: 0.85 };
+    }
+  }
+
   // Check for updates
   for (const pattern of UPDATE_PATTERNS) {
     if (pattern.test(title)) {
@@ -84,6 +92,7 @@ export function groupDownloadsByCategory<T extends { title: string }>(
     update: [],
     dlc: [],
     extra: [],
+    packs: [],
   };
 
   downloads.forEach((download) => {
@@ -107,5 +116,7 @@ export function getCategoryLabel(category: DownloadCategory): string {
       return "DLC & Expansions";
     case "extra":
       return "Extras";
+    case "packs":
+      return "Packs/Addons";
   }
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -178,6 +178,12 @@ export const games = sqliteTable("games", {
   searchResultsAvailable: integer("search_results_available", { mode: "boolean" })
     .default(false)
     .notNull(),
+  updateSearchResultsAvailable: integer("update_search_results_available", { mode: "boolean" })
+    .default(false)
+    .notNull(),
+  packsSearchResultsAvailable: integer("packs_search_results_available", { mode: "boolean" })
+    .default(false)
+    .notNull(),
   addedAt: integer("added_at", { mode: "timestamp_ms" }).default(
     sql`(strftime('%s', 'now') * 1000)`
   ),

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -411,7 +411,7 @@ export const claimDownloadRequestSchema = z.object({
   downloadHash: z.string().min(1),
   downloadTitle: z.string().min(1),
   currentStatus: z.string().min(1),
-  category: z.enum(["main", "update", "dlc", "extra"]),
+  category: z.enum(["main", "update", "dlc", "extra", "packs"]),
   gameId: z.string().optional(),
   newGame: z
     .object({
@@ -442,8 +442,8 @@ export const downloadRulesSchema = z.object({
   minSeeders: z.number().int().min(0).default(0),
   sortBy: z.enum(["seeders", "date", "size"]).default("seeders"),
   visibleCategories: z
-    .array(z.enum(["main", "update", "dlc", "extra"]))
-    .default(["main", "update", "dlc", "extra"]),
+    .array(z.enum(["main", "update", "dlc", "extra", "packs"]))
+    .default(["main", "update", "dlc", "extra", "packs"]),
 });
 
 export type DownloadRules = z.infer<typeof downloadRulesSchema>;


### PR DESCRIPTION
﻿## Summary
- add a distinct 'packs' category for standalone packs and add-ons
- expose the category in manual claims, search filtering, and auto-download rules
- auto-search now surfaces packs/add-ons for owned games, like updates
- keep explicit DLC and expansion packs classified as DLC

## Compatibility
- no database migration is required; download categories are stored as text
- existing saved visibility rules remain unchanged, so users can opt into the new category

## Validation
- 'npx vitest run shared/__tests__/download-categorizer.test.ts' (26 passed)
- 'npx tsc --noEmit' (passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Packs/Addons** download category across settings, claims, and download results.
  * Pack and add-on releases are distinguished from DLC and can be filtered, downloaded, and displayed separately.
  * Automatic searches include packs/add-ons and can notify you when matching content is found.
  * Packs/Addons are included in the default visible download categories.

* **Bug Fixes**
  * Improved category counts and labels across download settings and results.
  * Update and pack availability notifications are now tracked independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->