### PR TITLE
Bump main to 1.4.3 to avoid colliding with the v1.4.2 hotfix tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,4 @@ LABEL org.opencontainers.image.description="Questarr is a smart game library man
 LABEL org.opencontainers.image.authors="Doezer"
 LABEL org.opencontainers.image.source="https://github.com/Doezer/questarr"
 LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
-LABEL org.opencontainers.image.version="1.4.2"
+LABEL org.opencontainers.image.version="1.4.3"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.4.2] - 2026-08-xx
+## [1.4.3] - 2026-08-xx
 
 Hotfix release addressing dependency vulnerabilities flagged by `npm audit`.
 
@@ -20,6 +20,10 @@ Hotfix release addressing dependency vulnerabilities flagged by `npm audit`.
 ### Changed
 
 - Dependency updates: `undici` 7.29.0 → 8.9.0 (direct dependency, used by the SSRF-safe fetch wrapper in `server/ssrf.ts`). No vulnerability fix — see `docs/CVE_FIXES_BY_RELEASE.md` for verification. Major version bump; undici 8.9.0 requires Node `>=22.19.0`, so Questarr's own `engines.node` floor is raised from `>=20` to `>=22.19.0` to match — this only formalizes existing practice, since CI (`node-version: 26.x`) and the production Docker image (`node:26-alpine`) were already on Node 26. Full test suite and `server/__tests__/ssrf.test.ts` verified green against the new version.
+
+## [1.4.2] - 2026-08-11
+
+Hotfix release, tagged directly off `v1.4.1` rather than from `main` — not part of this branch's history. Fixed the same `ip-address` and `socket.io-parser` advisories independently patched above for `main`'s own accumulated changes (see the `[1.4.3]` entry). Full details in the `v1.4.2` tag and its own copy of this file.
 
 ## [1.4.1] - 2026-08-02
 

--- a/docs/CVE_FIXES_BY_RELEASE.md
+++ b/docs/CVE_FIXES_BY_RELEASE.md
@@ -1,4 +1,4 @@
-# Questarr — CVEs fixed per release (v1.2.0 → v1.4.2)
+# Questarr — CVEs fixed per release (v1.2.0 → v1.4.3)
 
 Method: diffed `package.json`/`package-lock.json` at each tag boundary, then cross-checked every bumped package through OSV.dev's `querybatch` endpoint (query old-version vs new-version, take the set difference of returned GHSA IDs) and confirmed exact `fixed` boundaries via per-GHSA `/v1/vulns/{id}` lookups. All headline findings below — including axios, node-forge, and socket.io-parser — were verified through the same batch-diff method, not just by trusting commit messages. Only entries with a confirmed OSV `fixed` event landing inside the bump range are listed as fixes.
 
@@ -66,7 +66,15 @@ No dependency bump in this release crosses a `fixed` OSV boundary — purely mai
 - **body-parser** 1.20.5 → 1.20.6 — fixes **CVE-2026-12590** (GHSA-v422-hmwv-36x6, LOW) — an invalid `limit` value (unparseable string or `NaN`) made `bytes.parse()` return `null`, silently disabling size enforcement and allowing arbitrarily large request bodies. Fixed version throws at parser initialization instead.
 - **minimatch** (devDep-only, transitive via `eslint-plugin-react` → bundled `minimatch@3.1.5`) — new `overrides` pin to `^10.2.5` closes a second resolution path for **CVE-2026-14257** (GHSA-mh99-v99m-4gvg, HIGH), the same brace-expansion advisory fixed above via the `archiver` chain. Not shipped in the production image, but `npm audit` (without `--omit=dev`) still flagged it, so pinned for a fully clean audit.
 
-## v1.4.2 (from v1.4.1)
+## v1.4.2 (from v1.4.1) — hotfix tag, not part of this branch's history
+
+Tagged directly off `v1.4.1`, not from `main` — fixed `ip-address` (10.2.0 →
+10.5.0) and `socket.io-parser` (4.2.6 → 4.2.7), the same two advisories
+`main` independently patches below in the `v1.4.3` entry. Skipped in this
+diff-based report since it isn't reachable from `main`'s commit history; see
+the `v1.4.2` tag and its own copy of this file for the full record.
+
+## v1.4.3 (from v1.4.1, via main)
 
 - **fast-xml-parser** 5.10.0 → 5.10.1 — fixes GHSA-8r6m-32jq-jx6q (no CVE assigned, HIGH, CVSS 8.7) — vulnerable range `>=5.9.3 <5.10.1`; the direct-dependency range `^5.10.0` still permitted the unpatched `5.10.0`, so the fix required a `package.json` bump, not just a lockfile refresh.
 - **fast-uri** (npm `overrides` pin, dev-only via `secretlint` → `ajv`) 3.1.3 → 3.1.4 → 3.1.5 — fixes **CVE-2026-16221** (GHSA-v2hh-gcrm-f6hx, HIGH, fixed by the 3.1.3→3.1.4 leg) and GHSA-7p8r-x3mc-p8w7 (HIGH, host confusion via backslash authority introducer, vulnerable range `3.0.0 - 3.1.4`, fixed by the 3.1.4→3.1.5 leg). Doesn't reach production, but forced past both vulnerable ranges out of caution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "questarr",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "questarr",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "questarr",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A video game management application inspired by the -Arr apps. Track and organize your video game collection with automated discovery and download management.",
   "type": "module",
   "packageManager": "npm@11.7.0",

--- a/questarr/Dockerfile
+++ b/questarr/Dockerfile
@@ -1,7 +1,7 @@
 # NOSONAR - ha-entrypoint.sh must run as root to chown /data before su-exec drops to questarr
 FROM ghcr.io/doezer/questarr:latest
 ARG BUILD_ARCH=amd64
-ARG QUESTARR_VERSION=1.4.2
+ARG QUESTARR_VERSION=1.4.3
 
 LABEL \
     io.hass.name="Questarr" \

--- a/questarr/config.yaml
+++ b/questarr/config.yaml
@@ -1,5 +1,5 @@
 name: Questarr
-version: "1.4.2"
+version: "1.4.3"
 slug: questarr
 description: Questarr is an *Arr-inspired game manager that helps you discover, track, and automatically download the games you want.
 url: "https://github.com/Doezer/Questarr"


### PR DESCRIPTION
## Context

A `v1.4.2` hotfix tag was just cut directly off `v1.4.1` (not from `main`) to patch two high-severity advisories (`ip-address`, `socket.io-parser`) on the last release without pulling in `main`'s unrelated accumulated work.

`main`'s `package.json`/Dockerfiles/`questarr/config.yaml` already self-identified as `1.4.2` in anticipation of its own next release — but that name is now taken by a completely different commit history. This bumps `main` to `1.4.3` so its next release tag doesn't collide.

## Changes

- `package.json`, `package-lock.json`, `Dockerfile`, `questarr/Dockerfile`, `questarr/config.yaml`: version `1.4.2` → `1.4.3`.
- `docs/CHANGELOG.md`, `docs/CVE_FIXES_BY_RELEASE.md`: renamed the pending `1.4.2` entries to `1.4.3`, and added a short note in each explaining where `v1.4.2` actually came from, so the changelog doesn't jump `1.4.1` → `1.4.3` with no explanation.

No code changes. `npm run check` passes; this is a version-string-only diff (confirmed via `git diff --stat`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3hfcGbDL3KCXEgN3DeLTX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application to version 1.4.3.
  * Updated container metadata and configuration to report the new version.

* **Documentation**
  * Updated the changelog and release security documentation to include version 1.4.3.
  * Added release history details for the 1.4.2 hotfix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->