### PR TITLE
⚡ Bolt: optimize sidebar badge calculation performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -52,3 +52,13 @@
 
 **Learning:** When extracting code logic to satisfy SonarCloud Maintainability and Duplication gates (such as creating helper functions to eliminate nested ternaries), ensure that the TypeScript method signature explicitly allows the types of the underlying variables (e.g., `Date | number | string | null | undefined`) instead of using `as unknown as string` casts, which bypasses the type-checker and reduces code safety.
 **Action:** Define broad, accurate union types for helper functions rather than aggressively casting parameters to fit narrow function signatures.
+
+## 2026-07-30 - O(N) Array Iteration Optimization
+
+**Learning:** Using chained `.filter()` calls evaluates the entire array on each pass and re-evaluating the invariant `searchQuery.toLowerCase()` inside the loops causes redundant allocations.
+**Action:** When computing multiple derived states from the same dependency array in `useMemo`, consolidate the logic into a single manual `for` loop to achieve a single pass (O(N)). Also, always ensure invariant derivations (like `.toLowerCase()`) are evaluated outside the loop.
+
+## 2026-07-30 - O(N) Array Filter Optimization
+
+**Learning:** Using chained `.filter(...).length` calls for counting evaluates the entire array on each pass and creates unnecessary array allocations for items that are immediately discarded. In heavily re-rendered components like `AppSidebar`, this degrades performance.
+**Action:** When counting items based on a condition, always use a single manual `for` loop to increment a counter instead of `.filter(...).length`. Ensure this is wrapped in a `useMemo` hook to prevent recalculation on every render.

--- a/client/src/components/AppSidebar.tsx
+++ b/client/src/components/AppSidebar.tsx
@@ -45,11 +45,25 @@ export default function AppSidebar({ activeItem = "/", onNavigate }: Readonly<Ap
     refetchInterval: 30_000,
   });
 
+  // ⚡ Bolt: Consolidate O(N) filtering into a single loop to avoid redundant array allocations.
   const wishlistCount = useMemo(() => {
-    return games.filter((g) => g.status === "wanted").length;
+    let count = 0;
+    for (let i = 0; i < games.length; i++) {
+      if (games[i].status === "wanted") count++;
+    }
+    return count;
   }, [games]);
-  const activeDownloadsCount =
-    downloadsData?.downloads?.filter((d) => d.status === "downloading").length || 0;
+
+  // ⚡ Bolt: Wrap in useMemo and use a manual loop to prevent O(N) traversals on every render.
+  const activeDownloadsCount = useMemo(() => {
+    const downloads = downloadsData?.downloads;
+    if (!downloads) return 0;
+    let count = 0;
+    for (let i = 0; i < downloads.length; i++) {
+      if (downloads[i].status === "downloading") count++;
+    }
+    return count;
+  }, [downloadsData?.downloads]);
 
   const navigation = primaryNavigation.map((item) => {
     let badge: string | undefined;


### PR DESCRIPTION
💡 What: Replaced array `.filter(...).length` calls with manual `for` loop counters in `AppSidebar.tsx` and wrapped the `activeDownloadsCount` derivation in a `useMemo` hook.

🎯 Why: Using `.filter().length` evaluates the entire array on each pass and creates unnecessary array allocations for items that are immediately discarded. In heavily re-rendered components like `AppSidebar` (which spans across the entire application and updates frequently via React Query interval polling), this degrades frontend performance and increases garbage collection overhead.

📊 Impact: Reduces memory allocation and iteration overhead by avoiding intermediate array creations. Ensures `activeDownloadsCount` is strictly memoized and only recalculates when the underlying downloads list updates, eliminating an `O(N)` traversal from every general React render cycle.

🔬 Measurement: Observe the React DevTools Profiler while navigating between pages or receiving background download updates. The render time of the `AppSidebar` component will be slightly reduced, and memory snapshots will show fewer intermediate arrays being allocated and collected.

---
*PR created automatically by Jules for task [12408274492004152721](https://jules.google.com/task/12408274492004152721) started by @Doezer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved sidebar responsiveness by optimizing wishlist and active-download badge count calculations.
  * Download badges now display zero when download information is unavailable, providing clearer and more consistent feedback.

* **Documentation**
  * Added performance guidance for efficient derived-state calculations and condition-based item counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->