### PR TITLE
Tighten GHCR untagged package pruning to same-day cutoff

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -233,7 +233,7 @@ jobs:
 
           echo "Pruned ${deleted_count} stale test-sha GHCR tag(s)."
 
-      - name: Prune old GHCR package versions (keep 15 days)
+      - name: Prune untagged GHCR package versions (older than today)
         if: github.event_name == 'schedule' && env.ENVIRONMENT == 'dev'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -243,7 +243,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          cutoff_epoch=$(date -u -d '15 days ago' +%s)
+          # Keep only versions created today (UTC); anything untagged and
+          # created before today's start-of-day gets deleted below.
+          cutoff_epoch=$(date -u -d 'today' +%s)
           deleted_count=0
 
           if gh api "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions?per_page=1" >/dev/null 2>&1; then


### PR DESCRIPTION
# Pull Request _Template_

## Description

`.github/workflows/deploy.yml` already has a scheduled step that prunes untagged GHCR package versions (image manifests left behind once a tag moves on, that aren't referenced by any currently-tagged manifest). Previously it kept untagged versions for 15 days before deleting them. This PR changes the cutoff to start-of-today (UTC), so any untagged package version older than today is removed on the next scheduled run instead of waiting up to 15 days.

The digest-safety check that skips versions still referenced by a live tag (added to avoid breaking `docker pull` on multi-manifest/SBOM-attested images) is unchanged.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

(Workflow/CI configuration change — no application code changed.)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

(This is a scheduled GitHub Actions workflow step with no dedicated test suite; validated by parsing the YAML with `python3 -c "import yaml; yaml.safe_load(...)"`.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZuqxysFj9ARaXmf5hu5yu)_