### PR TITLE
⚡ Bolt: Consolidate array traversals for library filters

### DIFF
--- a/client/src/components/Library.tsx
+++ b/client/src/components/Library.tsx
@@ -110,19 +110,30 @@ export default function Library() {
     errorMessage: "Failed to update game visibility",
   });
 
-  const uniqueGenres = useMemo(
-    () =>
-      Array.from(new Set(games.flatMap((g) => g.genres ?? []))).sort((a, b) => a.localeCompare(b)),
-    [games]
-  );
+  // ⚡ Bolt: Consolidate multiple array traversals into a single pass to
+  // optimize render performance and reduce unnecessary allocations.
+  const { uniqueGenres, uniquePlatforms } = useMemo(() => {
+    const genreSet = new Set<string>();
+    const platformSet = new Set<string>();
 
-  const uniquePlatforms = useMemo(
-    () =>
-      Array.from(new Set(games.flatMap((g) => g.platforms ?? []))).sort((a, b) =>
-        a.localeCompare(b)
-      ),
-    [games]
-  );
+    for (const g of games) {
+      if (g.genres) {
+        for (const genre of g.genres) {
+          genreSet.add(genre);
+        }
+      }
+      if (g.platforms) {
+        for (const platform of g.platforms) {
+          platformSet.add(platform);
+        }
+      }
+    }
+
+    return {
+      uniqueGenres: Array.from(genreSet).sort((a, b) => a.localeCompare(b)),
+      uniquePlatforms: Array.from(platformSet).sort((a, b) => a.localeCompare(b)),
+    };
+  }, [games]);
 
   const filteredGames = useMemo(() => {
     return games.filter((game) => {


### PR DESCRIPTION
### 💡 What
Consolidated the extraction of `uniqueGenres` and `uniquePlatforms` in `Library.tsx` from two separate `flatMap` and `Set` operations into a single manual `for...of` loop inside one `useMemo` block.

### 🎯 Why
Previously, creating the genre and platform filters required iterating over the entire `games` array multiple times, creating large intermediate arrays via `flatMap`, converting them to `Set`s, and then sorting them. This resulted in O(N) redundant iterations and unnecessary memory allocations during React renders, which can cause jank on large libraries.

### 📊 Impact
Reduces intermediate array allocations and redundant iterations for calculating library filter pills. Iteration time over the `games` array for these filters is effectively halved (one pass instead of two `flatMap` passes).

### 🔬 Measurement
Run `npm run test` and check tests under `client/__tests__`. All tests remain passing, proving functionality has been preserved while optimizing performance.

---
*PR created automatically by Jules for task [12988629753325404580](https://jules.google.com/task/12988629753325404580) started by @Doezer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved library filtering efficiency when generating genre and platform options.
  * Preserved consistent alphabetical sorting of available filter options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->