### PR TITLE
Sanitize indexer comments URL before linking release titles

### DIFF
--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -312,6 +312,26 @@ describe("GameDownloadDialog", () => {
     }
   );
 
+  it.each([false, true])(
+    "sanitizes an unsafe indexer comments URL when mobile is %s",
+    async (isMobile) => {
+      mockIsMobile = isMobile;
+      globalThis.fetch = createFetchMock({
+        search: makeSearchResult([
+          makeTorrentItem({
+            title: "Unsafe Release",
+            comments: "javascript:alert(document.cookie)",
+          }),
+        ]),
+      });
+
+      renderComponent();
+
+      const link = await screen.findByRole("link", { name: "Unsafe Release" });
+      expect(link).toHaveAttribute("href", "#");
+    }
+  );
+
   it("identifies Usenet vs Torrent items", async () => {
     renderComponent();
 

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -67,7 +67,7 @@ import {
 } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
-import { cn } from "@/lib/utils";
+import { cn, safeUrl } from "@/lib/utils";
 import {
   type Game,
   type Indexer,
@@ -1140,7 +1140,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                         <h4 className="font-semibold text-sm leading-snug break-all line-clamp-2 min-w-0 flex-1">
                                           {download.comments ? (
                                             <a
-                                              href={download.comments}
+                                              href={safeUrl(download.comments)}
                                               target="_blank"
                                               rel="noopener noreferrer"
                                               className="hover:underline cursor-pointer"
@@ -1256,7 +1256,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                                   <h4 className="font-bold text-base leading-tight break-words min-w-0">
                                     {download.comments ? (
                                       <a
-                                        href={download.comments}
+                                        href={safeUrl(download.comments)}
                                         target="_blank"
                                         rel="noopener noreferrer"
                                         className="hover:underline cursor-pointer"


### PR DESCRIPTION
## Description

PR #872 ("Link download results to indexer sources") linked release titles in `GameDownloadDialog.tsx` to `download.comments` — a URL sourced verbatim from Torznab/Newznab indexer XML responses (`server/torznab.ts` copies the `<comments>` attribute through untouched) — via a raw `<a href={download.comments}>`, with no URL scheme validation.

A configured indexer (or a MITM on that connection, since these are user-added third-party URLs) returning `javascript:...` or `data:text/html,...` in place of a normal link would have that URI navigated/executed in the app's origin when a user clicked the release title.

The codebase already has `safeUrl()` in `client/src/lib/utils.ts`, written specifically to prevent this (only allows `http:`/`https:`, otherwise falls back to `"#"`), and it's already used for the same purpose in `GameDetailsModal.tsx`. This PR wraps the two `download.comments` usages (mobile card + desktop row) in `GameDownloadDialog.tsx` with it, consistent with the rest of the codebase.

Found while reviewing open PRs from @Pachinko0 — not part of any of those, since #872 (which introduced this) is already merged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Validation

- `npx vitest run client/__tests__/GameDownloadDialog.test.tsx` — 30 passed, 1 skipped (added a `javascript:` URL regression test alongside the existing legitimate-link test)
- `npm run check` — passed
- `npx eslint` / `npx prettier --check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5QxVdkLT1aQ9vSDKp3r74)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Secured release comment links by blocking unsafe URL schemes.
  - Unsafe links now fall back to a safe placeholder instead of being opened.

- **Tests**
  - Added coverage for unsafe links in both mobile and desktop views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->