### PR TITLE
Combine #887, #888, #889: sidebar perf, RSS tooltips, downloader SSRF fix

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -52,3 +52,8 @@
 
 **Learning:** When extracting code logic to satisfy SonarCloud Maintainability and Duplication gates (such as creating helper functions to eliminate nested ternaries), ensure that the TypeScript method signature explicitly allows the types of the underlying variables (e.g., `Date | number | string | null | undefined`) instead of using `as unknown as string` casts, which bypasses the type-checker and reduces code safety.
 **Action:** Define broad, accurate union types for helper functions rather than aggressively casting parameters to fit narrow function signatures.
+
+## 2026-07-30 - O(N) Array Filter Optimization
+
+**Learning:** Using chained `.filter(...).length` calls for counting evaluates the entire array on each pass and creates unnecessary array allocations for items that are immediately discarded. In heavily re-rendered components like `AppSidebar`, this degrades performance. SonarCloud also flags manual index-based `for` loops over arrays when the index itself is unused — a `for...of` loop is the preferred single-pass form.
+**Action:** When counting items based on a condition, use a memoized `for...of` loop to increment a counter instead of `.filter(...).length`. Also hoist any `useQuery` no-data fallback (e.g. `data: x = []`) to a stable module-level constant — an inline `[]` default creates a new array reference on every render with no data, which defeats a `useMemo` keyed on that value.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,8 +22,14 @@
 **Learning:** Checking for string prefixes on URLs is insufficient for security because the userinfo component (e.g. `https://discord.com/api/webhooks/@127.0.0.1`) can be used to bypass the check. The `fetch` API and URL parsers will interpret `127.0.0.1` as the hostname and `discord.com` as the credentials.
 **Prevention:** Never rely on string prefix matching for URL validation. Always use the project's `safeFetch` utility which properly resolves and validates the target IP address to prevent SSRF and DNS rebinding attacks.
 
-## $(date +%Y-%m-%d) - Prevent SSRF by validating parsed URL components instead of prefix matching
+## 2025-05-24 - Prevent SSRF by validating parsed URL components instead of prefix matching
 
 **Vulnerability:** The application validated Discord webhook URLs (and potentially other external URLs) by matching the string prefix (`url.startsWith("https://discord.com")`). This is vulnerable to SSRF bypasses via the userinfo component (e.g., `https://discord.com@127.0.0.1/api/webhooks/`).
 **Learning:** Checking string prefixes for URL validation is fundamentally insecure because parts of the prefix might be interpreted as the username/password in a URL with a different domain. Attackers can leverage this to bypass domain allowlists.
 **Prevention:** Always use the `URL` object (e.g., `new URL()`) to parse URLs and explicitly validate the `hostname` and `pathname` properties instead of checking raw string prefixes.
+
+## 2025-05-24 - SSRF Prevention in Internal Downstream Requests
+
+**Vulnerability:** Downloader API communication (e.g. qBittorrent, Transmission, NZBGet, Deluge, rTorrent) was using the native `fetch()` to call external URLs (e.g. downloaders running locally or remotely), making the application vulnerable to Server-Side Request Forgery (SSRF) and DNS Rebinding via metadata or local networks.
+**Learning:** Even internal API connections must be shielded from interacting with sensitive hostnames or local/cloud metadata networks (169.254.169.254, etc.) via DNS rebinding. Replacing native `fetch` with a secure wrapper ensures strict host-level validation of all connections.
+**Prevention:** Always use the local `safeFetch` implementation from `server/ssrf.ts` instead of the global `fetch()` when making external network requests to any user-provided URL or API configuration to prevent SSRF vulnerabilities.

--- a/client/src/components/AppSidebar.tsx
+++ b/client/src/components/AppSidebar.tsx
@@ -50,9 +50,9 @@ export default function AppSidebar({ activeItem = "/", onNavigate }: Readonly<Ap
   });
 
   // ⚡ Single-pass counts instead of `.filter(...).length`, which walks the array
-  // twice (filter + length) and allocates an intermediate array that's immediately
-  // discarded. Memoized so heavily re-rendered components like this sidebar don't
-  // recompute on every render.
+  // once and allocates an intermediate array that's immediately discarded.
+  // Memoized so heavily re-rendered components like this sidebar don't recompute
+  // on every render.
   const wishlistCount = useMemo(() => {
     let count = 0;
     for (const game of games) {

--- a/client/src/components/AppSidebar.tsx
+++ b/client/src/components/AppSidebar.tsx
@@ -29,6 +29,10 @@ interface AppSidebarProps {
   onNavigate?: (url: string) => void;
 }
 
+// Stable reference for useQuery's no-data fallback so `games` doesn't change
+// identity on every render (which would otherwise defeat wishlistCount's memo).
+const EMPTY_GAMES: Game[] = [];
+
 export default function AppSidebar({ activeItem = "/", onNavigate }: Readonly<AppSidebarProps>) {
   const { logout, user } = useAuth();
 
@@ -36,7 +40,7 @@ export default function AppSidebar({ activeItem = "/", onNavigate }: Readonly<Ap
     onNavigate?.(url);
   };
 
-  const { data: games = [] } = useQuery<Game[]>({
+  const { data: games = EMPTY_GAMES } = useQuery<Game[]>({
     queryKey: ["/api/games"],
   });
 
@@ -45,11 +49,27 @@ export default function AppSidebar({ activeItem = "/", onNavigate }: Readonly<Ap
     refetchInterval: 30_000,
   });
 
+  // ⚡ Single-pass counts instead of `.filter(...).length`, which walks the array
+  // twice (filter + length) and allocates an intermediate array that's immediately
+  // discarded. Memoized so heavily re-rendered components like this sidebar don't
+  // recompute on every render.
   const wishlistCount = useMemo(() => {
-    return games.filter((g) => g.status === "wanted").length;
+    let count = 0;
+    for (const game of games) {
+      if (game.status === "wanted") count++;
+    }
+    return count;
   }, [games]);
-  const activeDownloadsCount =
-    downloadsData?.downloads?.filter((d) => d.status === "downloading").length || 0;
+
+  const activeDownloadsCount = useMemo(() => {
+    const downloads = downloadsData?.downloads;
+    if (!downloads) return 0;
+    let count = 0;
+    for (const download of downloads) {
+      if (download.status === "downloading") count++;
+    }
+    return count;
+  }, [downloadsData?.downloads]);
 
   const navigation = primaryNavigation.map((item) => {
     let badge: string | undefined;

--- a/client/src/components/RssFeedList.tsx
+++ b/client/src/components/RssFeedList.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { formatDistanceToNow } from "date-fns";
 import { ExternalLink, RefreshCw, AlertTriangle, LayoutGrid, List } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { apiRequest } from "@/lib/queryClient";
 import CompactRssFeedItem from "./CompactRssFeedItem";
 import { cn, safeUrl } from "@/lib/utils";
@@ -63,26 +64,38 @@ export default function RssFeedList() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-2 border rounded-md p-1 bg-muted/50">
-          <Button
-            variant={viewMode === "grid" ? "secondary" : "ghost"}
-            size="sm"
-            className="h-8 w-8 p-0"
-            onClick={() => setViewMode("grid")}
-            title="Grid View"
-            aria-label="Grid View"
-          >
-            <LayoutGrid className="h-4 w-4" aria-hidden="true" />
-          </Button>
-          <Button
-            variant={viewMode === "list" ? "secondary" : "ghost"}
-            size="sm"
-            className="h-8 w-8 p-0"
-            onClick={() => setViewMode("list")}
-            title="List View"
-            aria-label="List View"
-          >
-            <List className="h-4 w-4" aria-hidden="true" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={viewMode === "grid" ? "secondary" : "ghost"}
+                size="sm"
+                className="h-8 w-8 p-0"
+                onClick={() => setViewMode("grid")}
+                aria-label="Grid View"
+              >
+                <LayoutGrid className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Grid View</p>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={viewMode === "list" ? "secondary" : "ghost"}
+                size="sm"
+                className="h-8 w-8 p-0"
+                onClick={() => setViewMode("list")}
+                aria-label="List View"
+              >
+                <List className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>List View</p>
+            </TooltipContent>
+          </Tooltip>
         </div>
 
         <Button onClick={() => refreshFeeds()} disabled={isRefreshing} size="sm" variant="outline">

--- a/server/__tests__/downloaders_deluge.test.ts
+++ b/server/__tests__/downloaders_deluge.test.ts
@@ -19,6 +19,7 @@ vi.mock("../logger.js", () => ({
 
 vi.mock("../ssrf.js", () => ({
   isSafeUrl: vi.fn().mockResolvedValue(true),
+  safeFetch: vi.fn((url: string, options?: RequestInit) => fetch(url, options)),
 }));
 
 vi.mock("../downloaders/utils.js", async (importOriginal) => {

--- a/server/__tests__/downloaders_deluge_coverage.test.ts
+++ b/server/__tests__/downloaders_deluge_coverage.test.ts
@@ -19,6 +19,7 @@ vi.mock("../logger.js", () => ({
 
 vi.mock("../ssrf.js", () => ({
   isSafeUrl: vi.fn().mockResolvedValue(true),
+  safeFetch: vi.fn((url: string, options?: RequestInit) => fetch(url, options)),
 }));
 
 vi.mock("../downloaders/utils.js", async (importOriginal) => {

--- a/server/__tests__/downloaders_deluge_remaining.test.ts
+++ b/server/__tests__/downloaders_deluge_remaining.test.ts
@@ -18,6 +18,10 @@ vi.mock("../logger.js", () => ({
 }));
 
 global.fetch = fetchMock as unknown as typeof fetch;
+vi.mock("../ssrf.js", () => ({
+  isSafeUrl: vi.fn().mockResolvedValue(true),
+  safeFetch: vi.fn((url: string, options?: RequestInit) => global.fetch(url, options)),
+}));
 
 const { DelugeClient } = await import("../downloaders/deluge.js");
 

--- a/server/__tests__/downloaders_helpers_regression.test.ts
+++ b/server/__tests__/downloaders_helpers_regression.test.ts
@@ -10,11 +10,12 @@ import { RTorrentClient } from "../downloaders/rtorrent.js";
 import { SABnzbdClient } from "../downloaders/sabnzbd.js";
 import { SynologyDownloadStationClient } from "../downloaders/synology.js";
 import { TransmissionClient } from "../downloaders/transmission.js";
+import { safeFetch } from "../ssrf.js";
 
-vi.mock("dns/promises", () => ({
-  default: {
-    lookup: vi.fn().mockResolvedValue([{ address: "127.0.0.1", family: 4 }]),
-  },
+vi.mock("../ssrf.js", () => ({
+  isSafeUrl: vi.fn().mockResolvedValue(true),
+  safeFetch: vi.fn((url: string, options?: RequestInit) => fetch(url, options)),
+  resolveSafeAddress: vi.fn().mockResolvedValue({ address: "127.0.0.1", family: 4 }),
 }));
 
 vi.mock("../logger.js", () => ({
@@ -154,6 +155,11 @@ describe("downloaders helper regression coverage", () => {
 
     await expect(client.fetchWithFallback("https://sab.local", {})).resolves.toBe(insecureResponse);
     expect(insecureSpy).toHaveBeenCalled();
+    // fetchWithFallback must route through the SSRF-safe wrapper, not raw fetch.
+    expect(safeFetch).toHaveBeenCalledWith(
+      "https://sab.local",
+      expect.objectContaining({ allowPrivate: true })
+    );
 
     fetchMock.mockRejectedValueOnce(new Error("network boom"));
     await expect(client.fetchWithFallback("https://sab.local", {})).rejects.toThrow("network boom");
@@ -370,6 +376,9 @@ describe("downloaders helper regression coverage", () => {
     const retriedCall = fetchMock.mock.calls[1][1] as RequestInit;
     expect((retriedCall.headers as Record<string, string>).Cookie).toBe("SID=new");
     expect(retriedCall.body).toBeInstanceOf(Uint8Array);
+    // makeRequest must route both the initial request and the re-auth retry
+    // through the SSRF-safe wrapper rather than calling fetch() directly.
+    expect(safeFetch).toHaveBeenCalledTimes(2);
 
     fetchMock
       .mockResolvedValueOnce({

--- a/server/__tests__/downloaders_nzbget_remaining.test.ts
+++ b/server/__tests__/downloaders_nzbget_remaining.test.ts
@@ -52,6 +52,11 @@ describe("NZBGet remaining coverage", () => {
     vi.mocked(isSafeUrl).mockResolvedValue(true);
     vi.mocked(safeFetch).mockReset();
     vi.stubGlobal("fetch", vi.fn());
+    // Default: forward to the (mocked) global fetch so existing tests that only
+    // stub `fetch` keep working now that downloader requests go through safeFetch.
+    vi.mocked(safeFetch).mockImplementation((url: string, options?: RequestInit) =>
+      fetch(url, options)
+    );
   });
 
   it("covers URL fallback, XML value parsing fallbacks, faults, and null responses", async () => {
@@ -114,6 +119,8 @@ describe("NZBGet remaining coverage", () => {
          </methodResponse>`,
     } as Response);
     await expect(privateClient.makeXMLRPCRequest("echo", ["param"])).resolves.toBe("pong");
+    // makeXMLRPCRequest must route through the SSRF-safe wrapper, not raw fetch.
+    expect(safeFetch).toHaveBeenCalled();
 
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,

--- a/server/__tests__/downloaders_qbittorrent_remaining.test.ts
+++ b/server/__tests__/downloaders_qbittorrent_remaining.test.ts
@@ -21,7 +21,7 @@ vi.mock("../logger.js", () => ({
 
 vi.mock("../ssrf.js", () => ({
   isSafeUrl: vi.fn().mockResolvedValue(true),
-  safeFetch: vi.fn(),
+  safeFetch: vi.fn((url: string, options?: RequestInit) => global.fetch(url, options)),
 }));
 
 vi.mock("../downloaders/utils.js", async (importOriginal) => {
@@ -34,7 +34,7 @@ vi.mock("../downloaders/utils.js", async (importOriginal) => {
 
 global.fetch = fetchMock as unknown as typeof fetch;
 
-const { isSafeUrl } = await import("../ssrf.js");
+const { isSafeUrl, safeFetch } = await import("../ssrf.js");
 const { QBittorrentClient } = await import("../downloaders/qbittorrent.js");
 
 const createDownloader = (overrides: Partial<Downloader> = {}): Downloader => {
@@ -115,6 +115,8 @@ describe("qbittorrent remaining regression coverage", () => {
     await expect(authClient.authenticate(true)).rejects.toThrow(
       "Authentication failed: 503 Offline - denied"
     );
+    // authenticate() must route through the SSRF-safe wrapper, not raw fetch.
+    expect(safeFetch).toHaveBeenCalled();
 
     fetchMock
       .mockResolvedValueOnce({

--- a/server/__tests__/downloaders_rtorrent_remaining.test.ts
+++ b/server/__tests__/downloaders_rtorrent_remaining.test.ts
@@ -22,6 +22,7 @@ vi.mock("../logger.js", () => ({
 
 vi.mock("../ssrf.js", () => ({
   isSafeUrl: vi.fn().mockResolvedValue(true),
+  safeFetch: vi.fn((url: string, options?: RequestInit) => fetch(url, options)),
 }));
 
 vi.mock("../downloaders/utils.js", async (importOriginal) => {

--- a/server/__tests__/downloaders_transmission_remaining.test.ts
+++ b/server/__tests__/downloaders_transmission_remaining.test.ts
@@ -21,6 +21,7 @@ vi.mock("../logger.js", () => ({
 
 vi.mock("../ssrf.js", () => ({
   isSafeUrl: vi.fn().mockResolvedValue(true),
+  safeFetch: vi.fn((url: string, options?: RequestInit) => fetch(url, options)),
 }));
 
 vi.mock("../downloaders/utils.js", async (importOriginal) => {

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Downloader } from "../../shared/schema";
 import { DownloaderManager } from "../downloaders.js";
 
+vi.mock("../ssrf.js", () => ({
+  isSafeUrl: vi.fn().mockResolvedValue(true),
+  safeFetch: vi.fn((url: string, options?: RequestInit) => global.fetch(url, options)),
+}));
+
 describe("/api/downloads endpoint", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 

--- a/server/__tests__/ssrf.test.ts
+++ b/server/__tests__/ssrf.test.ts
@@ -223,13 +223,19 @@ describe("safeFetch", () => {
     vi.mocked(fetch).mockResolvedValueOnce(new Response("ok"));
 
     await safeFetch("https://example.com/rpc", {
-      headers: { Authorization: "Basic secret", Cookie: "SID=secret", "X-Other": "keep-me" },
+      headers: {
+        Authorization: "Basic secret",
+        Cookie: "SID=secret",
+        "Proxy-Authorization": "Basic proxy-secret",
+        "X-Other": "keep-me",
+      },
     });
 
     expect(fetch).toHaveBeenCalledTimes(2);
     const redirectedHeaders = new Headers(vi.mocked(fetch).mock.calls[1][1]?.headers);
     expect(redirectedHeaders.get("authorization")).toBeNull();
     expect(redirectedHeaders.get("cookie")).toBeNull();
+    expect(redirectedHeaders.get("proxy-authorization")).toBeNull();
     expect(redirectedHeaders.get("x-other")).toBe("keep-me");
   });
 
@@ -249,12 +255,51 @@ describe("safeFetch", () => {
     vi.mocked(fetch).mockResolvedValueOnce(new Response("ok"));
 
     await safeFetch("https://example.com/rpc", {
-      headers: { Authorization: "Basic secret" },
+      headers: { Authorization: "Basic secret", Cookie: "SID=secret" },
     });
 
     expect(fetch).toHaveBeenCalledTimes(2);
     const redirectedHeaders = new Headers(vi.mocked(fetch).mock.calls[1][1]?.headers);
     expect(redirectedHeaders.get("authorization")).toBe("Basic secret");
+    expect(redirectedHeaders.get("cookie")).toBe("SID=secret");
+  });
+
+  it("should preserve HEAD (not switch to GET) on a 303 redirect", async () => {
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
+      { address: "1.2.3.4", family: 4 },
+    ]);
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, { status: 303, headers: { location: "https://example.com/rpc2" } })
+    );
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
+      { address: "1.2.3.4", family: 4 },
+    ]);
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("ok"));
+
+    await safeFetch("https://example.com/rpc", { method: "HEAD" });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(fetch).mock.calls[1][1]?.method).toBe("HEAD");
+  });
+
+  it("should switch POST to GET on a 303 redirect", async () => {
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
+      { address: "1.2.3.4", family: 4 },
+    ]);
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, { status: 303, headers: { location: "https://example.com/rpc2" } })
+    );
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
+      { address: "1.2.3.4", family: 4 },
+    ]);
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("ok"));
+
+    await safeFetch("https://example.com/rpc", { method: "POST", body: "payload" });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const redirectedCall = vi.mocked(fetch).mock.calls[1][1];
+    expect(redirectedCall?.method).toBe("GET");
+    expect(redirectedCall?.body).toBeUndefined();
   });
 
   it("should reject URLs that fail DNS resolution", async () => {

--- a/server/__tests__/ssrf.test.ts
+++ b/server/__tests__/ssrf.test.ts
@@ -264,40 +264,49 @@ describe("safeFetch", () => {
     expect(redirectedHeaders.get("cookie")).toBe("SID=secret");
   });
 
-  it("should preserve HEAD (not switch to GET) on a 303 redirect", async () => {
+  // Shared setup for the method-rewrite matrix below: one same-origin redirect
+  // hop, then a successful response — only the initial status/method vary.
+  async function fetchThroughRedirect(
+    status: number,
+    method: string,
+    body?: string
+  ): Promise<RequestInit | undefined> {
     vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
       { address: "1.2.3.4", family: 4 },
     ]);
     vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(null, { status: 303, headers: { location: "https://example.com/rpc2" } })
+      new Response(null, { status, headers: { location: "https://example.com/rpc2" } })
     );
     vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
       { address: "1.2.3.4", family: 4 },
     ]);
     vi.mocked(fetch).mockResolvedValueOnce(new Response("ok"));
 
-    await safeFetch("https://example.com/rpc", { method: "HEAD" });
+    await safeFetch("https://example.com/rpc", { method, body });
 
     expect(fetch).toHaveBeenCalledTimes(2);
-    expect(vi.mocked(fetch).mock.calls[1][1]?.method).toBe("HEAD");
-  });
+    return vi.mocked(fetch).mock.calls[1][1];
+  }
 
-  it("should switch POST to GET on a 303 redirect", async () => {
-    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
-      { address: "1.2.3.4", family: 4 },
-    ]);
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(null, { status: 303, headers: { location: "https://example.com/rpc2" } })
-    );
-    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
-      { address: "1.2.3.4", family: 4 },
-    ]);
-    vi.mocked(fetch).mockResolvedValueOnce(new Response("ok"));
+  it.each([
+    [303, "HEAD"],
+    [301, "PUT"],
+    [302, "PATCH"],
+    [301, "DELETE"],
+  ])(
+    "should preserve the request method on a %s redirect with method %s",
+    async (status, method) => {
+      const redirectedCall = await fetchThroughRedirect(status, method);
+      expect(redirectedCall?.method).toBe(method);
+    }
+  );
 
-    await safeFetch("https://example.com/rpc", { method: "POST", body: "payload" });
-
-    expect(fetch).toHaveBeenCalledTimes(2);
-    const redirectedCall = vi.mocked(fetch).mock.calls[1][1];
+  it.each([
+    [303, "POST"],
+    [301, "POST"],
+    [302, "POST"],
+  ])("should switch to GET on a %s redirect with method %s", async (status, method) => {
+    const redirectedCall = await fetchThroughRedirect(status, method, "payload");
     expect(redirectedCall?.method).toBe("GET");
     expect(redirectedCall?.body).toBeUndefined();
   });

--- a/server/__tests__/ssrf.test.ts
+++ b/server/__tests__/ssrf.test.ts
@@ -289,20 +289,22 @@ describe("safeFetch", () => {
   }
 
   it.each([
-    [303, "HEAD"],
-    [301, "PUT"],
-    [302, "PATCH"],
-    [301, "DELETE"],
+    [303, "HEAD", undefined],
+    [301, "PUT", "payload"],
+    [302, "PATCH", "payload"],
+    [301, "DELETE", "payload"],
   ])(
-    "should preserve the request method on a %s redirect with method %s",
-    async (status, method) => {
-      const redirectedCall = await fetchThroughRedirect(status, method);
+    "should preserve the request method and body on a %s redirect with method %s",
+    async (status, method, body) => {
+      const redirectedCall = await fetchThroughRedirect(status, method, body);
       expect(redirectedCall?.method).toBe(method);
+      expect(redirectedCall?.body).toBe(body);
     }
   );
 
   it.each([
     [303, "POST"],
+    [303, "PUT"],
     [301, "POST"],
     [302, "POST"],
   ])("should switch to GET on a %s redirect with method %s", async (status, method) => {

--- a/server/__tests__/ssrf.test.ts
+++ b/server/__tests__/ssrf.test.ts
@@ -205,6 +205,58 @@ describe("safeFetch", () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
+  it("should strip Authorization/Cookie headers when a redirect crosses origins", async () => {
+    // Initial request to example.com...
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
+      { address: "1.2.3.4", family: 4 },
+    ]);
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://attacker.example/steal" },
+      })
+    );
+    // ...redirected to a different origin, which must be revalidated too.
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
+      { address: "5.6.7.8", family: 4 },
+    ]);
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("ok"));
+
+    await safeFetch("https://example.com/rpc", {
+      headers: { Authorization: "Basic secret", Cookie: "SID=secret", "X-Other": "keep-me" },
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const redirectedHeaders = new Headers(vi.mocked(fetch).mock.calls[1][1]?.headers);
+    expect(redirectedHeaders.get("authorization")).toBeNull();
+    expect(redirectedHeaders.get("cookie")).toBeNull();
+    expect(redirectedHeaders.get("x-other")).toBe("keep-me");
+  });
+
+  it("should preserve Authorization/Cookie headers when a redirect stays same-origin", async () => {
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
+      { address: "1.2.3.4", family: 4 },
+    ]);
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://example.com/rpc2" },
+      })
+    );
+    vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockResolvedValueOnce([
+      { address: "1.2.3.4", family: 4 },
+    ]);
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("ok"));
+
+    await safeFetch("https://example.com/rpc", {
+      headers: { Authorization: "Basic secret" },
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const redirectedHeaders = new Headers(vi.mocked(fetch).mock.calls[1][1]?.headers);
+    expect(redirectedHeaders.get("authorization")).toBe("Basic secret");
+  });
+
   it("should reject URLs that fail DNS resolution", async () => {
     // Mock DNS lookup to fail
     vi.mocked(dns.lookup as unknown as import("node:dns").LookupAddress[]).mockRejectedValueOnce(

--- a/server/downloaders/deluge.ts
+++ b/server/downloaders/deluge.ts
@@ -6,7 +6,7 @@ import type {
   DownloadDetails,
 } from "../../shared/schema.js";
 import { downloadersLogger } from "../logger.js";
-import { isSafeUrl } from "../ssrf.js";
+import { isSafeUrl, safeFetch } from "../ssrf.js";
 import type { DownloadRequest, DownloaderClient } from "./types.js";
 import { fetchWithMagnetDetection, extractHashFromUrl } from "./utils.js";
 import { z } from "zod";
@@ -767,7 +767,7 @@ export class DelugeClient implements DownloaderClient {
       headers["Cookie"] = this.cookie;
     }
 
-    const response = await fetch(url, {
+    const response = await safeFetch(url, {
       method: "POST",
       headers,
       body: JSON.stringify(body),

--- a/server/downloaders/nzbget.ts
+++ b/server/downloaders/nzbget.ts
@@ -196,7 +196,7 @@ export class NZBGetClient implements DownloaderClient {
 
     downloadersLogger.debug({ url, method, params: logParams }, "Making NZBGet XML-RPC request");
 
-    const response = await fetch(url, {
+    const response = await safeFetch(url, {
       method: "POST",
       headers,
       body: xmlBody,

--- a/server/downloaders/qbittorrent.ts
+++ b/server/downloaders/qbittorrent.ts
@@ -8,7 +8,7 @@ import type {
 import { downloadersLogger } from "../logger.js";
 import { randomUUID } from "node:crypto";
 import parseTorrent from "parse-torrent";
-import { isSafeUrl } from "../ssrf.js";
+import { isSafeUrl, safeFetch } from "../ssrf.js";
 import type { DownloadRequest, DownloaderClient } from "./types.js";
 import { fetchWithMagnetDetection, extractHashFromUrl, fixNzbUrlEncoding } from "./utils.js";
 
@@ -1189,7 +1189,7 @@ export class QBittorrentClient implements DownloaderClient {
     formData.append("password", this.downloader.password);
 
     try {
-      const response = await fetch(url, {
+      const response = await safeFetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
@@ -1339,7 +1339,7 @@ export class QBittorrentClient implements DownloaderClient {
       "Making qBittorrent request"
     );
 
-    let response = await fetch(url, {
+    let response = await safeFetch(url, {
       method,
       headers,
       body: requestBody,
@@ -1358,7 +1358,7 @@ export class QBittorrentClient implements DownloaderClient {
         retryHeaders["Cookie"] = this.cookie;
       }
 
-      response = await fetch(url, {
+      response = await safeFetch(url, {
         method,
         headers: retryHeaders,
         body: requestBody,

--- a/server/downloaders/rtorrent.ts
+++ b/server/downloaders/rtorrent.ts
@@ -8,7 +8,7 @@ import type {
 import { downloadersLogger } from "../logger.js";
 import parseTorrent from "parse-torrent";
 import crypto from "crypto";
-import { isSafeUrl } from "../ssrf.js";
+import { isSafeUrl, safeFetch } from "../ssrf.js";
 import type { DownloadRequest, DownloaderClient, XMLValue } from "./types.js";
 import { fetchWithMagnetDetection, extractHashFromUrl } from "./utils.js";
 import { XMLParser } from "fast-xml-parser";
@@ -711,7 +711,7 @@ export class RTorrentClient implements DownloaderClient {
       headers["Authorization"] = `Basic ${auth}`;
     }
 
-    const response = await fetch(url, {
+    const response = await safeFetch(url, {
       method: "POST",
       headers,
       body: xmlBody,
@@ -744,7 +744,7 @@ export class RTorrentClient implements DownloaderClient {
 
             downloadersLogger.debug({ url }, "Retrying rTorrent request with Digest Auth");
 
-            const retryResponse = await fetch(url, {
+            const retryResponse = await safeFetch(url, {
               method: "POST",
               headers,
               body: xmlBody,

--- a/server/downloaders/transmission.ts
+++ b/server/downloaders/transmission.ts
@@ -7,7 +7,7 @@ import type {
 } from "../../shared/schema.js";
 import { downloadersLogger } from "../logger.js";
 import parseTorrent from "parse-torrent";
-import { isSafeUrl } from "../ssrf.js";
+import { isSafeUrl, safeFetch } from "../ssrf.js";
 import type { DownloadRequest, DownloaderClient } from "./types.js";
 import { fetchWithMagnetDetection } from "./utils.js";
 
@@ -699,7 +699,7 @@ export class TransmissionClient implements DownloaderClient {
       headers["Authorization"] = `Basic ${auth}`;
     }
 
-    const response = await fetch(url, {
+    const response = await safeFetch(url, {
       method: "POST",
       headers,
       body: JSON.stringify(body),
@@ -716,7 +716,7 @@ export class TransmissionClient implements DownloaderClient {
         downloadersLogger.debug({ method, url }, "Retrying Transmission request with session ID");
 
         // Retry with session ID
-        const retryResponse = await fetch(url, {
+        const retryResponse = await safeFetch(url, {
           method: "POST",
           headers,
           body: JSON.stringify(body),

--- a/server/ssrf.ts
+++ b/server/ssrf.ts
@@ -85,16 +85,35 @@ function isRedirectStatus(status: number): boolean {
   return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
 }
 
-function getRedirectOptions(fetchOptions: RequestInit, status: number): RequestInit {
+function getRedirectOptions(
+  fetchOptions: RequestInit,
+  status: number,
+  previousUrl: URL,
+  nextUrl: URL
+): RequestInit {
   const method = (fetchOptions.method || "GET").toUpperCase();
   const shouldSwitchToGet =
     status === 303 || ((status === 301 || status === 302) && method !== "GET" && method !== "HEAD");
 
-  if (!shouldSwitchToGet) {
-    return fetchOptions;
+  const headers = new Headers(fetchOptions.headers ?? {});
+
+  // Match native fetch/undici's cross-origin redirect behavior: never replay
+  // credentials against a different origin. Our custom redirect loop below
+  // (needed to re-validate each hop against SSRF) bypasses that built-in
+  // protection unless we replicate it here — otherwise a malicious or
+  // compromised downloader daemon could redirect a request to an
+  // attacker-controlled host and walk off with the configured Basic-auth
+  // credentials or session cookie.
+  if (previousUrl.origin !== nextUrl.origin) {
+    headers.delete("authorization");
+    headers.delete("cookie");
+    headers.delete("proxy-authorization");
   }
 
-  const headers = new Headers(fetchOptions.headers ?? {});
+  if (!shouldSwitchToGet) {
+    return { ...fetchOptions, headers };
+  }
+
   headers.delete("content-length");
   headers.delete("content-type");
 
@@ -399,8 +418,9 @@ export async function safeFetch(urlStr: string, options: SafeFetchOptions = {}):
       throw new Error(`Too many redirects (max ${maxRedirects})`);
     }
 
-    currentUrl = new URL(location, currentUrl);
-    currentOptions = getRedirectOptions(currentOptions, response.status);
+    const nextUrl = new URL(location, currentUrl);
+    currentOptions = getRedirectOptions(currentOptions, response.status, currentUrl, nextUrl);
+    currentUrl = nextUrl;
     redirectCount++;
   }
 }

--- a/server/ssrf.ts
+++ b/server/ssrf.ts
@@ -92,8 +92,11 @@ function getRedirectOptions(
   nextUrl: URL
 ): RequestInit {
   const method = (fetchOptions.method || "GET").toUpperCase();
+  // Per RFC 9110 / the Fetch spec, a redirect only switches the method to GET
+  // when the original method isn't already GET or HEAD — a 303 to a HEAD
+  // request stays HEAD, it doesn't start pulling a response body.
   const shouldSwitchToGet =
-    status === 303 || ((status === 301 || status === 302) && method !== "GET" && method !== "HEAD");
+    (status === 301 || status === 302 || status === 303) && method !== "GET" && method !== "HEAD";
 
   const headers = new Headers(fetchOptions.headers ?? {});
 

--- a/server/ssrf.ts
+++ b/server/ssrf.ts
@@ -92,11 +92,13 @@ function getRedirectOptions(
   nextUrl: URL
 ): RequestInit {
   const method = (fetchOptions.method || "GET").toUpperCase();
-  // Per RFC 9110 / the Fetch spec, a redirect only switches the method to GET
-  // when the original method isn't already GET or HEAD — a 303 to a HEAD
+  // Per RFC 9110 / the Fetch spec: 301/302 only rewrite POST to GET (a PUT,
+  // PATCH, or DELETE keeps its method and body on those statuses), while 303
+  // rewrites anything that isn't already GET or HEAD — a 303 to a HEAD
   // request stays HEAD, it doesn't start pulling a response body.
   const shouldSwitchToGet =
-    (status === 301 || status === 302 || status === 303) && method !== "GET" && method !== "HEAD";
+    ((status === 301 || status === 302) && method === "POST") ||
+    (status === 303 && method !== "GET" && method !== "HEAD");
 
   const headers = new Headers(fetchOptions.headers ?? {});
 


### PR DESCRIPTION
## Description

Combines three separate auto-generated PRs (#887, #888, #889) into a single PR, with every review comment left on each of them addressed.

**#887 — Optimize sidebar badge calculation performance**
- `wishlistCount` and `activeDownloadsCount` in `AppSidebar.tsx` now use single-pass `for...of` loops instead of `.filter(...).length`, memoized with `useMemo`.
- Hoisted a stable `EMPTY_GAMES` constant for `useQuery`'s no-data fallback, so the `games` array reference doesn't change identity on every render and defeat the memo (CodeRabbit nit).
- Used `for...of` instead of index-based `for` loops per CodeRabbit/SonarCloud ("Expected a for-of loop instead of a for loop with this simple iteration").

**#888 — Replace native tooltips with UI tooltips in RssFeedList**
- Replaced the native `title` attributes on the Grid View / List View buttons with the shared `Tooltip` component for consistent, non-delayed hover UI. `aria-label` is preserved so screen readers are unaffected. No review comments were raised on this one (CodeRabbit: "No actionable comments").

**#889 — [HIGH] Enforce safeFetch for downloader API connections to prevent SSRF**
- Routed the Deluge, NZBGet, qBittorrent, rTorrent, and Transmission daemon-communication requests (auth + RPC calls) through `safeFetch` instead of native `fetch`, closing the SSRF/DNS-rebinding gap on those call sites (the download-URL fetches were already gated by `isSafeUrl`/`safeFetch`; this closes the remaining daemon-connection paths).
- Updated the affected test files' `../ssrf.js` mocks to forward through `safeFetch` so they still exercise the real request flow.
- Added assertions that `safeFetch` (not just the raw `fetch` mock) is actually invoked on the qBittorrent, NZBGet, and SABnzbd request paths, addressing CodeRabbit's "cover safeFetch controls" comment.
- Fixed a markdownlint nit (missing blank line after a heading) and a stale unresolved `` $(date +%Y-%m-%d) `` placeholder in `.jules/sentinel.md`.

**Not applied:** CodeRabbit's suggestion to centralize the repeated `vi.mock("../ssrf.js", ...)` boilerplate into `tests/setup.ts`. That mock pattern is already duplicated across 30+ test files project-wide, most of which predate this change — a real centralization is a much larger, separate refactor than fits inside this combined PR, and risks touching many unrelated tests. Left as a follow-up.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`.jules/bolt.md`, `.jules/sentinel.md` learnings updated)
- [x] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly — reviewed `docs/SECURITY_ASSESSMENT.md`; no existing risk-register row became inaccurate, and this closes a gap rather than introducing a new risk, so no entry was added
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes — full suite: 1972 passed, 7 skipped (pre-existing); `npm run lint`, `npm run format:check`, and `npm run check` all clean

Closes #887, closes #888, closes #889.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GKZXabax7wQtWb9vgoSfUL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Downloader integrations now use SSRF-safe networking for requests, authentication, and retries.
  - Improved protection across Deluge, NZBGet, qBittorrent, rTorrent, and Transmission connections.
  - Redirects now protect authentication and cookie information across origins while preserving expected request methods.

- **Performance**
  - Sidebar badge counts are calculated more efficiently while preserving accurate wishlist and download totals.

- **UI Improvements**
  - Grid and list view controls now display clear “Grid View” and “List View” tooltips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->