### PR TITLE
Fix Dockerfile: pin node base image with explicit tag alongside digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Build stage with shared dependencies
-# node:26-alpine
-FROM node@sha256:aadf416b2cdce311a8811ba3f0608a61b77dbf997500e2eafe781b51f6a0b019 AS base
+FROM node:26-alpine@sha256:aadf416b2cdce311a8811ba3f0608a61b77dbf997500e2eafe781b51f6a0b019 AS base
 WORKDIR /app
 
 # better-sqlite3 bundles a prebuilt binary for this platform, so no C++
@@ -20,8 +19,7 @@ COPY . .
 RUN npm run build
 
 # Production stage
-# node:26-alpine
-FROM node@sha256:aadf416b2cdce311a8811ba3f0608a61b77dbf997500e2eafe781b51f6a0b019 AS production
+FROM node:26-alpine@sha256:aadf416b2cdce311a8811ba3f0608a61b77dbf997500e2eafe781b51f6a0b019 AS production
 
 WORKDIR /app
 


### PR DESCRIPTION
# Pull Request _Template_

## Description

While reviewing dependabot PR #909 (`chore(deps): bump node from aadf416 to bde0dae`), I found it broke the Docker build: the `docker-build` CI check failed with `apk: not found` on both build stages.

Root cause: `sha256:bde0dae02f2b12d2bce5ee72b2432f0e511767b7b2dc4dd3b064df11ae422fee` resolves to the plain `node:26` tag (Debian-based), not `node:26-alpine` as the Dockerfile assumes (and as its comment says). `node:26` doesn't ship `apk`, so `apk add ...` fails immediately.

The Dockerfile pinned the base image as a bare digest (`FROM node@sha256:...`) with only a `# node:26-alpine` comment noting the intended tag. That gives dependabot's Docker digest updater no reliable signal for which tag family the digest belongs to, so its bump drifted to a different tag's digest entirely (`26` instead of `26-alpine`).

This PR pins both stages as `node:26-alpine@sha256:aadf416b2cdce...` — same (correct, current) digest as before, but now with the tag made explicit in the `FROM` line instead of just a comment. That should keep future dependabot digest bumps scoped to the `26-alpine` family.

No functional change: the digest is unchanged from what's currently on `main`, since it's still the current `node:26-alpine` digest on Docker Hub.

I've commented on #909 recommending it not be merged as-is.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (Dockerfile-only change; no code tests affected)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012UoiM2yhUBWhVnfii4mcdk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s build and production environment to use an explicitly versioned, integrity-pinned Node.js 26 Alpine image for more consistent deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->