### PR TITLE
Add platform and release year filters to game search

### DIFF
--- a/client/__tests__/AddGameModal.test.tsx
+++ b/client/__tests__/AddGameModal.test.tsx
@@ -25,6 +25,8 @@ vi.mock("lucide-react", () => ({
   Calendar: () => <div data-testid="icon-calendar" />,
   Loader2: () => <div data-testid="icon-loader" />,
   Check: () => <div data-testid="icon-check" />,
+  ChevronDown: () => <div />,
+  ChevronUp: () => <div />,
   X: () => <div />,
 }));
 
@@ -145,7 +147,7 @@ describe("AddGameModal", () => {
     // The effect runs on `open` change; simulate by typing and then looking for clear.
     const input = screen.getByDisplayValue("Hollow Knight");
     fireEvent.change(input, { target: { value: "" } });
-    expect(screen.getByDisplayValue("")).toBeInTheDocument();
+    expect(screen.getByLabelText("Search games")).toHaveValue("");
   });
 
   it("shows Calendar icon for search results with a release date", async () => {
@@ -193,6 +195,60 @@ describe("AddGameModal", () => {
         expect.any(Object)
       );
     });
+  });
+
+  it("requests at most 10 games and forwards a valid release year filter", async () => {
+    const searchResults = Array.from({ length: 12 }, (_, index) => ({
+      ...makeSearchResult(`God of War ${index + 1}`, "2005-03-22"),
+      id: `igdb-${index + 1}`,
+      igdbId: 100 + index,
+    }));
+    setupFetch({ searchResults });
+    renderModal({ initialQuery: "God of War" });
+    fireEvent.click(screen.getByTestId("open-btn"));
+
+    const yearInput = await screen.findByLabelText("Release year filter");
+    fireEvent.change(yearInput, { target: { value: "2005" } });
+
+    await waitFor(() => {
+      const searchCalls = vi
+        .mocked(globalThis.fetch)
+        .mock.calls.filter(([url]) => String(url).includes("/api/igdb/search"));
+      expect(
+        searchCalls.some(([url]) => {
+          const params = new URL(String(url), "http://localhost").searchParams;
+          return params.get("limit") === "10" && params.get("year") === "2005";
+        })
+      ).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId(/^search-result-igdb-/)).toHaveLength(10);
+    });
+    expect(screen.queryByText("God of War 11")).not.toBeInTheDocument();
+  });
+
+  it("does not search while a nonempty release year is incomplete", async () => {
+    setupFetch({ searchResults: [makeSearchResult("God of War", "2005-03-22")] });
+    renderModal({ initialQuery: "God of War" });
+    fireEvent.click(screen.getByTestId("open-btn"));
+
+    await screen.findByText("God of War");
+    const searchCallsBefore = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.filter(([url]) => String(url).includes("/api/igdb/search")).length;
+
+    fireEvent.change(screen.getByLabelText("Release year filter"), {
+      target: { value: "20" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("God of War")).not.toBeInTheDocument();
+    });
+    const searchCallsAfter = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.filter(([url]) => String(url).includes("/api/igdb/search")).length;
+    expect(searchCallsAfter).toBe(searchCallsBefore);
   });
 
   it("shows the mobile configuration prompt when IGDB is not configured", async () => {

--- a/client/src/components/AddGameModal.tsx
+++ b/client/src/components/AddGameModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Dialog,
   DialogContent,
@@ -21,6 +21,13 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Search, Plus, Star, AlertCircle, Calendar, Check, Loader2 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { type Game, type InsertGame, type Config } from "@shared/schema";
@@ -39,18 +46,36 @@ interface AddGameModalProps {
   initialQuery?: string;
 }
 
+interface IGDBPlatform {
+  id: number;
+  name: string;
+}
+
 export default function AddGameModal({ children, initialQuery }: AddGameModalProps) {
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [showUndatedGames, setShowUndatedGames] = useState(false);
+  const [selectedPlatform, setSelectedPlatform] = useState("all");
+  const [releaseYear, setReleaseYear] = useState("");
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
+  const parsedReleaseYear = Number.parseInt(releaseYear, 10);
+  const hasValidReleaseYear =
+    /^\d{4}$/.test(releaseYear) && parsedReleaseYear >= 1950 && parsedReleaseYear <= 2100;
+  const canSearchWithReleaseYear = releaseYear === "" || hasValidReleaseYear;
 
   const { data: config } = useQuery<Config>({
     queryKey: ["/api/config"],
     queryFn: () => apiRequest("GET", "/api/config").then((res) => res.json()),
+  });
+
+  const { data: platforms = [] } = useQuery<IGDBPlatform[]>({
+    queryKey: ["/api/igdb/platforms"],
+    queryFn: () => apiRequest("GET", "/api/igdb/platforms").then((res) => res.json()),
+    enabled: open && !!config?.igdb?.configured,
+    staleTime: 24 * 60 * 60 * 1000,
   });
 
   // Debounce search query
@@ -75,12 +100,14 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
       setSearchQuery("");
       setDebouncedQuery("");
       setShowUndatedGames(false);
+      setSelectedPlatform("all");
+      setReleaseYear("");
     }
   }, [open, initialQuery]);
 
   // Search IGDB for games
-  const { data: searchResults = [], isLoading: isSearching } = useQuery({
-    queryKey: ["/api/igdb/search", debouncedQuery, showUndatedGames],
+  const { data: searchResults = [], isFetching: isSearching } = useQuery({
+    queryKey: ["/api/igdb/search", debouncedQuery, showUndatedGames, selectedPlatform, releaseYear],
     queryFn: async () => {
       if (!debouncedQuery.trim()) return [];
       const token = localStorage.getItem("token");
@@ -88,15 +115,22 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
       if (token) {
         headers["Authorization"] = `Bearer ${token}`;
       }
-      const response = await fetch(
-        `/api/igdb/search?q=${encodeURIComponent(debouncedQuery)}&limit=10&includeUndated=${showUndatedGames}`,
-        { headers }
-      );
+      const params = new URLSearchParams({
+        q: debouncedQuery,
+        limit: "10",
+        includeUndated: String(showUndatedGames),
+      });
+      if (selectedPlatform !== "all") params.set("platform", selectedPlatform);
+      if (hasValidReleaseYear) {
+        params.set("year", releaseYear);
+      }
+      const response = await fetch(`/api/igdb/search?${params.toString()}`, { headers });
       if (!response.ok) throw new Error("Search failed");
-      return response.json();
+      const data: unknown = await response.json();
+      return Array.isArray(data) ? data.slice(0, 10) : [];
     },
-    enabled: debouncedQuery.trim().length > 2 && !!config?.igdb?.configured,
-    placeholderData: keepPreviousData,
+    enabled:
+      debouncedQuery.trim().length > 2 && canSearchWithReleaseYear && !!config?.igdb?.configured,
   });
 
   // Get user's collection to check if games are already added
@@ -140,6 +174,14 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
     // Search is handled by the debounced query
   };
 
+  const handleReleaseYearChange = (value: string) => {
+    setReleaseYear(value);
+    const parsedYear = Number.parseInt(value, 10);
+    if (/^\d{4}$/.test(value) && parsedYear >= 1950 && parsedYear <= 2100) {
+      setShowUndatedGames(false);
+    }
+  };
+
   const handleAddGame = (searchResult: SearchResult) => {
     // Map to InsertGame to filter out client-only fields before sending to server
     const gameData = mapGameToInsertGame(searchResult);
@@ -156,7 +198,7 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
 
   // Mark games already in collection
   const resultsWithCollectionStatus: SearchResult[] = useMemo(() => {
-    return searchResults.map((game: Game) => ({
+    return searchResults.slice(0, 10).map((game: Game) => ({
       ...game,
       inCollection: game.igdbId != null ? userGameIgdbIds.has(game.igdbId) : false,
     }));
@@ -212,11 +254,37 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
                     aria-label="Search games"
                   />
                 </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <Select value={selectedPlatform} onValueChange={setSelectedPlatform}>
+                    <SelectTrigger aria-label="Platform filter">
+                      <SelectValue placeholder="All platforms" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All platforms</SelectItem>
+                      {platforms.map((platform) => (
+                        <SelectItem key={platform.id} value={String(platform.id)}>
+                          {platform.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Input
+                    type="number"
+                    inputMode="numeric"
+                    min="1950"
+                    max="2100"
+                    placeholder="Release year"
+                    value={releaseYear}
+                    onChange={(event) => handleReleaseYearChange(event.target.value)}
+                    aria-label="Release year filter"
+                  />
+                </div>
                 <div className="flex items-center justify-between gap-2 px-0.5">
                   <span className="text-xs text-muted-foreground">Show undated games first</span>
                   <Switch
                     checked={showUndatedGames}
                     onCheckedChange={setShowUndatedGames}
+                    disabled={hasValidReleaseYear}
                     aria-label="Show undated games first"
                   />
                 </div>
@@ -378,6 +446,32 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
               </Button>
             </form>
 
+            <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Select value={selectedPlatform} onValueChange={setSelectedPlatform}>
+                <SelectTrigger aria-label="Platform filter">
+                  <SelectValue placeholder="All platforms" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All platforms</SelectItem>
+                  {platforms.map((platform) => (
+                    <SelectItem key={platform.id} value={String(platform.id)}>
+                      {platform.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Input
+                type="number"
+                inputMode="numeric"
+                min="1950"
+                max="2100"
+                placeholder="Release year"
+                value={releaseYear}
+                onChange={(event) => handleReleaseYearChange(event.target.value)}
+                aria-label="Release year filter"
+              />
+            </div>
+
             <div className="mb-4 flex items-center justify-between gap-3 rounded-md border px-3 py-2">
               <div className="space-y-1">
                 <p className="text-sm font-medium">Show undated games first</p>
@@ -385,7 +479,11 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
                   Include titles without a release date and place them before dated results.
                 </p>
               </div>
-              <Switch checked={showUndatedGames} onCheckedChange={setShowUndatedGames} />
+              <Switch
+                checked={showUndatedGames}
+                onCheckedChange={setShowUndatedGames}
+                disabled={hasValidReleaseYear}
+              />
             </div>
 
             <div className="space-y-4" aria-live="polite">

--- a/client/src/components/AddGameModal.tsx
+++ b/client/src/components/AddGameModal.tsx
@@ -182,6 +182,60 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
     }
   };
 
+  const renderDiscoveryFilters = (compact = false) => (
+    <div className={compact ? "space-y-2" : "mb-4 space-y-4"}>
+      <div className="grid grid-cols-2 gap-2">
+        <Select value={selectedPlatform} onValueChange={setSelectedPlatform}>
+          <SelectTrigger aria-label="Platform filter">
+            <SelectValue placeholder="All platforms" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All platforms</SelectItem>
+            {platforms.map((platform) => (
+              <SelectItem key={platform.id} value={String(platform.id)}>
+                {platform.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          type="number"
+          inputMode="numeric"
+          min="1950"
+          max="2100"
+          placeholder="Release year"
+          value={releaseYear}
+          onChange={(event) => handleReleaseYearChange(event.target.value)}
+          aria-label="Release year filter"
+        />
+      </div>
+      <div
+        className={
+          compact
+            ? "flex items-center justify-between gap-2"
+            : "flex items-center justify-between gap-2 rounded-md border px-4 py-2"
+        }
+      >
+        <div className={compact ? undefined : "space-y-1"}>
+          <p className={compact ? "text-xs text-muted-foreground" : "text-sm font-medium"}>
+            Show undated games first
+          </p>
+          {!compact && (
+            <p className="text-xs text-muted-foreground">
+              Include titles without a release date and place them before dated results.
+            </p>
+          )}
+        </div>
+        <Switch
+          checked={showUndatedGames}
+          onCheckedChange={setShowUndatedGames}
+          disabled={hasValidReleaseYear}
+          aria-label="Show undated games first"
+        />
+      </div>
+    </div>
+  );
+
   const handleAddGame = (searchResult: SearchResult) => {
     // Map to InsertGame to filter out client-only fields before sending to server
     const gameData = mapGameToInsertGame(searchResult);
@@ -254,40 +308,7 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
                     aria-label="Search games"
                   />
                 </div>
-                <div className="grid grid-cols-2 gap-2">
-                  <Select value={selectedPlatform} onValueChange={setSelectedPlatform}>
-                    <SelectTrigger aria-label="Platform filter">
-                      <SelectValue placeholder="All platforms" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">All platforms</SelectItem>
-                      {platforms.map((platform) => (
-                        <SelectItem key={platform.id} value={String(platform.id)}>
-                          {platform.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    min="1950"
-                    max="2100"
-                    placeholder="Release year"
-                    value={releaseYear}
-                    onChange={(event) => handleReleaseYearChange(event.target.value)}
-                    aria-label="Release year filter"
-                  />
-                </div>
-                <div className="flex items-center justify-between gap-2 px-0.5">
-                  <span className="text-xs text-muted-foreground">Show undated games first</span>
-                  <Switch
-                    checked={showUndatedGames}
-                    onCheckedChange={setShowUndatedGames}
-                    disabled={hasValidReleaseYear}
-                    aria-label="Show undated games first"
-                  />
-                </div>
+                {renderDiscoveryFilters(true)}
               </div>
 
               {/* Scrollable results */}
@@ -446,45 +467,7 @@ export default function AddGameModal({ children, initialQuery }: AddGameModalPro
               </Button>
             </form>
 
-            <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
-              <Select value={selectedPlatform} onValueChange={setSelectedPlatform}>
-                <SelectTrigger aria-label="Platform filter">
-                  <SelectValue placeholder="All platforms" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All platforms</SelectItem>
-                  {platforms.map((platform) => (
-                    <SelectItem key={platform.id} value={String(platform.id)}>
-                      {platform.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Input
-                type="number"
-                inputMode="numeric"
-                min="1950"
-                max="2100"
-                placeholder="Release year"
-                value={releaseYear}
-                onChange={(event) => handleReleaseYearChange(event.target.value)}
-                aria-label="Release year filter"
-              />
-            </div>
-
-            <div className="mb-4 flex items-center justify-between gap-3 rounded-md border px-3 py-2">
-              <div className="space-y-1">
-                <p className="text-sm font-medium">Show undated games first</p>
-                <p className="text-xs text-muted-foreground">
-                  Include titles without a release date and place them before dated results.
-                </p>
-              </div>
-              <Switch
-                checked={showUndatedGames}
-                onCheckedChange={setShowUndatedGames}
-                disabled={hasValidReleaseYear}
-              />
-            </div>
+            {renderDiscoveryFilters()}
 
             <div className="space-y-4" aria-live="polite">
               {isSearching && (

--- a/server/__tests__/api_routes.test.ts
+++ b/server/__tests__/api_routes.test.ts
@@ -892,6 +892,19 @@ describe("API Routes - Extended Coverage", () => {
           undatedFirst: true,
         });
       });
+      it("should pass platform and release year filters to IGDB search", async () => {
+        vi.mocked(igdbClient.searchGames).mockResolvedValue([]);
+
+        const response = await request(app).get(
+          "/api/igdb/search?q=God%20of%20War&limit=10&platform=8&year=2005"
+        );
+
+        expect(response.status).toBe(200);
+        expect(igdbClient.searchGames).toHaveBeenCalledWith("God of War", 20, {
+          platformId: 8,
+          releaseYear: 2005,
+        });
+      });
     });
 
     describe("GET /api/igdb/popular", () => {

--- a/server/__tests__/igdb.test.ts
+++ b/server/__tests__/igdb.test.ts
@@ -169,6 +169,35 @@ describe("IGDBClient - Fallback Mechanism", { timeout: 20000 }, () => {
     expect(results.map((game) => game.name)).toEqual(["Undated Game", "Newer Game", "Older Game"]);
   });
 
+  it("applies platform and release year filters before the IGDB result limit", async () => {
+    const authResponse = {
+      ok: true,
+      json: async () => ({
+        access_token: "test-token",
+        expires_in: 3600,
+        token_type: "bearer",
+      }),
+    };
+    const successResponse = {
+      ok: true,
+      json: async () => [{ id: 1, name: "God of War", first_release_date: 1110844800 }],
+    };
+
+    fetchMock.mockResolvedValueOnce(authResponse).mockResolvedValueOnce(successResponse);
+
+    const { igdbClient } = await import("../igdb.js");
+    await igdbClient.searchGames("God of War", 10, { platformId: 8, releaseYear: 2005 });
+
+    const gameRequest = fetchMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("api.igdb.com/v4/games")
+    );
+    const body = String(gameRequest?.[1]?.body);
+    expect(body).toContain("platforms = (8)");
+    expect(body).toContain("first_release_date >= 1104537600");
+    expect(body).toContain("first_release_date < 1136073600");
+    expect(body.indexOf("platforms = (8)")).toBeLessThan(body.indexOf("limit 10"));
+  });
+
   it("should return empty array when all search approaches fail", async () => {
     // Mock authentication response
     const authResponse = {

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -85,6 +85,8 @@ export interface IGDBGame {
 interface SearchGamesOptions {
   includeUndated?: boolean;
   undatedFirst?: boolean;
+  platformId?: number;
+  releaseYear?: number;
 }
 
 interface IGDBAuthResponse {
@@ -372,19 +374,34 @@ class IGDBClient {
 
     let attemptCount = 0;
 
+    const filters: string[] = [];
+    if (options.platformId) {
+      filters.push(`platforms = (${options.platformId})`);
+    }
+    if (options.releaseYear) {
+      const yearStart = Math.floor(Date.UTC(options.releaseYear, 0, 1) / 1000);
+      const nextYearStart = Math.floor(Date.UTC(options.releaseYear + 1, 0, 1) / 1000);
+      filters.push(`first_release_date >= ${yearStart}`);
+      filters.push(`first_release_date < ${nextYearStart}`);
+    }
+    const withFilters = (conditions: string[] = []) => {
+      const allConditions = [...conditions, ...filters];
+      return allConditions.length > 0 ? `where ${allConditions.join(" & ")}; ` : "";
+    };
+
     // Try multiple search approaches to maximize results
     const searchApproaches = [
       // Approach 1: Full text search without category filter
-      `search "${sanitizedQuery}"; fields ${IGDB_GAME_FIELDS}; limit ${limit};`,
+      `search "${sanitizedQuery}"; fields ${IGDB_GAME_FIELDS}; ${withFilters()}limit ${limit};`,
 
       // Approach 2: Full text search with category filter
-      `search "${sanitizedQuery}"; fields ${IGDB_GAME_FIELDS}; where category = 0; limit ${limit};`,
+      `search "${sanitizedQuery}"; fields ${IGDB_GAME_FIELDS}; ${withFilters(["category = 0"])}limit ${limit};`,
 
       // Approach 3: Case-insensitive name matching without category
-      `fields ${IGDB_GAME_FIELDS}; where name ~= "${sanitizedQuery}"; limit ${limit};`,
+      `fields ${IGDB_GAME_FIELDS}; ${withFilters([`name ~= "${sanitizedQuery}"`])}limit ${limit};`,
 
       // Approach 4: Partial name matching without category
-      `fields ${IGDB_GAME_FIELDS}; where name ~ *"${sanitizedQuery}"*; sort rating desc; limit ${limit};`,
+      `fields ${IGDB_GAME_FIELDS}; ${withFilters([`name ~ *"${sanitizedQuery}"*`])}sort rating desc; limit ${limit};`,
     ];
 
     for (let i = 0; i < searchApproaches.length && attemptCount < MAX_SEARCH_ATTEMPTS; i++) {
@@ -448,7 +465,7 @@ class IGDBClient {
           const sanitizedWord = sanitizeIgdbInput(word);
           if (!sanitizedWord) return [];
 
-          const wordQuery = `fields ${IGDB_GAME_FIELDS}; where name ~ *"${sanitizedWord}"*; sort rating desc; limit ${limit};`;
+          const wordQuery = `fields ${IGDB_GAME_FIELDS}; ${withFilters([`name ~ *"${sanitizedWord}"*`])}sort rating desc; limit ${limit};`;
           // Cache word search results for 15 minutes
           return await this.makeRequest<IGDBGame[]>("games", wordQuery, 15 * 60 * 1000);
         } catch (error) {

--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -97,6 +97,16 @@ export const sanitizeSearchQuery = [
     .isBoolean()
     .withMessage("includeUndated must be a boolean")
     .toBoolean(),
+  query("platform")
+    .optional()
+    .isInt({ min: 1 })
+    .withMessage("Platform must be a valid IGDB platform ID")
+    .toInt(),
+  query("year")
+    .optional()
+    .isInt({ min: 1950, max: 2100 })
+    .withMessage("Year must be between 1950 and 2100")
+    .toInt(),
 ];
 
 // Sanitization rules for game ID parameters

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1734,7 +1734,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     validateRequest,
     async (req: Request, res: Response) => {
       try {
-        const { q, limit, includeUndated } = req.query;
+        const { q, limit, includeUndated, platform, year } = req.query;
         if (!q || typeof q !== "string") {
           return res.status(400).json({ error: "Search query required" });
         }
@@ -1747,10 +1747,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
               : NaN;
         const limitNum =
           Number.isNaN(parsedLimit) || parsedLimit < 1 ? 20 : Math.min(parsedLimit, 100);
-        const searchOptions =
-          typeof includeUndated === "boolean"
+        const searchOptions = {
+          ...(typeof includeUndated === "boolean"
             ? { includeUndated, undatedFirst: includeUndated }
-            : {};
+            : {}),
+          ...(typeof platform === "number" ? { platformId: platform } : {}),
+          ...(typeof year === "number" ? { releaseYear: year } : {}),
+        };
         const formattedGames = await fetchFilteredIgdbGames(req.user!.id, limitNum, (fetchLimit) =>
           igdbClient.searchGames(q, fetchLimit, searchOptions)
         );


### PR DESCRIPTION
## Summary
- add IGDB-backed platform filtering to the Add Game dialog
- add an optional release-year filter with strict server validation
- keep result payloads capped at 10 and avoid stale results during filter transitions
- support undated-first searches without combining incompatible year filters

## Verification
- `npm run check`
- `npm run lint`
- `npm run build`
- `npm test -- --run` (2,054 passed, 7 skipped)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform and release-year filters to game searches.
  * Search results are limited to 10 games and refresh cleanly while loading.
  * Valid release years range from 1950 to 2100.
  * Undated sorting is disabled when filtering by release year.

* **Bug Fixes**
  * Incomplete year filters no longer trigger searches or retain outdated results.
  * Platform and release-year filters are applied consistently to search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->