### PR TITLE
Fix Unraid template PUID/PGID defaults and add UMASK support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ENV NODE_ENV=production
 ENV PORT=5000
 ENV PUID=1000
 ENV PGID=1000
+ENV UMASK=022
 
 # Install su-exec (for privilege dropping), shadow (for usermod/groupmod), and
 # Python + Apprise for local CLI notifications.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,12 +9,16 @@ set -e
 
 PUID=${PUID:-1000}
 PGID=${PGID:-1000}
+UMASK=${UMASK:-022}
 
 echo "───────────────────────────────────────"
 echo "  Questarr — Starting container"
 echo "  PUID: ${PUID}"
 echo "  PGID: ${PGID}"
+echo "  UMASK: ${UMASK}"
 echo "───────────────────────────────────────"
+
+umask "$UMASK"
 
 # Adjust the questarr group GID if it differs from PGID
 CURRENT_GID=$(id -g questarr)

--- a/unraid/questarr.xml
+++ b/unraid/questarr.xml
@@ -44,13 +44,18 @@
   </Data>
   <Environment>
     <Variable>
-      <Value>1000</Value>
+      <Value>99</Value>
       <Name>PUID</Name>
       <Mode/>
     </Variable>
     <Variable>
-      <Value>1000</Value>
+      <Value>100</Value>
       <Name>PGID</Name>
+      <Mode/>
+    </Variable>
+    <Variable>
+      <Value>022</Value>
+      <Name>UMASK</Name>
       <Mode/>
     </Variable>
     <Variable>
@@ -69,8 +74,9 @@
   <Config Name="HTTPS/SSL Port" Target="9898" Default="9898" Mode="tcp" Description="Web UI HTTPS/SSL port. Use only for native SSL support." Type="Port" Display="always" Required="false" Mask="false">9898</Config>
   <Config Name="Data Path" Target="/app/data" Default="/mnt/user/appdata/questarr" Mode="rw" Description="Path to store Questarr data including the SQLite database." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/questarr</Config>
   <Config Name="Library Path" Target="/data" Default="" Mode="rw" Description="Optional: mount the same root your download client(s) write into (e.g. /mnt/user/data). Only needed if you want Questarr to move completed downloads into your game library; configure the matching path under Settings &#8594; Path Mappings. Leave blank if you manage imports manually." Type="Path" Display="always" Required="false" Mask="false"></Config>
-  <Config Name="PUID" Target="PUID" Default="1000" Mode="" Description="User ID for file permissions." Type="Variable" Display="always" Required="true" Mask="false">1000</Config>
-  <Config Name="PGID" Target="PGID" Default="1000" Mode="" Description="Group ID for file permissions." Type="Variable" Display="always" Required="true" Mask="false">1000</Config>
+  <Config Name="PUID" Target="PUID" Default="99" Mode="" Description="User ID for file permissions." Type="Variable" Display="always" Required="true" Mask="false">99</Config>
+  <Config Name="PGID" Target="PGID" Default="100" Mode="" Description="Group ID for file permissions." Type="Variable" Display="always" Required="true" Mask="false">100</Config>
+  <Config Name="UMASK" Target="UMASK" Default="022" Mode="" Description="File creation mask for permissions." Type="Variable" Display="advanced" Required="false" Mask="false">022</Config>
   <Config Name="SQLite DB Path" Target="SQLITE_DB_PATH" Default="/app/data/sqlite.db" Mode="" Description="Full path to the SQLite database file inside the container." Type="Variable" Display="advanced" Required="false" Mask="false">/app/data/sqlite.db</Config>
   <Config Name="SSL Port" Target="SSL_PORT" Default="9898" Mode="" Description="SSL port used internally by the app. Must match the HTTPS/SSL port mapping above." Type="Variable" Display="advanced" Required="false" Mask="false">9898</Config>
 </Container>


### PR DESCRIPTION
## Description

The Unraid Community Applications template for Questarr defaulted `PUID`/`PGID` to `1000`/`1000`, which caused the container to fail to start (or loop) for Unraid users, since Unraid's conventional user/group is `nobody:users` (`99:100`). This also adds a `UMASK` variable so file creation permissions can be tuned from the template, as requested.

Fixes: https://github.com/Doezer/Questarr/issues/466#issuecomment-5177189220

Changes:
- `unraid/questarr.xml`: default `PUID` to `99`, `PGID` to `100`, and add a new `UMASK` config/variable (default `022`).
- `entrypoint.sh`: apply the `UMASK` env var via `umask` before dropping to the `questarr` user, so the new template variable actually takes effect for file permissions.
- `Dockerfile`: set a default `UMASK=022` env var for consistency with the existing `PUID`/`PGID` defaults.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (verified `sh -n entrypoint.sh` and XML validation; no automated tests cover the Unraid template or entrypoint script)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CASGL43MKqq5bGmKMKRVuT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default file permissions for files created by the container.
  * Updated Unraid container defaults to use standard permission settings.
  * Added an optional UMASK configuration for advanced permission control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->