### PR TITLE
🎨 Palette: Replace native tooltips with UI tooltips in RssFeedList

### DIFF
--- a/client/src/components/RssFeedList.tsx
+++ b/client/src/components/RssFeedList.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { formatDistanceToNow } from "date-fns";
 import { ExternalLink, RefreshCw, AlertTriangle, LayoutGrid, List } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { apiRequest } from "@/lib/queryClient";
 import CompactRssFeedItem from "./CompactRssFeedItem";
 import { cn, safeUrl } from "@/lib/utils";
@@ -63,26 +64,38 @@ export default function RssFeedList() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-2 border rounded-md p-1 bg-muted/50">
-          <Button
-            variant={viewMode === "grid" ? "secondary" : "ghost"}
-            size="sm"
-            className="h-8 w-8 p-0"
-            onClick={() => setViewMode("grid")}
-            title="Grid View"
-            aria-label="Grid View"
-          >
-            <LayoutGrid className="h-4 w-4" aria-hidden="true" />
-          </Button>
-          <Button
-            variant={viewMode === "list" ? "secondary" : "ghost"}
-            size="sm"
-            className="h-8 w-8 p-0"
-            onClick={() => setViewMode("list")}
-            title="List View"
-            aria-label="List View"
-          >
-            <List className="h-4 w-4" aria-hidden="true" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={viewMode === "grid" ? "secondary" : "ghost"}
+                size="sm"
+                className="h-8 w-8 p-0"
+                onClick={() => setViewMode("grid")}
+                aria-label="Grid View"
+              >
+                <LayoutGrid className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Grid View</p>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={viewMode === "list" ? "secondary" : "ghost"}
+                size="sm"
+                className="h-8 w-8 p-0"
+                onClick={() => setViewMode("list")}
+                aria-label="List View"
+              >
+                <List className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>List View</p>
+            </TooltipContent>
+          </Tooltip>
         </div>
 
         <Button onClick={() => refreshFeeds()} disabled={isRefreshing} size="sm" variant="outline">


### PR DESCRIPTION
💡 **What**: Replaced the native `title` attributes on the "Grid View" and "List View" icon buttons in `RssFeedList.tsx` with custom `Tooltip` components from `@/components/ui/tooltip`.

🎯 **Why**: Native HTML `title` attributes suffer from unpredictable delays and poor visual integration compared to UI tooltips. This enhances the user experience by providing immediate, visually consistent feedback for icon-only actions.

📸 **Before/After**: Visually, users hovering over the Grid and List toggle buttons will see an instant, styled tooltip ("Grid View" or "List View") instead of a delayed browser-default title box.

♿ **Accessibility**: The change uses standard `aria-label` attributes on the buttons to ensure screen readers continue to properly announce the actions, while providing visual users with clearer, more responsive feedback.

---
*PR created automatically by Jules for task [12626816271433626031](https://jules.google.com/task/12626816271433626031) started by @Doezer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added clearer hover tooltips for the Grid View and List View controls.
  * Preserved existing view-selection behavior and accessibility labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->