### PR TITLE
Add sca-gate bypass to deploy.yml for republishing released tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,21 @@ on:
         required: false
         default: false
         type: boolean
+      bypass_sca_gate:
+        description: >-
+          Skip failing the build on Critical/High npm audit findings. For
+          republishing an already-released tag (a missed platform, a
+          registry hiccup) whose lockfile predates fixes for advisories
+          disclosed after it shipped — never for new code. Requires
+          bypass_reason. Per docs/VULNERABILITY_MANAGEMENT.md §1.2 item 3,
+          also add a risk-register row in docs/SECURITY_ASSESSMENT.md.
+        required: false
+        default: false
+        type: boolean
+      bypass_reason:
+        description: "Required if bypass_sca_gate is true: why this republish is safe to ship with known findings."
+        required: false
+        default: ""
       comment-id: # ← passed automatically by slash-command-dispatch
         required: false
       repository: # ← also passed automatically
@@ -66,8 +81,41 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      # Guard rail for the bypass below: a bypass with no stated reason is
+      # never allowed through, even on workflow_dispatch.
+      - name: Validate bypass reason
+        if: inputs.bypass_sca_gate == true && inputs.bypass_reason == ''
+        run: |
+          echo "::error::bypass_sca_gate requires a non-empty bypass_reason explaining why this republish is safe to ship with known findings."
+          exit 1
+
+      # Policy: docs/VULNERABILITY_MANAGEMENT.md §1.3 — no release may ship
+      # with an unresolved Critical/High SCA finding, EXCEPT a deliberate,
+      # logged republish via bypass_sca_gate (see §1.3.1 and the
+      # risk-register requirement in §1.2 item 3).
       - name: Audit production dependencies (Critical/High blocks release)
-        run: npm audit --omit=dev --audit-level=high
+        run: |
+          set +e
+          npm audit --omit=dev --audit-level=high
+          status=$?
+          set -e
+
+          if [ "$status" -ne 0 ]; then
+            if [ "${{ inputs.bypass_sca_gate }}" == "true" ]; then
+              {
+                echo "## ⚠️ sca-gate bypassed"
+                echo ""
+                echo "- **Ref built:** \`${{ github.ref }}\`"
+                echo "- **Reason:** ${{ inputs.bypass_reason }}"
+                echo "- **Triggered by:** @${{ github.actor }}"
+                echo ""
+                echo "Record this acceptance as a risk-register row in \`docs/SECURITY_ASSESSMENT.md\` per \`docs/VULNERABILITY_MANAGEMENT.md\` §1.2 item 3, if not already covered by an existing entry."
+              } | tee -a "$GITHUB_STEP_SUMMARY"
+              echo "::warning::sca-gate bypassed for this republish — see job summary."
+            else
+              exit "$status"
+            fi
+          fi
 
       # @lizenz/checker is a pinned devDependency (see package.json), installed above by
       # `npm ci` — --no-install below guarantees this never installs anything ad-hoc.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,10 +84,14 @@ jobs:
       # Guard rail for the bypass below: a bypass with no stated reason is
       # never allowed through, even on workflow_dispatch.
       - name: Validate bypass reason
-        if: inputs.bypass_sca_gate == true && inputs.bypass_reason == ''
+        if: inputs.bypass_sca_gate == true
+        env:
+          BYPASS_REASON: ${{ inputs.bypass_reason }}
         run: |
-          echo "::error::bypass_sca_gate requires a non-empty bypass_reason explaining why this republish is safe to ship with known findings."
-          exit 1
+          if [ -z "${BYPASS_REASON//[[:space:]]/}" ]; then
+            echo "::error::bypass_sca_gate requires a non-empty bypass_reason explaining why this republish is safe to ship with known findings."
+            exit 1
+          fi
 
       # Policy: docs/VULNERABILITY_MANAGEMENT.md §1.3 — no release may ship
       # with an unresolved Critical/High SCA finding, EXCEPT a deliberate,
@@ -113,9 +117,13 @@ jobs:
             # consider the bypass when the JSON report itself confirms a
             # High/Critical count; otherwise this is an audit failure, not a
             # vulnerability to accept, and always fails the job.
+            # npm audit --json itself exits non-zero when it finds
+            # vulnerabilities, so its status can't gate whether we trust the
+            # JSON — capture the report and status separately, and parse
+            # whatever JSON came back regardless of that status.
             confirmed_finding=false
-            if audit_json=$(npm audit --omit=dev --json 2>/dev/null) &&
-              counts=$(echo "$audit_json" | jq -e '(.metadata.vulnerabilities.high // 0) + (.metadata.vulnerabilities.critical // 0)') &&
+            audit_json=$(npm audit --omit=dev --json 2>/dev/null || true)
+            if counts=$(echo "$audit_json" | jq -e '(.metadata.vulnerabilities.high // 0) + (.metadata.vulnerabilities.critical // 0)' 2>/dev/null) &&
               [ "$counts" -gt 0 ]; then
               confirmed_finding=true
             fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,6 +94,13 @@ jobs:
       # logged republish via bypass_sca_gate (see §1.3.1 and the
       # risk-register requirement in §1.2 item 3).
       - name: Audit production dependencies (Critical/High blocks release)
+        env:
+          # Passed as env vars, never interpolated directly into the script,
+          # so a crafted bypass_reason/actor can't execute as shell code.
+          BYPASS_SCA_GATE: ${{ inputs.bypass_sca_gate }}
+          BYPASS_REASON: ${{ inputs.bypass_reason }}
+          BUILT_REF: ${{ github.ref }}
+          ACTOR: ${{ github.actor }}
         run: |
           set +e
           npm audit --omit=dev --audit-level=high
@@ -101,13 +108,30 @@ jobs:
           set -e
 
           if [ "$status" -ne 0 ]; then
-            if [ "${{ inputs.bypass_sca_gate }}" == "true" ]; then
+            # A nonzero exit isn't necessarily a confirmed finding — npm audit
+            # also exits nonzero on registry/network/auth failures. Only
+            # consider the bypass when the JSON report itself confirms a
+            # High/Critical count; otherwise this is an audit failure, not a
+            # vulnerability to accept, and always fails the job.
+            confirmed_finding=false
+            if audit_json=$(npm audit --omit=dev --json 2>/dev/null) &&
+              counts=$(echo "$audit_json" | jq -e '(.metadata.vulnerabilities.high // 0) + (.metadata.vulnerabilities.critical // 0)') &&
+              [ "$counts" -gt 0 ]; then
+              confirmed_finding=true
+            fi
+
+            if [ "$confirmed_finding" != true ]; then
+              echo "::error::npm audit exited non-zero without a confirmed High/Critical count in its JSON report — treating as an audit failure (registry/network/auth), not a bypassable finding."
+              exit "$status"
+            fi
+
+            if [ "$BYPASS_SCA_GATE" == "true" ]; then
               {
                 echo "## ⚠️ sca-gate bypassed"
                 echo ""
-                echo "- **Ref built:** \`${{ github.ref }}\`"
-                echo "- **Reason:** ${{ inputs.bypass_reason }}"
-                echo "- **Triggered by:** @${{ github.actor }}"
+                printf -- '- **Ref built:** `%s`\n' "$BUILT_REF"
+                printf -- '- **Reason:** %s\n' "$BYPASS_REASON"
+                printf -- '- **Triggered by:** @%s\n' "$ACTOR"
                 echo ""
                 echo "Record this acceptance as a risk-register row in \`docs/SECURITY_ASSESSMENT.md\` per \`docs/VULNERABILITY_MANAGEMENT.md\` §1.2 item 3, if not already covered by an existing entry."
               } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/docs/VULNERABILITY_MANAGEMENT.md
+++ b/docs/VULNERABILITY_MANAGEMENT.md
@@ -94,6 +94,36 @@ This is enforced by an automated status check, not a manual step:
 
 Moderate and Low findings do not block release.
 
+### 1.3.1 Republishing an already-released tag
+
+Occasionally a tag that already shipped needs to be rebuilt as-is — a missed
+platform (e.g. forgetting `build_arm64`), a registry hiccup — with no code or
+version change. Because §1.3's `sca-scan`/`sca-gate` jobs audit whatever
+lockfile is checked out, an old tag's dependencies can trip advisories
+disclosed _after_ that tag shipped, even though nothing about the tag itself
+changed.
+
+`.github/workflows/deploy.yml`'s `workflow_dispatch` exposes `bypass_sca_gate`
+(boolean) and `bypass_reason` (required alongside it) for exactly this case:
+when set, a failing `sca-gate` audit is logged to the job summary — ref
+built, reason, and triggering actor — with a warning annotation, instead of
+failing the job. `bypass_reason` is mandatory; an empty reason fails the run
+outright.
+
+This is the risk-acceptance path from §1.2 item 3, applied at dispatch time
+rather than to `package.json`/`package-lock.json` — it doesn't change what's
+in the lockfile or waive the gate for new code, only for a deliberate,
+logged rebuild of unchanged, already-released history. Add the corresponding
+risk-register row in
+[`docs/SECURITY_ASSESSMENT.md`](/docs/SECURITY_ASSESSMENT.md) per §1.2 item
+3, unless an existing entry already covers the same finding.
+
+**Caveat:** `workflow_dispatch` runs the workflow file as committed on the
+ref you select in the dispatch UI, not necessarily `main`'s current copy. A
+tag cut before `bypass_sca_gate` existed doesn't have it and can't be
+dispatched directly with the bypass — only tags cut from a `main` that
+already includes this mechanism carry it forward automatically.
+
 ### 1.4 License policy
 
 Questarr is licensed under `GPL-3.0-only` (see [`LICENSE`](/LICENSE)).


### PR DESCRIPTION
## Context

The originally reported `npm audit --omit=dev --audit-level=high` findings (`ip-address`, `socket.io-parser`) turned out to already be fixed on `main` (commit `9d78825`, including the doc updates in `docs/CHANGELOG.md` and `docs/CVE_FIXES_BY_RELEASE.md`) — this branch was already clean of them, confirmed via `npm audit --omit=dev --audit-level=high` (0 vulnerabilities).

The actual, current blocker: **republishing an already-released tag** (e.g. rebuilding `v1.4.1` to add a missed `arm64` platform) trips `sca-gate` in `.github/workflows/deploy.yml`, because that tag's lockfile predates fixes for advisories disclosed after it shipped — even though no code changed.

## Changes

- `.github/workflows/deploy.yml`: add `bypass_sca_gate` (boolean) and `bypass_reason` (required alongside it) `workflow_dispatch` inputs. When set, a failing `sca-gate` audit is logged to the job summary (ref built, reason, triggering actor) with a warning annotation instead of failing the job. An empty `bypass_reason` while `bypass_sca_gate` is true fails the run outright — no silent bypass.
- `docs/VULNERABILITY_MANAGEMENT.md`: new §1.3.1 documenting the mechanism, its risk-register requirement (per existing §1.2 item 3), and the caveat that `workflow_dispatch` runs the workflow file as committed on the dispatched ref — a tag cut before this change won't have the bypass unless dispatched from a branch (e.g. `main`) that already includes it.

## Note on `v1.4.1` specifically

This doesn't retroactively unblock a direct dispatch off the `v1.4.1` tag itself (GitHub runs the workflow file as committed on the selected ref, and that tag predates this change). It ensures **future** tags — cut from a `main` that already has this mechanism — can be republished without hitting this same wall.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3hfcGbDL3KCXEgN3DeLTX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional deployment control to bypass the software composition analysis gate.
  * Requires a non-empty reason and records the request reference, reason, actor, and risk-register reminder.
  * Only confirmed High/Critical findings can be bypassed; registry, network, authentication, and unconfirmed failures still block deployment.
  * Bypassed checks generate a warning in the deployment summary.

* **Documentation**
  * Documented bypass requirements, risk-register tracking, and limitations for older releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->