### PR TITLE
Fix stale test assertion causing CI failure on #803

### DIFF
--- a/server/__tests__/import_manager.test.ts
+++ b/server/__tests__/import_manager.test.ts
@@ -639,7 +639,7 @@ describe("ImportManager", () => {
     execSpy.mockRestore();
   });
 
-  it("confirmImport: extraction failure (unpack=true) sets error status and rejects — extraction runs inside the try block", async () => {
+  it("confirmImport: extraction failure (unpack=true) sets manual_review_required status and rejects — extraction runs inside the try block", async () => {
     storage.getGameDownload.mockResolvedValue({
       id: "dl-1",
       gameId: "g1",
@@ -675,7 +675,12 @@ describe("ImportManager", () => {
       })
     ).rejects.toThrow("archive is corrupt");
 
-    expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith("dl-1", "error");
+    expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith(
+      "dl-1",
+      "manual_review_required",
+      "archive is corrupt"
+    );
+    expect(storage.updateGameDownloadStatus).not.toHaveBeenCalledWith("dl-1", "error");
   });
 
   // ─── extractRemoteHost edge cases (via resolveLocalPath → processImport) ────


### PR DESCRIPTION
## Summary

CI on #803 was failing on the `test (1)` shard because of a stale assertion in a test that PR #803 itself added.

- `server/__tests__/import_manager.test.ts` — `confirmImport: extraction failure (unpack=true)` asserted that a failed extraction sets the download status to `"error"`.
- `ImportManager.confirmImport`'s catch handler routes extraction/import failures to `"manual_review_required"` (with the error message attached) instead of a terminal `"error"` status — this behavior was introduced in #840 ("Allow re-attempting import after a failure instead of dead-ending") so failed imports stay actionable/retryable via Pending Manual Imports.
- The new test added by #803 wasn't updated to match that existing behavior, so it failed against the real (correct) implementation.

## Changes

- Updated the test to assert `updateGameDownloadStatus` is called with `"dl-1", "manual_review_required", "archive is corrupt"` and to assert it is *not* called with `"error"`, matching the pattern used by the other tests in this file for the same code path.
- Renamed the test title to reflect the corrected expectation.

## Testing

- `npx vitest run` — all 2069 tests pass (7 skipped), 0 failures.
- `npx tsc --noEmit` — no errors.
- `npx eslint` on the changed file — no errors.

---

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017NCupbKc9gbSE5fkg3EVEG)_