### PR TITLE
Add game-file persistence and content API

### DIFF
--- a/client/__tests__/ImportSettings.test.tsx
+++ b/client/__tests__/ImportSettings.test.tsx
@@ -113,7 +113,7 @@ describe("ImportSettings", () => {
     renderComponent();
     await screen.findByText("Sort add-on files into subfolders");
 
-    fireEvent.click(screen.getAllByRole("switch")[4]);
+    fireEvent.click(screen.getByRole("switch", { name: /sort add-on files into subfolders/i }));
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
 
     await waitFor(() => {

--- a/client/__tests__/ImportSettings.test.tsx
+++ b/client/__tests__/ImportSettings.test.tsx
@@ -29,6 +29,7 @@ const baseConfig: ImportConfig = {
   libraryRoot: "/data/library",
   transferMode: "hardlink",
   autoDeleteAfterImport: false,
+  sortExtras: false,
   importPlatformIds: [],
   renamePattern: "{Title} ({Year})",
 } as unknown as ImportConfig;
@@ -103,6 +104,23 @@ describe("ImportSettings", () => {
         "PATCH",
         "/api/imports/config",
         expect.objectContaining({ autoUnpack: false })
+      );
+    });
+  });
+
+  it("allows category subfolders to be enabled", async () => {
+    const { apiRequest } = await import("@/lib/queryClient");
+    renderComponent();
+    await screen.findByText("Sort add-on files into subfolders");
+
+    fireEvent.click(screen.getAllByRole("switch")[4]);
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(apiRequest).toHaveBeenCalledWith(
+        "PATCH",
+        "/api/imports/config",
+        expect.objectContaining({ sortExtras: true })
       );
     });
   });

--- a/client/src/components/ImportSettings.tsx
+++ b/client/src/components/ImportSettings.tsx
@@ -293,15 +293,16 @@ export default function ImportSettings() {
                       </div>
                       <div className="flex items-center justify-between">
                         <div className="space-y-0.5">
-                          <Label>Sort add-on files into subfolders</Label>
+                          <Label htmlFor="sort-extras">Sort add-on files into subfolders</Label>
                           <p className="text-xs text-muted-foreground">
-                            For directory imports, place detected DLC, updates, and extras in
-                            <code> dlc/</code>, <code>update/</code>, and <code>extra/</code>{" "}
+                            For directory imports, place detected DLC, updates, and extras in{" "}
+                            <code>dlc/</code>, <code>update/</code>, and <code>extra/</code>{" "}
                             subfolders inside the game folder. Single-file imports keep their
                             existing layout.
                           </p>
                         </div>
                         <Switch
+                          id="sort-extras"
                           checked={localConfig.sortExtras}
                           onCheckedChange={(checked) =>
                             setLocalConfig({ ...localConfig, sortExtras: checked })

--- a/client/src/components/ImportSettings.tsx
+++ b/client/src/components/ImportSettings.tsx
@@ -291,6 +291,23 @@ export default function ImportSettings() {
                           }
                         />
                       </div>
+                      <div className="flex items-center justify-between">
+                        <div className="space-y-0.5">
+                          <Label>Sort add-on files into subfolders</Label>
+                          <p className="text-xs text-muted-foreground">
+                            For directory imports, place detected DLC, updates, and extras in
+                            <code> dlc/</code>, <code>update/</code>, and <code>extra/</code>{" "}
+                            subfolders inside the game folder. Single-file imports keep their
+                            existing layout.
+                          </p>
+                        </div>
+                        <Switch
+                          checked={localConfig.sortExtras}
+                          onCheckedChange={(checked) =>
+                            setLocalConfig({ ...localConfig, sortExtras: checked })
+                          }
+                        />
+                      </div>
                     </div>
 
                     <Separator className="mb-6" />

--- a/migrations/0027_confused_vulcan.sql
+++ b/migrations/0027_confused_vulcan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_settings` ADD `sort_extras` integer DEFAULT false NOT NULL;

--- a/migrations/0027_game_files.sql
+++ b/migrations/0027_game_files.sql
@@ -1,7 +1,7 @@
 CREATE TABLE `game_files` (
   `id` text PRIMARY KEY NOT NULL,
   `game_id` text NOT NULL REFERENCES `games`(`id`) ON DELETE cascade,
-  `download_id` text NOT NULL REFERENCES `game_downloads`(`id`) ON DELETE set null,
+  `download_id` text REFERENCES `game_downloads`(`id`) ON DELETE set null,
   `original_name` text NOT NULL,
   `stored_name` text NOT NULL,
   `category` text NOT NULL,

--- a/migrations/0027_game_files.sql
+++ b/migrations/0027_game_files.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `game_files` (
+  `id` text PRIMARY KEY NOT NULL,
+  `game_id` text NOT NULL REFERENCES `games`(`id`) ON DELETE cascade,
+  `download_id` text NOT NULL REFERENCES `game_downloads`(`id`) ON DELETE set null,
+  `original_name` text NOT NULL,
+  `stored_name` text NOT NULL,
+  `category` text NOT NULL,
+  `file_path` text NOT NULL,
+  `file_size` integer,
+  `created_at` integer DEFAULT (strftime('%s', 'now') * 1000)
+);--> statement-breakpoint
+CREATE INDEX `game_files_game_id_idx` ON `game_files` (`game_id`);--> statement-breakpoint
+CREATE INDEX `game_files_download_id_idx` ON `game_files` (`download_id`);

--- a/migrations/meta/0027_snapshot.json
+++ b/migrations/meta/0027_snapshot.json
@@ -1,0 +1,1714 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "49bb515d-121f-4207-a52a-4682a6040aea",
+  "prevId": "38bed938-b596-4db7-b378-ec05e0ca8874",
+  "tables": {
+    "downloaders": {
+      "name": "downloaders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "url_path": {
+          "name": "url_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "download_path": {
+          "name": "download_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'games'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Questarr'"
+        },
+        "add_stopped": {
+          "name": "add_stopped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "remove_completed": {
+          "name": "remove_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "post_import_category": {
+          "name": "post_import_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_downloads": {
+      "name": "game_downloads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "downloader_id": {
+          "name": "downloader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_type": {
+          "name": "download_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torrent'"
+        },
+        "download_hash": {
+          "name": "download_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_title": {
+          "name": "download_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'downloading'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "game_downloads_downloader_hash_idx": {
+          "name": "game_downloads_downloader_hash_idx",
+          "columns": [
+            "downloader_id",
+            "download_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "game_downloads_game_id_games_id_fk": {
+          "name": "game_downloads_game_id_games_id_fk",
+          "tableFrom": "game_downloads",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_downloads_downloader_id_downloaders_id_fk": {
+          "name": "game_downloads_downloader_id_downloaders_id_fk",
+          "tableFrom": "game_downloads",
+          "tableTo": "downloaders",
+          "columnsFrom": [
+            "downloader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "games": {
+      "name": "games",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steam_appid": {
+          "name": "steam_appid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "themes": {
+          "name": "themes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publishers": {
+          "name": "publishers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "developers": {
+          "name": "developers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "igdb_websites": {
+          "name": "igdb_websites",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "original_release_date": {
+          "name": "original_release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_status": {
+          "name": "release_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'upcoming'"
+        },
+        "early_access": {
+          "name": "early_access",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_adult_content": {
+          "name": "is_adult_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_age_restricted": {
+          "name": "is_age_restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "user_rating": {
+          "name": "user_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_path": {
+          "name": "library_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_results_available": {
+          "name": "search_results_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "update_search_results_available": {
+          "name": "update_search_results_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "packs_search_results_available": {
+          "name": "packs_search_results_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_user_id_users_id_fk": {
+          "name": "games_user_id_users_id_fk",
+          "tableFrom": "games",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_task_items": {
+      "name": "import_task_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "game_title": {
+          "name": "game_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "import_task_items_task_id_idx": {
+          "name": "import_task_items_task_id_idx",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "import_task_items_task_id_import_tasks_id_fk": {
+          "name": "import_task_items_task_id_import_tasks_id_fk",
+          "tableFrom": "import_task_items",
+          "tableTo": "import_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_tasks": {
+      "name": "import_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "added_items": {
+          "name": "added_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_items": {
+          "name": "skipped_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_items": {
+          "name": "failed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "import_tasks_user_id_users_id_fk": {
+          "name": "import_tasks_user_id_users_id_fk",
+          "tableFrom": "import_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexers": {
+      "name": "indexers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torznab'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "rss_enabled": {
+          "name": "rss_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_search_enabled": {
+          "name": "auto_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read": {
+          "name": "read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "path_mappings": {
+      "name": "path_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_path": {
+          "name": "remote_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_host": {
+          "name": "remote_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "platform_mappings": {
+      "name": "platform_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "igdb_platform_id": {
+          "name": "igdb_platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_platform_name": {
+          "name": "source_platform_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "release_blacklist": {
+      "name": "release_blacklist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_title": {
+          "name": "release_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexer_name": {
+          "name": "indexer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "release_blacklist_game_title_idx": {
+          "name": "release_blacklist_game_title_idx",
+          "columns": [
+            "game_id",
+            "release_title"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "release_blacklist_game_id_games_id_fk": {
+          "name": "release_blacklist_game_id_games_id_fk",
+          "tableFrom": "release_blacklist",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_feed_items": {
+      "name": "rss_feed_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pub_date": {
+          "name": "pub_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_game_id": {
+          "name": "igdb_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_game_name": {
+          "name": "igdb_game_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rss_feed_items_feed_id_rss_feeds_id_fk": {
+          "name": "rss_feed_items_feed_id_rss_feeds_id_fk",
+          "tableFrom": "rss_feed_items",
+          "tableTo": "rss_feeds",
+          "columnsFrom": [
+            "feed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_feeds": {
+      "name": "rss_feeds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "mapping": {
+          "name": "mapping",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_config": {
+      "name": "system_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auto_search_enabled": {
+          "name": "auto_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_download_enabled": {
+          "name": "auto_download_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_interval_hours": {
+          "name": "search_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 6
+        },
+        "igdb_rate_limit_per_second": {
+          "name": "igdb_rate_limit_per_second",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "download_rules": {
+          "name": "download_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_auto_search": {
+          "name": "last_auto_search",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "xrel_scene_releases": {
+          "name": "xrel_scene_releases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "xrel_p2p_releases": {
+          "name": "xrel_p2p_releases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_search_unreleased": {
+          "name": "auto_search_unreleased",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "steam_sync_failures": {
+          "name": "steam_sync_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "steam_sync_enabled": {
+          "name": "steam_sync_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "steam_sync_interval_hours": {
+          "name": "steam_sync_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "last_steam_sync": {
+          "name": "last_steam_sync",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_release_groups": {
+          "name": "preferred_release_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filter_by_preferred_groups": {
+          "name": "filter_by_preferred_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preferred_platform": {
+          "name": "preferred_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_adult_content": {
+          "name": "hide_adult_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "hide_age_restricted_content": {
+          "name": "hide_age_restricted_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "enable_post_processing": {
+          "name": "enable_post_processing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_unpack": {
+          "name": "auto_unpack",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rename_pattern": {
+          "name": "rename_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{Title} ({Region})'"
+        },
+        "overwrite_existing": {
+          "name": "overwrite_existing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "transfer_mode": {
+          "name": "transfer_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'hardlink'"
+        },
+        "import_platform_ids": {
+          "name": "import_platform_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "ignored_extensions": {
+          "name": "ignored_extensions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "min_file_size": {
+          "name": "min_file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "library_root": {
+          "name": "library_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'/data'"
+        },
+        "auto_delete_after_import": {
+          "name": "auto_delete_after_import",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_extras": {
+          "name": "sort_extras",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "steam_id_64": {
+          "name": "steam_id_64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "xrel_notified_releases": {
+      "name": "xrel_notified_releases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "xrel_release_id": {
+          "name": "xrel_release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "xrel_notified_releases_game_id_games_id_fk": {
+          "name": "xrel_notified_releases_game_id_games_id_fk",
+          "tableFrom": "xrel_notified_releases",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1786459125010,
       "tag": "0027_confused_vulcan",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1784581013230,
+      "tag": "0027_game_files",
+      "breakpoints": true
     }
   ]
 }

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1786221915267,
       "tag": "0026_aberrant_quentin_quire",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1786459125010,
+      "tag": "0027_confused_vulcan",
+      "breakpoints": true
     }
   ]
 }

--- a/server/__tests__/helpers/import-test-helpers.ts
+++ b/server/__tests__/helpers/import-test-helpers.ts
@@ -53,6 +53,7 @@ export function makeImportConfig(overrides: Partial<ImportConfig> = {}): ImportC
     minFileSize: 0,
     libraryRoot: "/data",
     autoDeleteAfterImport: false,
+    sortExtras: false,
     ...overrides,
   };
 }

--- a/server/__tests__/igdb_extended.test.ts
+++ b/server/__tests__/igdb_extended.test.ts
@@ -295,6 +295,15 @@ describe("IGDBClient - extended coverage", { timeout: 20000 }, () => {
         { company: { name: "Pub Co" }, developer: false, publisher: true },
       ],
       status: 4,
+      expansions: [
+        {
+          id: 2,
+          name: "Expansion One",
+          cover: { url: "//img/t_thumb/expansion.jpg" },
+          first_release_date: 1640995200,
+          game_type: 2,
+        },
+      ],
     });
 
     expect(formatted.title).toBe("Full Game");
@@ -304,6 +313,16 @@ describe("IGDBClient - extended coverage", { timeout: 20000 }, () => {
     expect(formatted.developers).toEqual(["Dev Co"]);
     expect(formatted.publishers).toEqual(["Pub Co"]);
     expect(formatted.earlyAccess).toBe(true);
+    expect(formatted.expansions).toEqual([
+      {
+        id: 2,
+        name: "Expansion One",
+        coverUrl: "https://img/t_cover_big/expansion.jpg",
+        releaseDate: "2022-01-01",
+        category: "dlc",
+        gameType: 2,
+      },
+    ]);
     expect(formatted.isReleased).toBe(true);
     expect(formatted.releaseYear).toBe(2021);
   });

--- a/server/__tests__/import_manager.test.ts
+++ b/server/__tests__/import_manager.test.ts
@@ -265,6 +265,7 @@ describe("ImportManager", () => {
       proposedPath: "/safe/root/PC/My Game",
       needsReview: false,
       transferMode: "move",
+      fileCategories: [{ name: "../../escape.bin", category: "dlc" }],
     });
 
     expect(fsMock.ensureDir).toHaveBeenCalled();

--- a/server/__tests__/import_manager.test.ts
+++ b/server/__tests__/import_manager.test.ts
@@ -543,6 +543,68 @@ describe("ImportManager", () => {
     execSpy.mockRestore();
   });
 
+  it("confirmImport: recomputes category placement server-side when sorting is enabled", async () => {
+    storage.getGameDownload.mockResolvedValue({
+      id: "dl-1",
+      gameId: "g1",
+      downloaderId: "d1",
+      downloadTitle: "My Game",
+    });
+    storage.getGame.mockResolvedValue({
+      id: "g1",
+      title: "My Game",
+      userId: "u1",
+      status: "wanted",
+      platforms: [6],
+    });
+    storage.getImportConfig.mockResolvedValue(
+      makeImportConfig({ libraryRoot: "/safe/root", sortExtras: true })
+    );
+
+    const { PCImportStrategy } = await import("../services/ImportStrategies.js");
+    const planSpy = vi.spyOn(PCImportStrategy.prototype, "planImport").mockResolvedValue({
+      needsReview: false,
+      originalPath: "/downloads/game",
+      proposedPath: "/safe/root/PC/My Game",
+      strategy: "pc",
+      fileCategories: [{ name: "Game Update v1.nsp", category: "update" }],
+    });
+    const execSpy = vi.spyOn(PCImportStrategy.prototype, "executeImport").mockResolvedValue({
+      destDir: "/safe/root/PC/My Game",
+      filesPlaced: ["/safe/root/PC/My Game/update/Game Update v1.nsp"],
+      modeUsed: "move",
+      conflictsResolved: [],
+    });
+
+    const manager = new ImportManager(
+      storage as never, // NOSONAR
+      pathService as never, // NOSONAR
+      platformService as never, // NOSONAR
+      archiveService as never // NOSONAR
+    );
+
+    try {
+      await manager.confirmImport("dl-1", {
+        strategy: "pc",
+        originalPath: "/downloads/game",
+        proposedPath: "/safe/root/PC/My Game",
+        needsReview: false,
+        transferMode: "move",
+      });
+
+      expect(execSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          proposedPath: "/safe/root/PC/My Game",
+          fileCategories: [{ name: "Game Update v1.nsp", category: "update" }],
+        }),
+        "move"
+      );
+    } finally {
+      planSpy.mockRestore();
+      execSpy.mockRestore();
+    }
+  });
+
   it("confirmImport: overridePlan.unpack = true → archiveService.extract is called", async () => {
     storage.getGameDownload.mockResolvedValue({
       id: "dl-1",

--- a/server/__tests__/import_strategies.test.ts
+++ b/server/__tests__/import_strategies.test.ts
@@ -110,11 +110,13 @@ describe("ImportStrategies", () => {
       const sourceDir = path.join(root, "downloads", "game-folder");
       const destination = path.join(root, "library", "PC", "My Game");
       await fs.ensureDir(path.join(sourceDir, "dlc"));
+      await fs.ensureDir(path.join(sourceDir, "update"));
       await fs.writeFile(path.join(sourceDir, "base.nsp"), "base");
       await fs.writeFile(path.join(sourceDir, "Game Update v1.nsp"), "update");
       await fs.writeFile(path.join(sourceDir, "Game Expansion Pack.nsp"), "dlc");
       await fs.writeFile(path.join(sourceDir, "Game OST.zip"), "extra");
       await fs.writeFile(path.join(sourceDir, "dlc", "Game DLC Pack.nsp"), "nested-dlc");
+      await fs.writeFile(path.join(sourceDir, "update", "Game DLC Patch.nsp"), "nested-update");
 
       const strategy = new PCImportStrategy();
       const plan = await strategy.planImport(
@@ -132,6 +134,7 @@ describe("ImportStrategies", () => {
           path.join(destination, "dlc", "Game Expansion Pack.nsp"),
           path.join(destination, "extra", "Game OST.zip"),
           path.join(destination, "dlc", "Game DLC Pack.nsp"),
+          path.join(destination, "update", "Game DLC Patch.nsp"),
         ])
       );
       expect(await fs.pathExists(path.join(destination, "dlc", "dlc"))).toBe(false);
@@ -210,6 +213,33 @@ describe("ImportStrategies", () => {
 
       expect(plan.needsReview).toBe(true);
       expect(plan.reviewReason).toMatch(/Destination already exists/);
+    });
+
+    it("rejects duplicate resolved destinations before transferring", async () => {
+      const root = tempDir();
+      const sourceDir = path.join(root, "downloads", "game-folder");
+      const destination = path.join(root, "library", "PC", "My Game");
+      await fs.ensureDir(path.join(sourceDir, "dlc"));
+      await fs.writeFile(path.join(sourceDir, "Game DLC Pack.nsp"), "root");
+      await fs.writeFile(path.join(sourceDir, "dlc", "Game DLC Pack.nsp"), "nested");
+
+      const strategy = new PCImportStrategy();
+      await expect(
+        strategy.executeImport(
+          {
+            needsReview: false,
+            originalPath: sourceDir,
+            proposedPath: destination,
+            strategy: "pc",
+            fileCategories: [
+              { name: "Game DLC Pack.nsp", category: "dlc" },
+              { name: path.join("dlc", "Game DLC Pack.nsp"), category: "dlc" },
+            ],
+          },
+          "copy"
+        )
+      ).rejects.toThrow("Duplicate import destination");
+      expect(await fs.pathExists(path.join(destination, "dlc", "Game DLC Pack.nsp"))).toBe(false);
     });
 
     it("keeps the existing flat destination for a single file when sorting is enabled", async () => {

--- a/server/__tests__/import_strategies.test.ts
+++ b/server/__tests__/import_strategies.test.ts
@@ -104,6 +104,38 @@ describe("ImportStrategies", () => {
       expect(result.filesPlaced.some((p) => p.endsWith("game.exe"))).toBe(true);
       expect(result.filesPlaced.some((p) => p.endsWith("data.pak"))).toBe(true);
     });
+
+    it("sorts detected add-on files while preserving main and existing category paths", async () => {
+      const root = tempDir();
+      const sourceDir = path.join(root, "downloads", "game-folder");
+      const destination = path.join(root, "library", "PC", "My Game");
+      await fs.ensureDir(path.join(sourceDir, "dlc"));
+      await fs.writeFile(path.join(sourceDir, "base.nsp"), "base");
+      await fs.writeFile(path.join(sourceDir, "Game Update v1.nsp"), "update");
+      await fs.writeFile(path.join(sourceDir, "Game Expansion Pack.nsp"), "dlc");
+      await fs.writeFile(path.join(sourceDir, "Game OST.zip"), "extra");
+      await fs.writeFile(path.join(sourceDir, "dlc", "Game DLC Pack.nsp"), "nested-dlc");
+
+      const strategy = new PCImportStrategy();
+      const plan = await strategy.planImport(
+        sourceDir,
+        makeGame({ title: "My Game" }),
+        path.join(root, "library"),
+        makeImportConfig({ sortExtras: true, overwriteExisting: true })
+      );
+      const result = await strategy.executeImport(plan, "copy");
+
+      expect(result.filesPlaced).toEqual(
+        expect.arrayContaining([
+          path.join(destination, "base.nsp"),
+          path.join(destination, "update", "Game Update v1.nsp"),
+          path.join(destination, "dlc", "Game Expansion Pack.nsp"),
+          path.join(destination, "extra", "Game OST.zip"),
+          path.join(destination, "dlc", "Game DLC Pack.nsp"),
+        ])
+      );
+      expect(await fs.pathExists(path.join(destination, "dlc", "dlc"))).toBe(false);
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -178,6 +210,24 @@ describe("ImportStrategies", () => {
 
       expect(plan.needsReview).toBe(true);
       expect(plan.reviewReason).toMatch(/Destination already exists/);
+    });
+
+    it("keeps the existing flat destination for a single file when sorting is enabled", async () => {
+      const root = tempDir();
+      const source = path.join(root, "downloads", "game.exe");
+      await fs.ensureDir(path.dirname(source));
+      await fs.writeFile(source, "exe-bytes");
+
+      const strategy = new PCImportStrategy();
+      const plan = await strategy.planImport(
+        source,
+        makeGame({ title: "My Game" }),
+        path.join(root, "library"),
+        makeImportConfig({ sortExtras: true })
+      );
+
+      expect(plan.proposedPath).toMatch(/My Game\.exe$/);
+      expect(plan.fileCategories).toBeUndefined();
     });
   });
 });

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -745,6 +745,15 @@ describe("Import And Mapping Helpers", () => {
     );
   });
 
+  it("should persist enabled sortExtras in import config", async () => {
+    const user = await storage.createUser({ username: "sort-user", passwordHash: "hash" });
+    await storage.createUserSettings({ userId: user.id, sortExtras: true });
+
+    await expect(storage.getImportConfig(user.id)).resolves.toEqual(
+      expect.objectContaining({ sortExtras: true })
+    );
+  });
+
   it("should apply defaults when no matching scoped settings exist", async () => {
     const importConfig = await storage.getImportConfig("missing-user");
     expect(importConfig).toEqual({

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -13,6 +13,7 @@ import type {
   InsertIndexer,
   InsertDownloader,
   InsertGameDownload,
+  InsertGameFile,
   InsertUserSettings,
   InsertReleaseBlacklist,
 } from "../../shared/schema";
@@ -206,6 +207,25 @@ describe("MemStorage", () => {
 
       const retrieved = await storage.getGame(game.id);
       expect(retrieved).toBeUndefined();
+    });
+
+    it("cascades game files when removing a game", async () => {
+      const game = await storage.addGame({
+        title: "Game with file",
+        status: "owned",
+        userId: "user-1",
+        hidden: false,
+      });
+      await storage.addGameFile({
+        gameId: game.id,
+        originalName: "game.exe",
+        storedName: "game.exe",
+        category: "main",
+        filePath: "/library/game.exe",
+      } as InsertGameFile);
+
+      await expect(storage.removeGame(game.id)).resolves.toBe(true);
+      await expect(storage.getGameFiles(game.id)).resolves.toEqual([]);
     });
 
     it("should filter games by status", async () => {
@@ -752,6 +772,44 @@ describe("Import And Mapping Helpers", () => {
     await expect(storage.getImportConfig(user.id)).resolves.toEqual(
       expect.objectContaining({ sortExtras: true })
     );
+  });
+
+  it("clears game-file download references when removing a download", async () => {
+    const game = await storage.addGame({
+      title: "Download game",
+      status: "owned",
+      userId: "user-1",
+      hidden: false,
+    });
+    const downloader = await storage.addDownloader({
+      name: "test",
+      type: "qbittorrent",
+      url: "http://localhost",
+      apiKey: "",
+      enabled: true,
+      priority: 1,
+    } as InsertDownloader);
+    const download = await storage.addGameDownload({
+      gameId: game.id,
+      downloaderId: downloader.id,
+      downloadHash: "hash",
+      downloadTitle: "Game",
+      status: "downloading",
+      downloadType: "torrent",
+      fileSize: null,
+    } as InsertGameDownload);
+    await storage.addGameFile({
+      gameId: game.id,
+      downloadId: download!.id,
+      originalName: "game.exe",
+      storedName: "game.exe",
+      category: "main",
+      filePath: "/library/game.exe",
+    } as InsertGameFile);
+
+    await expect(storage.removeGameDownload(download!.id, game.id)).resolves.toBe(true);
+    const files = await storage.getGameFiles(game.id);
+    expect(files[0]?.downloadId).toBeNull();
   });
 
   it("should apply defaults when no matching scoped settings exist", async () => {

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -758,6 +758,7 @@ describe("Import And Mapping Helpers", () => {
       minFileSize: 0,
       libraryRoot: "/data",
       autoDeleteAfterImport: false,
+      sortExtras: false,
     });
   });
 

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -15,7 +15,7 @@ export const IGDB_EARLY_ACCESS_STATUS = 4;
 
 // Shared field list for all IGDB game queries
 const IGDB_GAME_FIELDS =
-  "name, summary, cover.url, first_release_date, rating, aggregated_rating, aggregated_rating_count, platforms.name, genres.name, themes.name, age_ratings.category, age_ratings.rating, screenshots.url, websites.url, websites.category, involved_companies.company.name, involved_companies.developer, involved_companies.publisher, status";
+  "name, summary, cover.url, first_release_date, rating, aggregated_rating, aggregated_rating_count, platforms.name, genres.name, themes.name, age_ratings.category, age_ratings.rating, screenshots.url, websites.url, websites.category, involved_companies.company.name, involved_companies.developer, involved_companies.publisher, status, category, expansions.name, expansions.cover.url, expansions.first_release_date, expansions.category";
 
 // IGDB theme name flagged as adult content (Erotic)
 const ADULT_THEME_NAMES = new Set(["Erotic"]);
@@ -80,6 +80,14 @@ export interface IGDBGame {
     publisher: boolean;
   }>;
   status?: number;
+  category?: number;
+  expansions?: Array<{
+    id: number;
+    name: string;
+    cover?: { url: string };
+    first_release_date?: number;
+    category?: number;
+  }>;
 }
 
 interface SearchGamesOptions {

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -6,6 +6,7 @@ import { db } from "./db.js";
 import { userSettings } from "../shared/schema.js";
 import { logger } from "./logger.js";
 import { safeFetch } from "./ssrf.js";
+import type { DownloadCategory } from "../shared/download-categorizer.js";
 
 // Configuration constants for search limits
 const MAX_SEARCH_ATTEMPTS = 5;
@@ -15,7 +16,7 @@ export const IGDB_EARLY_ACCESS_STATUS = 4;
 
 // Shared field list for all IGDB game queries
 const IGDB_GAME_FIELDS =
-  "name, summary, cover.url, first_release_date, rating, aggregated_rating, aggregated_rating_count, platforms.name, genres.name, themes.name, age_ratings.category, age_ratings.rating, screenshots.url, websites.url, websites.category, involved_companies.company.name, involved_companies.developer, involved_companies.publisher, status, category, expansions.name, expansions.cover.url, expansions.first_release_date, expansions.category";
+  "name, summary, cover.url, first_release_date, rating, aggregated_rating, aggregated_rating_count, platforms.name, genres.name, themes.name, age_ratings.category, age_ratings.rating, screenshots.url, websites.url, websites.category, involved_companies.company.name, involved_companies.developer, involved_companies.publisher, status, game_type, expansions.name, expansions.cover.url, expansions.first_release_date, expansions.game_type";
 
 // IGDB theme name flagged as adult content (Erotic)
 const ADULT_THEME_NAMES = new Set(["Erotic"]);
@@ -28,6 +29,13 @@ const ADULT_AGE_RATINGS = [
 
 function hasEroticTheme(igdbGame: IGDBGame): boolean {
   return igdbGame.themes?.some((t) => ADULT_THEME_NAMES.has(t.name)) ?? false;
+}
+
+function mapIGDBGameType(gameType?: number): DownloadCategory {
+  if (gameType === 14) return "update";
+  if ([1, 2, 4, 6, 7, 13].includes(gameType ?? -1)) return "dlc";
+  if ([5].includes(gameType ?? -1)) return "extra";
+  return "main";
 }
 
 function hasAdultAgeRating(igdbGame: IGDBGame): boolean {
@@ -80,13 +88,13 @@ export interface IGDBGame {
     publisher: boolean;
   }>;
   status?: number;
-  category?: number;
+  game_type?: number;
   expansions?: Array<{
     id: number;
     name: string;
     cover?: { url: string };
     first_release_date?: number;
-    category?: number;
+    game_type?: number;
   }>;
 }
 
@@ -1110,6 +1118,8 @@ class IGDBClient {
       isReleased,
       releaseYear: releaseDate ? releaseDate.getFullYear() : null,
       earlyAccess: igdbGame.status === 4,
+      category: mapIGDBGameType(igdbGame.game_type),
+      gameType: igdbGame.game_type,
     };
   }
 }

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -6,7 +6,7 @@ import { db } from "./db.js";
 import { userSettings } from "../shared/schema.js";
 import { logger } from "./logger.js";
 import { safeFetch } from "./ssrf.js";
-import type { DownloadCategory } from "../shared/download-categorizer.js";
+import type { DownloadCategory } from "@shared/download-categorizer";
 
 // Configuration constants for search limits
 const MAX_SEARCH_ATTEMPTS = 5;
@@ -1120,6 +1120,19 @@ class IGDBClient {
       earlyAccess: igdbGame.status === 4,
       category: mapIGDBGameType(igdbGame.game_type),
       gameType: igdbGame.game_type,
+      expansions:
+        igdbGame.expansions?.map((expansion) => ({
+          id: expansion.id,
+          name: expansion.name,
+          coverUrl: expansion.cover?.url
+            ? `https:${expansion.cover.url.replace("t_thumb", "t_cover_big")}`
+            : "",
+          releaseDate: expansion.first_release_date
+            ? new Date(expansion.first_release_date * 1000).toISOString().split("T")[0]
+            : "",
+          category: mapIGDBGameType(expansion.game_type),
+          gameType: expansion.game_type,
+        })) ?? [],
     };
   }
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,4 +1,5 @@
 import express, { type Express, type Request, type Response, type NextFunction } from "express";
+import { body, param } from "express-validator";
 import { createServer, type Server } from "http";
 import { storage } from "./storage.js";
 import { igdbClient } from "./igdb.js";
@@ -1724,49 +1725,76 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(500).json({ error: "Failed to list blacklists" });
     }
   });
+  const gameIdParamValidation = [
+    param("gameId").trim().isUUID().withMessage("Invalid game ID format"),
+  ];
+  const gameFileIdParamValidation = [
+    param("id").trim().isUUID().withMessage("Invalid game file ID format"),
+  ];
+  const gameFileBodyValidation = [
+    body("gameId").trim().isUUID().withMessage("Invalid game ID format"),
+    body("downloadId")
+      .optional({ nullable: true })
+      .trim()
+      .isUUID()
+      .withMessage("Invalid download ID format"),
+    body("category")
+      .trim()
+      .isIn(["main", "dlc", "update", "extra"])
+      .withMessage("Invalid game file category"),
+  ];
+
   // Get game files for a specific game, grouped by category
-  app.get("/api/games/:gameId/content", authenticateToken, async (req: Request, res: Response) => {
-    try {
-      const { gameId } = req.params;
-      const userId = req.user!.id;
+  app.get(
+    "/api/games/:gameId/content",
+    authenticateToken,
+    gameIdParamValidation,
+    validateRequest,
+    async (req: Request, res: Response) => {
+      try {
+        const { gameId } = req.params;
+        const userId = req.user!.id;
 
-      const game = await resolveOwnedGame(gameId, userId, res);
-      if (!game) return;
+        const game = await resolveOwnedGame(gameId, userId, res);
+        if (!game) return;
 
-      const gameFiles = await storage.getGameFiles(gameId);
+        const gameFiles = await storage.getGameFiles(gameId);
 
-      const CATEGORIES = [
-        { category: "main", label: "Main Game" },
-        { category: "dlc", label: "DLC & Expansions" },
-        { category: "update", label: "Updates & Patches" },
-        { category: "extra", label: "Extras" },
-      ] as const;
+        const CATEGORIES = [
+          { category: "main", label: "Main Game" },
+          { category: "dlc", label: "DLC & Expansions" },
+          { category: "update", label: "Updates & Patches" },
+          { category: "extra", label: "Extras" },
+        ] as const;
 
-      const slots = CATEGORIES.map(({ category, label }) => {
-        const files = gameFiles
-          .filter((f) => f.category === category)
-          .map((f) => ({
-            id: f.id,
-            originalName: f.originalName,
-            storedName: f.storedName,
-            downloadId: f.downloadId,
-            fileSize: f.fileSize,
-            createdAt: f.createdAt,
-          }));
-        return { category, label, present: files.length > 0, files };
-      });
+        const slots = CATEGORIES.map(({ category, label }) => {
+          const files = gameFiles
+            .filter((f) => f.category === category)
+            .map((f) => ({
+              id: f.id,
+              originalName: f.originalName,
+              storedName: f.storedName,
+              downloadId: f.downloadId,
+              fileSize: f.fileSize,
+              createdAt: f.createdAt,
+            }));
+          return { category, label, present: files.length > 0, files };
+        });
 
-      res.json({ slots });
-    } catch (error) {
-      routesLogger.error({ error }, "error fetching game content");
-      res.status(500).json({ error: "Failed to fetch game content" });
+        res.json({ slots });
+      } catch (error) {
+        routesLogger.error({ error }, "error fetching game content");
+        res.status(500).json({ error: "Failed to fetch game content" });
+      }
     }
-  });
+  );
 
   // Get game files by download
   app.get(
     "/api/game-files/by-download/:downloadId",
     authenticateToken,
+    sanitizeDownloadId,
+    validateRequest,
     async (req: Request, res: Response) => {
       try {
         const { downloadId } = req.params;
@@ -1784,36 +1812,59 @@ export async function registerRoutes(app: Express): Promise<Server> {
   );
 
   // Create a game file record
-  app.post("/api/game-files", authenticateToken, async (req: Request, res: Response) => {
-    try {
-      const parsed = insertGameFileSchema.parse(req.body);
-      const game = await resolveOwnedGame(parsed.gameId, req.user!.id, res);
-      if (!game) return;
-      const gameFile = await storage.addGameFile(parsed);
-      res.status(201).json(gameFile);
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        return respondWithZodError(res, error, "Invalid game file data");
+  app.post(
+    "/api/game-files",
+    authenticateToken,
+    gameFileBodyValidation,
+    validateRequest,
+    async (req: Request, res: Response) => {
+      try {
+        const parsed = insertGameFileSchema.parse(req.body);
+        const game = await resolveOwnedGame(parsed.gameId, req.user!.id, res);
+        if (!game) return;
+        if (parsed.downloadId) {
+          const download = await storage.getGameDownload(parsed.downloadId, req.user!.id);
+          if (!download || download.gameId !== parsed.gameId) {
+            return res.status(404).json({ error: "Download not found for game" });
+          }
+        }
+        const gameFile = await storage.addGameFile(parsed);
+        res.status(201).json(gameFile);
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          return respondWithZodError(res, error, "Invalid game file data");
+        }
+        routesLogger.error({ error }, "error creating game file");
+        res.status(500).json({ error: "Failed to create game file" });
       }
-      routesLogger.error({ error }, "error creating game file");
-      res.status(500).json({ error: "Failed to create game file" });
     }
-  });
+  );
 
   // Delete a game file record
-  app.delete("/api/game-files/:id", authenticateToken, async (req: Request, res: Response) => {
-    try {
-      const { id } = req.params;
-      const deleted = await storage.removeGameFile(id);
-      if (!deleted) {
-        return res.status(404).json({ error: "Game file not found" });
+  app.delete(
+    "/api/game-files/:id",
+    authenticateToken,
+    gameFileIdParamValidation,
+    validateRequest,
+    async (req: Request, res: Response) => {
+      try {
+        const { id } = req.params;
+        const gameFile = await storage.getGameFile(id);
+        if (!gameFile) {
+          return res.status(404).json({ error: "Game file not found" });
+        }
+        if (!(await resolveOwnedGame(gameFile.gameId, req.user!.id, res))) return;
+        const deleted = await storage.removeGameFile(id);
+        if (!deleted) {
+          return res.status(404).json({ error: "Game file not found" });
+        }
+        res.json({ success: true });
+      } catch (error) {
+        routesLogger.error({ error }, "error deleting game file");
+        res.status(500).json({ error: "Failed to delete game file" });
       }
-      res.json({ success: true });
-    } catch (error) {
-      routesLogger.error({ error }, "error deleting game file");
-      res.status(500).json({ error: "Failed to delete game file" });
     }
-  });
+  );
 
   // IGDB discovery routes
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -20,6 +20,7 @@ import {
   passwordPolicySchema,
   insertRssFeedSchema,
   insertReleaseBlacklistSchema,
+  insertGameFileSchema,
   claimDownloadRequestSchema,
   type Config,
   type Game,
@@ -1721,6 +1722,96 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       routesLogger.error({ error }, "error listing all blacklists");
       res.status(500).json({ error: "Failed to list blacklists" });
+    }
+  });
+  // Get game files for a specific game, grouped by category
+  app.get("/api/games/:gameId/content", authenticateToken, async (req: Request, res: Response) => {
+    try {
+      const { gameId } = req.params;
+      const userId = req.user!.id;
+
+      const game = await resolveOwnedGame(gameId, userId, res);
+      if (!game) return;
+
+      const gameFiles = await storage.getGameFiles(gameId);
+
+      const CATEGORIES = [
+        { category: "main", label: "Main Game" },
+        { category: "dlc", label: "DLC & Expansions" },
+        { category: "update", label: "Updates & Patches" },
+        { category: "extra", label: "Extras" },
+      ] as const;
+
+      const slots = CATEGORIES.map(({ category, label }) => {
+        const files = gameFiles
+          .filter((f) => f.category === category)
+          .map((f) => ({
+            id: f.id,
+            originalName: f.originalName,
+            storedName: f.storedName,
+            downloadId: f.downloadId,
+            fileSize: f.fileSize,
+            createdAt: f.createdAt,
+          }));
+        return { category, label, present: files.length > 0, files };
+      });
+
+      res.json({ slots });
+    } catch (error) {
+      routesLogger.error({ error }, "error fetching game content");
+      res.status(500).json({ error: "Failed to fetch game content" });
+    }
+  });
+
+  // Get game files by download
+  app.get(
+    "/api/game-files/by-download/:downloadId",
+    authenticateToken,
+    async (req: Request, res: Response) => {
+      try {
+        const { downloadId } = req.params;
+        const download = await storage.getGameDownload(downloadId, req.user!.id);
+        if (!download) {
+          return res.status(404).json({ error: "Download not found" });
+        }
+        const files = await storage.getGameFilesByDownload(downloadId);
+        res.json(files);
+      } catch (error) {
+        routesLogger.error({ error }, "error fetching game files by download");
+        res.status(500).json({ error: "Failed to fetch game files" });
+      }
+    }
+  );
+
+  // Create a game file record
+  app.post("/api/game-files", authenticateToken, async (req: Request, res: Response) => {
+    try {
+      const parsed = insertGameFileSchema.parse(req.body);
+      const game = await resolveOwnedGame(parsed.gameId, req.user!.id, res);
+      if (!game) return;
+      const gameFile = await storage.addGameFile(parsed);
+      res.status(201).json(gameFile);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return respondWithZodError(res, error, "Invalid game file data");
+      }
+      routesLogger.error({ error }, "error creating game file");
+      res.status(500).json({ error: "Failed to create game file" });
+    }
+  });
+
+  // Delete a game file record
+  app.delete("/api/game-files/:id", authenticateToken, async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const deleted = await storage.removeGameFile(id);
+      if (!deleted) {
+        return res.status(404).json({ error: "Game file not found" });
+      }
+      res.json({ success: true });
+    } catch (error) {
+      routesLogger.error({ error }, "error deleting game file");
+      res.status(500).json({ error: "Failed to delete game file" });
     }
   });
 

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -44,6 +44,7 @@ const importConfigPatchSchema = z
     minFileSize: z.number().int().min(0).optional(),
     libraryRoot: z.string().min(1).max(1024).optional(),
     autoDeleteAfterImport: z.boolean().optional(),
+    sortExtras: z.boolean().optional(),
   })
   .strict();
 
@@ -328,6 +329,7 @@ importRouter.patch("/config", async (req, res) => {
       ignoredExtensions: newConfig.ignoredExtensions,
       minFileSize: newConfig.minFileSize,
       libraryRoot: newConfig.libraryRoot,
+      sortExtras: newConfig.sortExtras,
     };
 
     const existing = await storage.getUserSettings(userId);

--- a/server/services/ImportManager.ts
+++ b/server/services/ImportManager.ts
@@ -587,6 +587,7 @@ export class ImportManager {
 
     const planToExecute: ImportReview = {
       ...overridePlan,
+      fileCategories: undefined,
       originalPath: processPath,
     };
 

--- a/server/services/ImportManager.ts
+++ b/server/services/ImportManager.ts
@@ -594,6 +594,15 @@ export class ImportManager {
 
     try {
       const strategy = new PCImportStrategy();
+      if (config.sortExtras) {
+        const categorizedPlan = await strategy.planImport(
+          processPath,
+          game,
+          config.libraryRoot,
+          config
+        );
+        planToExecute.fileCategories = categorizedPlan.fileCategories;
+      }
       const result = await strategy.executeImport(planToExecute, transferMode);
 
       await this.finalizeImport(downloadId, game, result.destDir);

--- a/server/services/ImportStrategies.ts
+++ b/server/services/ImportStrategies.ts
@@ -143,6 +143,18 @@ async function categorizeSourceFiles(sourcePath: string): Promise<FileCategoryEn
   });
 }
 
+function resolveContainedPath(root: string, candidate: string): string {
+  const resolvedRoot = path.resolve(root);
+  const resolvedCandidate = path.resolve(candidate);
+  if (
+    resolvedCandidate !== resolvedRoot &&
+    !resolvedCandidate.startsWith(resolvedRoot + path.sep)
+  ) {
+    throw new Error(`Import path escapes review root: ${candidate}`);
+  }
+  return resolvedCandidate;
+}
+
 function destinationForFile(gameDir: string, entry: FileCategoryEntry): string {
   const firstSegment = entry.name.split(path.sep)[0]?.toLowerCase();
   if (["dlc", "update", "extra"].includes(firstSegment ?? "")) {
@@ -199,8 +211,14 @@ export class PCImportStrategy implements ImportStrategy {
 
       const plannedTransfers = review.fileCategories.map((entry) => ({
         entry,
-        sourceFile: path.join(review.originalPath, entry.name),
-        destinationFile: destinationForFile(review.proposedPath, entry),
+        sourceFile: resolveContainedPath(
+          review.originalPath,
+          path.join(review.originalPath, entry.name)
+        ),
+        destinationFile: resolveContainedPath(
+          review.proposedPath,
+          destinationForFile(review.proposedPath, entry)
+        ),
       }));
       const destinations = new Set<string>();
       for (const { destinationFile } of plannedTransfers) {

--- a/server/services/ImportStrategies.ts
+++ b/server/services/ImportStrategies.ts
@@ -133,6 +133,7 @@ const CATEGORY_DIR_MAP: Record<DownloadCategory, string> = {
   dlc: "dlc",
   update: "update",
   extra: "extra",
+  packs: "packs",
 };
 
 async function categorizeSourceFiles(sourcePath: string): Promise<FileCategoryEntry[]> {
@@ -157,7 +158,7 @@ function resolveContainedPath(root: string, candidate: string): string {
 
 function destinationForFile(gameDir: string, entry: FileCategoryEntry): string {
   const firstSegment = entry.name.split(path.sep)[0]?.toLowerCase();
-  if (["dlc", "update", "extra"].includes(firstSegment ?? "")) {
+  if (["dlc", "update", "extra", "packs"].includes(firstSegment ?? "")) {
     return path.join(gameDir, entry.name);
   }
 

--- a/server/services/ImportStrategies.ts
+++ b/server/services/ImportStrategies.ts
@@ -144,13 +144,14 @@ async function categorizeSourceFiles(sourcePath: string): Promise<FileCategoryEn
 }
 
 function destinationForFile(gameDir: string, entry: FileCategoryEntry): string {
+  const firstSegment = entry.name.split(path.sep)[0]?.toLowerCase();
+  if (["dlc", "update", "extra"].includes(firstSegment ?? "")) {
+    return path.join(gameDir, entry.name);
+  }
+
   const subdir = CATEGORY_DIR_MAP[entry.category];
   if (!subdir) return path.join(gameDir, entry.name);
-
-  const firstSegment = entry.name.split(path.sep)[0]?.toLowerCase();
-  return firstSegment === subdir
-    ? path.join(gameDir, entry.name)
-    : path.join(gameDir, subdir, entry.name);
+  return path.join(gameDir, subdir, entry.name);
 }
 
 export class PCImportStrategy implements ImportStrategy {
@@ -196,9 +197,21 @@ export class PCImportStrategy implements ImportStrategy {
       const conflictsResolved: string[] = [];
       let modeUsed: TransferMode = transferMode;
 
-      for (const entry of review.fileCategories) {
-        const sourceFile = path.join(review.originalPath, entry.name);
-        const destinationFile = destinationForFile(review.proposedPath, entry);
+      const plannedTransfers = review.fileCategories.map((entry) => ({
+        entry,
+        sourceFile: path.join(review.originalPath, entry.name),
+        destinationFile: destinationForFile(review.proposedPath, entry),
+      }));
+      const destinations = new Set<string>();
+      for (const { destinationFile } of plannedTransfers) {
+        const resolvedDestination = path.resolve(destinationFile);
+        if (destinations.has(resolvedDestination)) {
+          throw new Error(`Duplicate import destination: ${resolvedDestination}`);
+        }
+        destinations.add(resolvedDestination);
+      }
+
+      for (const { entry, sourceFile, destinationFile } of plannedTransfers) {
         const entryMode = await transferFile(sourceFile, destinationFile, transferMode);
         filesPlaced.push(destinationFile);
         if (entryMode !== transferMode) {

--- a/server/services/ImportStrategies.ts
+++ b/server/services/ImportStrategies.ts
@@ -1,4 +1,5 @@
 import { Game, ImportConfig } from "../../shared/schema.js";
+import { categorizeDownload, type DownloadCategory } from "../../shared/download-categorizer.js";
 import fs from "fs-extra";
 import path from "node:path";
 import { logger } from "../logger.js";
@@ -26,7 +27,13 @@ export interface ImportReview {
   proposedPath: string;
   strategy: "pc";
   ignoredExtensions?: string[];
+  fileCategories?: FileCategoryEntry[];
   importResult?: ImportResult;
+}
+
+export interface FileCategoryEntry {
+  name: string;
+  category: DownloadCategory;
 }
 
 export interface ImportStrategy {
@@ -49,6 +56,10 @@ async function transferFile(
   destination: string,
   mode: "move" | "copy" | "hardlink" | "symlink"
 ): Promise<"move" | "copy" | "hardlink" | "symlink"> {
+  if (path.resolve(source) === path.resolve(destination)) {
+    return mode;
+  }
+
   await ensureParentDir(destination);
 
   if (mode === "move") {
@@ -117,6 +128,31 @@ async function gatherFiles(rootPath: string): Promise<string[]> {
   return collected;
 }
 
+const CATEGORY_DIR_MAP: Record<DownloadCategory, string> = {
+  main: "",
+  dlc: "dlc",
+  update: "update",
+  extra: "extra",
+};
+
+async function categorizeSourceFiles(sourcePath: string): Promise<FileCategoryEntry[]> {
+  const files = await gatherFiles(sourcePath);
+  return files.map((filePath) => {
+    const name = path.relative(sourcePath, filePath);
+    return { name, category: categorizeDownload(name).category };
+  });
+}
+
+function destinationForFile(gameDir: string, entry: FileCategoryEntry): string {
+  const subdir = CATEGORY_DIR_MAP[entry.category];
+  if (!subdir) return path.join(gameDir, entry.name);
+
+  const firstSegment = entry.name.split(path.sep)[0]?.toLowerCase();
+  return firstSegment === subdir
+    ? path.join(gameDir, entry.name)
+    : path.join(gameDir, subdir, entry.name);
+}
+
 export class PCImportStrategy implements ImportStrategy {
   async planImport(
     sourcePath: string,
@@ -133,6 +169,10 @@ export class PCImportStrategy implements ImportStrategy {
     const cleanTitle = sanitizeFsName(game.title);
     const ext = stats.isDirectory() ? "" : path.extname(sourcePath);
     const destination = path.join(targetRoot, platformDir ?? "PC", cleanTitle + ext);
+    const fileCategories =
+      stats.isDirectory() && config.sortExtras
+        ? await categorizeSourceFiles(sourcePath)
+        : undefined;
 
     const destinationExists = await fs.pathExists(destination);
     const needsReview = destinationExists && !config.overwriteExisting;
@@ -143,6 +183,7 @@ export class PCImportStrategy implements ImportStrategy {
       originalPath: sourcePath,
       proposedPath: destination,
       strategy: "pc",
+      fileCategories,
     };
   }
 
@@ -150,6 +191,41 @@ export class PCImportStrategy implements ImportStrategy {
     review: ImportReview,
     transferMode: "move" | "copy" | "hardlink" | "symlink"
   ): Promise<ImportResult> {
+    if (review.fileCategories && review.fileCategories.length > 0) {
+      const filesPlaced: string[] = [];
+      const conflictsResolved: string[] = [];
+      let modeUsed: TransferMode = transferMode;
+
+      for (const entry of review.fileCategories) {
+        const sourceFile = path.join(review.originalPath, entry.name);
+        const destinationFile = destinationForFile(review.proposedPath, entry);
+        const entryMode = await transferFile(sourceFile, destinationFile, transferMode);
+        filesPlaced.push(destinationFile);
+        if (entryMode !== transferMode) {
+          modeUsed = entryMode;
+          conflictsResolved.push(`${entry.name} (mode fallback: ${entryMode})`);
+        }
+      }
+
+      const resolvedSource = path.resolve(review.originalPath);
+      const resolvedDestination = path.resolve(review.proposedPath);
+      const destinationInsideSource = resolvedDestination.startsWith(resolvedSource + path.sep);
+      if (
+        transferMode === "move" &&
+        resolvedSource !== resolvedDestination &&
+        !destinationInsideSource
+      ) {
+        await fs.remove(review.originalPath);
+      }
+
+      return {
+        destDir: review.proposedPath,
+        filesPlaced,
+        modeUsed,
+        conflictsResolved,
+      };
+    }
+
     await fs.ensureDir(path.dirname(review.proposedPath));
     const modeUsed = await transferFile(review.originalPath, review.proposedPath, transferMode);
     const filesPlaced = await gatherFiles(review.proposedPath);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -51,6 +51,9 @@ import {
   type ImportConfig,
   importConfigSchema,
   releaseBlacklist,
+  type GameFile,
+  type InsertGameFile,
+  gameFiles,
 } from "../shared/schema.js";
 import { randomUUID } from "crypto";
 import { db } from "./db.js";
@@ -298,6 +301,14 @@ export interface IStorage {
   getImportTask(id: string): Promise<ImportTask | undefined>;
   getImportTaskItems(taskId: string): Promise<ImportTaskItem[]>;
   deleteImportTasksOlderThan(cutoffMs: number): Promise<number>;
+
+  // GameFile methods
+  getGameFiles(gameId: string): Promise<GameFile[]>;
+  getGameFilesByDownload(downloadId: string): Promise<GameFile[]>;
+  addGameFile(file: InsertGameFile): Promise<GameFile>;
+  addGameFilesBatch(files: InsertGameFile[]): Promise<GameFile[]>;
+  removeGameFile(id: string): Promise<boolean>;
+  removeGameFilesByGameId(gameId: string): Promise<number>;
 }
 
 export class MemStorage implements IStorage {
@@ -315,6 +326,7 @@ export class MemStorage implements IStorage {
   private readonly pathMappings: Map<string, PathMapping>;
   private readonly platformMappings: Map<string, PlatformMapping>;
   private releaseBlacklists: Map<string, ReleaseBlacklist>;
+  private gameFiles: Map<string, GameFile>;
 
   constructor() {
     this.users = new Map();
@@ -331,6 +343,7 @@ export class MemStorage implements IStorage {
     this.pathMappings = new Map();
     this.platformMappings = new Map();
     this.releaseBlacklists = new Map();
+    this.gameFiles = new Map();
   }
 
   // System Config methods
@@ -1306,6 +1319,49 @@ export class MemStorage implements IStorage {
       .filter((r) => r.gameId === gameId)
       .map((r) => r.releaseTitle);
     return new Set(titles);
+  }
+
+  // GameFile methods
+  async getGameFiles(gameId: string): Promise<GameFile[]> {
+    return Array.from(this.gameFiles.values()).filter((f) => f.gameId === gameId);
+  }
+
+  async getGameFilesByDownload(downloadId: string): Promise<GameFile[]> {
+    return Array.from(this.gameFiles.values()).filter((f) => f.downloadId === downloadId);
+  }
+
+  async addGameFile(file: InsertGameFile): Promise<GameFile> {
+    const id = randomUUID();
+    const gf: GameFile = {
+      ...file,
+      id,
+      downloadId: file.downloadId ?? null,
+      category: file.category as GameFile["category"],
+      fileSize: file.fileSize ?? null,
+      createdAt: new Date(),
+    };
+    this.gameFiles.set(id, gf);
+    return gf;
+  }
+
+  async addGameFilesBatch(files: InsertGameFile[]): Promise<GameFile[]> {
+    const result: GameFile[] = [];
+    for (const file of files) {
+      result.push(await this.addGameFile(file));
+    }
+    return result;
+  }
+
+  async removeGameFile(id: string): Promise<boolean> {
+    return this.gameFiles.delete(id);
+  }
+
+  async removeGameFilesByGameId(gameId: string): Promise<number> {
+    const toDelete = Array.from(this.gameFiles.values()).filter((f) => f.gameId === gameId);
+    for (const f of toDelete) {
+      this.gameFiles.delete(f.id);
+    }
+    return toDelete.length;
   }
 
   // Import task history — not implemented in MemStorage (tests use DatabaseStorage)
@@ -2412,6 +2468,44 @@ export class DatabaseStorage implements IStorage {
       .from(releaseBlacklist)
       .where(eq(releaseBlacklist.gameId, gameId));
     return new Set(rows.map((r) => r.releaseTitle));
+  }
+
+  // GameFile methods
+  async getGameFiles(gameId: string): Promise<GameFile[]> {
+    return db.select().from(gameFiles).where(eq(gameFiles.gameId, gameId));
+  }
+
+  async getGameFilesByDownload(downloadId: string): Promise<GameFile[]> {
+    return db.select().from(gameFiles).where(eq(gameFiles.downloadId, downloadId));
+  }
+
+  async addGameFile(file: InsertGameFile): Promise<GameFile> {
+    const id = randomUUID();
+    const [gf] = await db
+      .insert(gameFiles)
+      .values({ ...file, id, category: file.category as "main" | "dlc" | "update" | "extra" })
+      .returning();
+    return gf;
+  }
+
+  async addGameFilesBatch(files: InsertGameFile[]): Promise<GameFile[]> {
+    if (files.length === 0) return [];
+    const values = files.map((file) => ({
+      ...file,
+      id: randomUUID(),
+      category: file.category as "main" | "dlc" | "update" | "extra",
+    }));
+    return db.insert(gameFiles).values(values).returning();
+  }
+
+  async removeGameFile(id: string): Promise<boolean> {
+    const result = await db.delete(gameFiles).where(eq(gameFiles.id, id));
+    return (result.changes ?? 0) > 0;
+  }
+
+  async removeGameFilesByGameId(gameId: string): Promise<number> {
+    const result = await db.delete(gameFiles).where(eq(gameFiles.gameId, gameId));
+    return result.changes ?? 0;
   }
 
   // Import task history methods

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -93,6 +93,7 @@ function buildImportConfigFromSettings(
     | "minFileSize"
     | "libraryRoot"
     | "autoDeleteAfterImport"
+    | "sortExtras"
   >
 ): ImportConfig {
   const parsed = importConfigSchema.safeParse({
@@ -106,6 +107,7 @@ function buildImportConfigFromSettings(
     minFileSize: settings?.minFileSize ?? 0,
     libraryRoot: settings?.libraryRoot ?? "/data",
     autoDeleteAfterImport: settings?.autoDeleteAfterImport ?? false,
+    sortExtras: settings?.sortExtras ?? false,
   });
 
   if (parsed.success) return parsed.data;
@@ -121,6 +123,7 @@ function buildImportConfigFromSettings(
     minFileSize: settings?.minFileSize ?? 0,
     libraryRoot: settings?.libraryRoot ?? "/data",
     autoDeleteAfterImport: settings?.autoDeleteAfterImport ?? false,
+    sortExtras: settings?.sortExtras ?? false,
   };
 }
 
@@ -1106,6 +1109,7 @@ export class MemStorage implements IStorage {
       minFileSize: insertSettings.minFileSize ?? 0,
       libraryRoot: insertSettings.libraryRoot ?? "/data",
       autoDeleteAfterImport: insertSettings.autoDeleteAfterImport ?? false,
+      sortExtras: insertSettings.sortExtras ?? false,
 
       preferredReleaseGroups: insertSettings.preferredReleaseGroups ?? null,
       filterByPreferredGroups: insertSettings.filterByPreferredGroups ?? false,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -304,6 +304,7 @@ export interface IStorage {
 
   // GameFile methods
   getGameFiles(gameId: string): Promise<GameFile[]>;
+  getGameFile(id: string): Promise<GameFile | undefined>;
   getGameFilesByDownload(downloadId: string): Promise<GameFile[]>;
   addGameFile(file: InsertGameFile): Promise<GameFile>;
   addGameFilesBatch(files: InsertGameFile[]): Promise<GameFile[]>;
@@ -602,7 +603,9 @@ export class MemStorage implements IStorage {
   }
 
   async removeGame(id: string): Promise<boolean> {
-    return this.games.delete(id);
+    const deleted = this.games.delete(id);
+    if (deleted) await this.removeGameFilesByGameId(id);
+    return deleted;
   }
 
   async assignOrphanGamesToUser(userId: string): Promise<number> {
@@ -881,6 +884,9 @@ export class MemStorage implements IStorage {
   async removeGameDownload(id: string, gameId: string): Promise<boolean> {
     const gd = this.gameDownloads.get(id);
     if (!gd || gd.gameId !== gameId) return false;
+    for (const [fileId, file] of this.gameFiles.entries()) {
+      if (file.downloadId === id) this.gameFiles.set(fileId, { ...file, downloadId: null });
+    }
     return this.gameDownloads.delete(id);
   }
 
@@ -1326,11 +1332,19 @@ export class MemStorage implements IStorage {
     return Array.from(this.gameFiles.values()).filter((f) => f.gameId === gameId);
   }
 
+  async getGameFile(id: string): Promise<GameFile | undefined> {
+    return this.gameFiles.get(id);
+  }
+
   async getGameFilesByDownload(downloadId: string): Promise<GameFile[]> {
     return Array.from(this.gameFiles.values()).filter((f) => f.downloadId === downloadId);
   }
 
   async addGameFile(file: InsertGameFile): Promise<GameFile> {
+    if (!this.games.has(file.gameId)) throw new Error(`Game ${file.gameId} not found`);
+    if (file.downloadId && !this.gameDownloads.has(file.downloadId)) {
+      throw new Error(`Download ${file.downloadId} not found`);
+    }
     const id = randomUUID();
     const gf: GameFile = {
       ...file,
@@ -2473,6 +2487,11 @@ export class DatabaseStorage implements IStorage {
   // GameFile methods
   async getGameFiles(gameId: string): Promise<GameFile[]> {
     return db.select().from(gameFiles).where(eq(gameFiles.gameId, gameId));
+  }
+
+  async getGameFile(id: string): Promise<GameFile | undefined> {
+    const [file] = await db.select().from(gameFiles).where(eq(gameFiles.id, id)).limit(1);
+    return file;
   }
 
   async getGameFilesByDownload(downloadId: string): Promise<GameFile[]> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -71,6 +71,7 @@ export const userSettings = sqliteTable("user_settings", {
   autoDeleteAfterImport: integer("auto_delete_after_import", { mode: "boolean" })
     .notNull()
     .default(false),
+  sortExtras: integer("sort_extras", { mode: "boolean" }).notNull().default(false),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }).default(
     sql`(strftime('%s', 'now') * 1000)`
   ),
@@ -115,6 +116,7 @@ export interface ImportConfig {
   minFileSize: number;
   libraryRoot: string;
   autoDeleteAfterImport: boolean;
+  sortExtras: boolean;
 }
 
 export const IMPORT_TRANSFER_MODES = ["move", "copy", "hardlink", "symlink"] as const;
@@ -134,6 +136,7 @@ export const importConfigSchema = z.object({
   minFileSize: z.number().int().min(0),
   libraryRoot: z.string().min(1),
   autoDeleteAfterImport: z.boolean(),
+  sortExtras: z.boolean(),
 });
 
 export const systemConfig = sqliteTable("system_config", {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -835,3 +835,34 @@ export type InsertImportTask = (typeof insertImportTaskSchema)["_output"];
 
 export type ImportTaskItem = typeof importTaskItems.$inferSelect;
 export type InsertImportTaskItem = (typeof insertImportTaskItemSchema)["_output"];
+
+export const gameFiles = sqliteTable(
+  "game_files",
+  {
+    id: text("id").primaryKey(),
+    gameId: text("game_id")
+      .notNull()
+      .references(() => games.id, { onDelete: "cascade" }),
+    downloadId: text("download_id").references(() => gameDownloads.id, { onDelete: "set null" }),
+    originalName: text("original_name").notNull(),
+    storedName: text("stored_name").notNull(),
+    category: text("category").notNull().$type<"main" | "dlc" | "update" | "extra">(),
+    filePath: text("file_path").notNull(),
+    fileSize: integer("file_size"),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).default(
+      sql`(strftime('%s', 'now') * 1000)`
+    ),
+  },
+  (t) => [
+    index("game_files_game_id_idx").on(t.gameId),
+    index("game_files_download_id_idx").on(t.downloadId),
+  ]
+);
+
+export const insertGameFileSchema = createInsertSchema(gameFiles).omit({
+  id: true,
+  createdAt: true,
+});
+
+export type GameFile = typeof gameFiles.$inferSelect;
+export type InsertGameFile = (typeof insertGameFileSchema)["_output"];

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -836,6 +836,9 @@ export type InsertImportTask = (typeof insertImportTaskSchema)["_output"];
 export type ImportTaskItem = typeof importTaskItems.$inferSelect;
 export type InsertImportTaskItem = (typeof insertImportTaskItemSchema)["_output"];
 
+export const gameFileCategorySchema = z.enum(["main", "dlc", "update", "extra"]);
+export type GameFileCategory = z.infer<typeof gameFileCategorySchema>;
+
 export const gameFiles = sqliteTable(
   "game_files",
   {
@@ -846,7 +849,7 @@ export const gameFiles = sqliteTable(
     downloadId: text("download_id").references(() => gameDownloads.id, { onDelete: "set null" }),
     originalName: text("original_name").notNull(),
     storedName: text("stored_name").notNull(),
-    category: text("category").notNull().$type<"main" | "dlc" | "update" | "extra">(),
+    category: text("category").notNull().$type<GameFileCategory>(),
     filePath: text("file_path").notNull(),
     fileSize: integer("file_size"),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).default(
@@ -859,7 +862,9 @@ export const gameFiles = sqliteTable(
   ]
 );
 
-export const insertGameFileSchema = createInsertSchema(gameFiles).omit({
+export const insertGameFileSchema = createInsertSchema(gameFiles, {
+  category: gameFileCategorySchema,
+}).omit({
   id: true,
   createdAt: true,
 });


### PR DESCRIPTION
## Summary

- Add the `game_files` migration and schema.
- Add storage CRUD for game files.
- Add authenticated game content and file endpoints.
- Preserve nullable download links and game ownership checks.

This PR is stacked on #877 for migration ordering and import-schema compatibility. It intentionally excludes the Content tab UI, Scan Disk, and import-engine changes.

## Validation

- `npm run check`
- `npx vitest run server/__tests__/storage.test.ts --pool=forks --maxWorkers=1` — 44 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to automatically organize detected DLC, updates, and extras into dedicated subfolders during directory imports.
  * Added game-file tracking and management capabilities, including categorized file listings and deletion support.
  * Expanded game information with categories, game types, expansion details, cover art, and release dates.
* **Bug Fixes**
  * Improved import handling to prevent duplicate destinations and preserve flat layouts for single-file imports.
* **Tests**
  * Added coverage for categorized imports, game-file lifecycle behavior, and expanded game metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->