### PR TITLE
Add automatic telemetry reporting for unhandled server errors

### DIFF
--- a/client/src/components/NotificationCenter.tsx
+++ b/client/src/components/NotificationCenter.tsx
@@ -11,6 +11,7 @@ import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { useLocation } from "wouter";
 import GameDownloadDialog from "./GameDownloadDialog";
+import SendErrorReportDialog from "./SendErrorReportDialog";
 import { getSocket } from "@/lib/socket";
 
 export function NotificationCenter() {
@@ -18,6 +19,8 @@ export function NotificationCenter() {
   const [unreadCount, setUnreadCount] = useState(0);
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
   const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
+  const [errorReportId, setErrorReportId] = useState<string | null>(null);
+  const [errorReportDialogOpen, setErrorReportDialogOpen] = useState(false);
   const [_, setLocation] = useLocation();
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -108,6 +111,14 @@ export function NotificationCenter() {
         if (game) {
           setSelectedGame(game);
           setDownloadDialogOpen(true);
+          setOpen(false);
+          return;
+        }
+      } else if (notification.link.startsWith("error-report:")) {
+        const reportId = notification.link.split(":").pop();
+        if (reportId) {
+          setErrorReportId(reportId);
+          setErrorReportDialogOpen(true);
           setOpen(false);
           return;
         }
@@ -234,6 +245,12 @@ export function NotificationCenter() {
         game={selectedGame}
         open={downloadDialogOpen}
         onOpenChange={setDownloadDialogOpen}
+      />
+
+      <SendErrorReportDialog
+        reportId={errorReportId}
+        open={errorReportDialogOpen}
+        onOpenChange={setErrorReportDialogOpen}
       />
     </>
   );

--- a/client/src/components/SendErrorReportDialog.tsx
+++ b/client/src/components/SendErrorReportDialog.tsx
@@ -57,12 +57,20 @@ export default function SendErrorReportDialog({
   const {
     data: meta,
     isLoading,
-    isError: metaExpired,
+    isError,
+    error: metaError,
+    refetch: refetchMeta,
   } = useQuery<PendingReportMeta>({
     queryKey: ["/api/telemetry/pending", reportId],
     enabled: open && !!reportId,
     retry: false,
   });
+
+  // Only a 404 means the report actually expired/was already sent. Any other
+  // failure (network error, timeout, 5xx, auth) is a transient request error
+  // the user should be able to retry rather than being told the report is gone.
+  const metaExpired = isError && metaError instanceof ApiError && metaError.status === 404;
+  const metaLoadFailed = isError && !metaExpired;
 
   const reset = useCallback(() => {
     setStep("consent");
@@ -145,8 +153,30 @@ export default function SendErrorReportDialog({
           </>
         )}
 
+        {/* ── Metadata request failed (not expired — network/server error) ──── */}
+        {metaLoadFailed && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="text-destructive">Couldn't load report</DialogTitle>
+              <DialogDescription>
+                {metaError instanceof ApiError
+                  ? metaError.message
+                  : "Something went wrong loading this report."}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => refetchMeta()}>
+                Try again
+              </Button>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
         {/* ── Loading metadata ─────────────────────────────────────────────── */}
-        {!metaExpired && isLoading && (
+        {!metaExpired && !metaLoadFailed && isLoading && (
           <>
             <DialogHeader>
               <DialogTitle>Loading report…</DialogTitle>
@@ -159,7 +189,7 @@ export default function SendErrorReportDialog({
         )}
 
         {/* ── Consent ─────────────────────────────────────────────────────── */}
-        {!metaExpired && !isLoading && meta && step === "consent" && (
+        {!metaExpired && !metaLoadFailed && !isLoading && meta && step === "consent" && (
           <>
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2">

--- a/client/src/components/SendErrorReportDialog.tsx
+++ b/client/src/components/SendErrorReportDialog.tsx
@@ -133,7 +133,11 @@ export default function SendErrorReportDialog({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-md">
         {/* ── Expired / not found ─────────────────────────────────────────── */}
-        {metaExpired && (
+        {/* All metadata-query-derived states are scoped to step === "consent": after a
+            successful send, the finally block below invalidates this query, which
+            refetches the now-deleted report and 404s — without this guard that would
+            replace the "success" screen with "Report no longer available". */}
+        {step === "consent" && metaExpired && (
           <>
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2">
@@ -154,7 +158,7 @@ export default function SendErrorReportDialog({
         )}
 
         {/* ── Metadata request failed (not expired — network/server error) ──── */}
-        {metaLoadFailed && (
+        {step === "consent" && metaLoadFailed && (
           <>
             <DialogHeader>
               <DialogTitle className="text-destructive">Couldn't load report</DialogTitle>
@@ -176,7 +180,7 @@ export default function SendErrorReportDialog({
         )}
 
         {/* ── Loading metadata ─────────────────────────────────────────────── */}
-        {!metaExpired && !metaLoadFailed && isLoading && (
+        {step === "consent" && !metaExpired && !metaLoadFailed && isLoading && (
           <>
             <DialogHeader>
               <DialogTitle>Loading report…</DialogTitle>

--- a/client/src/components/SendErrorReportDialog.tsx
+++ b/client/src/components/SendErrorReportDialog.tsx
@@ -1,0 +1,311 @@
+import { useCallback, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Copy, ExternalLink, Loader2, Send, ShieldAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest, ApiError } from "@/lib/queryClient";
+import { buildGitHubIssueUrl } from "@/lib/send-logs";
+
+interface SendErrorReportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** id from a notification link of the form `error-report:<reportId>` */
+  reportId: string | null;
+}
+
+interface PendingReportMeta {
+  lineCount: number;
+  appVersion: string;
+  platform: string;
+  timestamp: string;
+}
+
+interface SendSuccess {
+  code: string;
+  issueNumber: number;
+}
+
+type Step = "consent" | "sending" | "success" | "error";
+
+/**
+ * Consent + send flow for a server-detected error, opened from the
+ * "An error occurred" notification (see NotificationCenter.tsx).
+ *
+ * Mirrors SendLogsDialog's UX, but the log bundle is built and scrubbed
+ * server-side (server/error-telemetry.ts) — this dialog only fetches
+ * metadata for the consent screen and confirms the send.
+ */
+export default function SendErrorReportDialog({
+  open,
+  onOpenChange,
+  reportId,
+}: Readonly<SendErrorReportDialogProps>) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [step, setStep] = useState<Step>("consent");
+  const [result, setResult] = useState<SendSuccess | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const {
+    data: meta,
+    isLoading,
+    isError: metaExpired,
+  } = useQuery<PendingReportMeta>({
+    queryKey: ["/api/telemetry/pending", reportId],
+    enabled: open && !!reportId,
+    retry: false,
+  });
+
+  const reset = useCallback(() => {
+    setStep("consent");
+    setResult(null);
+    setErrorMessage(null);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) reset();
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, reset]
+  );
+
+  const handleSend = useCallback(async () => {
+    if (!reportId) return;
+    setStep("sending");
+    try {
+      const res = await apiRequest("POST", `/api/telemetry/pending/${reportId}/send`);
+      const data = (await res.json()) as SendSuccess;
+      setResult(data);
+      setStep("success");
+    } catch (err) {
+      setErrorMessage(err instanceof ApiError ? err.message : "Failed to send diagnostic report.");
+      setStep("error");
+    } finally {
+      queryClient.invalidateQueries({ queryKey: ["/api/telemetry/pending", reportId] });
+    }
+  }, [reportId, queryClient]);
+
+  const handleCopyCode = useCallback(() => {
+    if (!result) return;
+    const clipboard = navigator.clipboard;
+    if (!clipboard) {
+      toast({
+        title: "Copy failed",
+        description: "Clipboard API not supported in this browser",
+        variant: "destructive",
+      });
+      return;
+    }
+    clipboard
+      .writeText(result.code)
+      .then(() => {
+        toast({ title: "Copied", description: `Code ${result.code} copied to clipboard` });
+      })
+      .catch(() => {
+        toast({
+          title: "Copy failed",
+          description: "Clipboard access denied",
+          variant: "destructive",
+        });
+      });
+  }, [result, toast]);
+
+  const issueUrl = result && meta ? buildGitHubIssueUrl(result.code, meta.appVersion) : null;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        {/* ── Expired / not found ─────────────────────────────────────────── */}
+        {metaExpired && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5 text-yellow-500" />
+                Report no longer available
+              </DialogTitle>
+              <DialogDescription>
+                This diagnostic report has expired or was already sent. You can still send fresh
+                logs from the Logs page at any time.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {/* ── Loading metadata ─────────────────────────────────────────────── */}
+        {!metaExpired && isLoading && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Loading report…</DialogTitle>
+              <DialogDescription className="sr-only">Fetching report details</DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-col items-center gap-4 py-8">
+              <Loader2 className="h-10 w-10 animate-spin text-primary" />
+            </div>
+          </>
+        )}
+
+        {/* ── Consent ─────────────────────────────────────────────────────── */}
+        {!metaExpired && !isLoading && meta && step === "consent" && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Send className="h-5 w-5" />
+                An error occurred
+              </DialogTitle>
+              <DialogDescription className="sr-only">
+                Review what will be shared before confirming
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 py-1 text-sm">
+              <p className="text-muted-foreground">
+                Questarr detected an unexpected error. Sending a diagnostic report helps the
+                maintainer fix it. Please review what will be shared:
+              </p>
+
+              <ul className="space-y-2 text-zinc-300">
+                <li className="flex gap-2">
+                  <span className="mt-0.5 text-blue-400">•</span>
+                  <span>
+                    <strong>Log content</strong> — the {meta.lineCount} most recent server log lines
+                    around the error, with emails, IP addresses, and UUIDs replaced by placeholders.
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="mt-0.5 text-blue-400">•</span>
+                  <span>
+                    <strong>App version</strong> — {meta.appVersion}
+                  </span>
+                </li>
+                <li className="flex gap-2">
+                  <span className="mt-0.5 text-blue-400">•</span>
+                  <span>
+                    <strong>Timestamp</strong> — {meta.timestamp}
+                  </span>
+                </li>
+              </ul>
+
+              <div className="flex items-start gap-2 rounded-lg border border-yellow-800/40 bg-yellow-950/30 p-3 text-yellow-300">
+                <ShieldAlert className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                <p className="text-xs leading-relaxed">
+                  Reports are stored as an issue in a <strong>private</strong> GitHub repository
+                  visible only to the Questarr maintainer, marked as an automated telemetry report
+                  so it's clearly distinguished from a manually submitted one. You will receive an
+                  issue number as your support code.
+                </p>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Dismiss
+              </Button>
+              <Button onClick={handleSend}>
+                <Send className="mr-2 h-4 w-4" />
+                Send report
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {/* ── Sending ──────────────────────────────────────────────────────── */}
+        {step === "sending" && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Sending report…</DialogTitle>
+              <DialogDescription className="sr-only">Upload in progress</DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-col items-center gap-4 py-8">
+              <Loader2 className="h-10 w-10 animate-spin text-primary" />
+              <p className="text-sm text-muted-foreground">Uploading diagnostic report…</p>
+            </div>
+          </>
+        )}
+
+        {/* ── Success ──────────────────────────────────────────────────────── */}
+        {step === "success" && result && (
+          <>
+            <DialogHeader>
+              <DialogTitle>Report sent</DialogTitle>
+              <DialogDescription className="sr-only">Support code ready</DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 py-2">
+              <p className="text-sm text-muted-foreground">Give this code to support:</p>
+
+              <div className="flex items-center gap-3 rounded-xl border border-border bg-zinc-900 px-4 py-3">
+                <span
+                  className="flex-1 text-center font-mono text-3xl font-bold tracking-[0.3em] text-primary"
+                  aria-label={`Support code: ${result.code}`}
+                >
+                  {result.code}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleCopyCode}
+                  aria-label="Copy support code"
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+
+            <DialogFooter className="flex-col gap-2 sm:flex-row">
+              <Button
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                className="sm:mr-auto"
+              >
+                Close
+              </Button>
+              {issueUrl && (
+                <Button asChild>
+                  <a href={issueUrl} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    Create GitHub issue
+                  </a>
+                </Button>
+              )}
+            </DialogFooter>
+          </>
+        )}
+
+        {/* ── Error ────────────────────────────────────────────────────────── */}
+        {step === "error" && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="text-destructive">Send failed</DialogTitle>
+              <DialogDescription className="sr-only">Error details</DialogDescription>
+            </DialogHeader>
+            <div className="space-y-3 py-2">
+              <p className="text-sm text-muted-foreground">{errorMessage}</p>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={reset}>
+                Try again
+              </Button>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/lib/send-logs.ts
+++ b/client/src/lib/send-logs.ts
@@ -1,152 +1,15 @@
 /**
- * Log submission utilities.
+ * Log submission utilities for the client's manual "Send Logs" flow (the
+ * "Send Logs" button on the Logs page).
  *
- * PII scrubbing covers patterns found in Questarr's server log fields:
- *  - Email addresses   (e.g. auth logs, Steam import errors)
- *  - IPv4/IPv6         (e.g. express access logs, socket connections)
- *  - UUIDs             (e.g. socket IDs formatted as UUIDs, download hashes)
- *  - JWT tokens        (defensive — tokens should never be logged)
- *  - OS home-dir paths (e.g. /home/alice/… or C:\Users\alice\…)
+ * PII scrubbing lives in `@shared/log-scrub` so it can also be used by the
+ * server's automatic error-telemetry flow (see `server/error-telemetry.ts`)
+ * without duplicating the regexes in two places.
  */
 
 import { SUPPORT_WORKER_URL, GITHUB_ISSUES_URL } from "./support-config";
 
-// ── PII patterns ──────────────────────────────────────────────────────────────
-
-/** IPv4 candidates are validated after matching to keep the regex maintainable */
-const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
-
-/** IPv6 candidates are validated after matching to avoid an overly complex regex */
-const IPV6_RE = /(?<![A-Fa-f0-9:])[A-Fa-f0-9:]{2,}(?![A-Fa-f0-9:])/g;
-
-/** RFC-4122 UUID */
-const UUID_RE = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g;
-
-/** JWT (three base64url segments starting with eyJ…) */
-const JWT_RE = /eyJ[A-Za-z0-9+/=_-]+\.eyJ[A-Za-z0-9+/=_-]+\.[A-Za-z0-9+/=_-]+/g;
-
-/**
- * Unix home dir:   /home/alice/… or /Users/alice/…
- * Windows home dir: C:\Users\alice\… (backslash or forward slash)
- */
-const HOME_PATH_RE = /(?:\/(?:home|Users)|[A-Za-z]:\\[Uu]sers)[\\/]([^\\/\s"',:}]{1,64})/g;
-const WINDOWS_USERS_SEGMENT = String.raw`\Users`;
-
-// ── Public API ────────────────────────────────────────────────────────────────
-
-/**
- * Replace PII in a single log string (raw NDJSON line or plain text).
- * Each regex is applied independently so replacements don't interfere.
- */
-export function scrubPii(text: string): string {
-  return scrubEmailAddresses(text)
-    .replace(JWT_RE, "[jwt]") // before email — JWTs contain dots
-    .replace(IPV6_RE, (match) => (isIpv6(match) ? "[ip]" : match))
-    .replace(IPV4_RE, (match) => (isIpv4(match) ? "[ip]" : match))
-    .replace(UUID_RE, "[uuid]")
-    .replace(HOME_PATH_RE, (_match, _username: string) => {
-      const prefix = _match.startsWith("/")
-        ? "/home"
-        : _match.substring(0, 2) + WINDOWS_USERS_SEGMENT;
-      const sep = _match.includes("\\") ? "\\" : "/";
-      return `${prefix}${sep}[user]`;
-    });
-}
-
-function scrubEmailAddresses(text: string): string {
-  let result = "";
-  let cursor = 0;
-
-  while (cursor < text.length) {
-    const atIndex = text.indexOf("@", cursor);
-    if (atIndex === -1) {
-      result += text.slice(cursor);
-      break;
-    }
-
-    let start = atIndex - 1;
-    while (start >= cursor && isEmailLocalChar(text[start])) {
-      start--;
-    }
-
-    let end = atIndex + 1;
-    while (end < text.length && isEmailDomainChar(text[end])) {
-      end++;
-    }
-
-    const candidate = text.slice(start + 1, end);
-    if (isLikelyEmail(candidate)) {
-      result += text.slice(cursor, start + 1);
-      result += "[email]";
-      cursor = end;
-      continue;
-    }
-
-    result += text.slice(cursor, atIndex + 1);
-    cursor = atIndex + 1;
-  }
-
-  return result;
-}
-
-function isEmailLocalChar(char: string): boolean {
-  return /[A-Za-z0-9._%+-]/.test(char);
-}
-
-function isEmailDomainChar(char: string): boolean {
-  return /[A-Za-z0-9.-]/.test(char);
-}
-
-function isLikelyEmail(candidate: string): boolean {
-  const atIndex = candidate.indexOf("@");
-  if (atIndex <= 0 || atIndex !== candidate.lastIndexOf("@")) return false;
-
-  const domain = candidate.slice(atIndex + 1);
-  if (!domain || domain.startsWith(".") || domain.endsWith(".")) return false;
-
-  const labels = domain.split(".");
-  if (labels.length < 2) return false;
-
-  return labels.every(
-    (label) =>
-      label.length > 0 &&
-      !label.startsWith("-") &&
-      !label.endsWith("-") &&
-      /^[A-Za-z0-9-]+$/.test(label)
-  );
-}
-
-/**
- * Scrub all lines and join them back into a newline-delimited string.
- */
-export function scrubLogLines(lines: string[]): string {
-  return lines.map(scrubPii).join("\n");
-}
-
-function isIpv4(value: string): boolean {
-  const octets = value.split(".");
-  return (
-    octets.length === 4 &&
-    octets.every((octet) => {
-      if (!/^\d{1,3}$/.test(octet)) return false;
-      const parsed = Number(octet);
-      return parsed >= 0 && parsed <= 255;
-    })
-  );
-}
-
-function isIpv6(value: string): boolean {
-  if (!value.includes(":")) return false;
-
-  const compressedGroups = value.split("::");
-  if (compressedGroups.length > 2) return false;
-
-  const groups = value.split(":");
-  if (groups.length < 3 || groups.length > 8) return false;
-  if (compressedGroups.length === 1 && groups.length !== 8) return false;
-
-  return groups.every((group) => group === "" || /^[0-9a-fA-F]{1,4}$/.test(group));
-}
+export { scrubPii, scrubLogLines } from "@shared/log-scrub";
 
 // ── Worker communication ──────────────────────────────────────────────────────
 
@@ -155,6 +18,13 @@ export interface SendLogsPayload {
   appVersion: string;
   platform: string;
   timestamp: string;
+  /**
+   * Distinguishes a manual user-initiated submission (omitted, the default)
+   * from a telemetry report triggered by automatic error detection
+   * (`server/error-telemetry.ts`). The worker doesn't act on this field yet —
+   * it's forwarded so a future worker update can use it (e.g. for labeling).
+   */
+  reportType?: "telemetry-auto" | "telemetry-prompted";
 }
 
 export interface SendLogsSuccess {

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -2079,8 +2079,8 @@ export default function SettingsPage() {
                     </Label>
                     <p className="text-xs text-muted-foreground">
                       Off by default. When Questarr detects an unexpected server error, it will
-                      normally ask you first (see the "Error Detected" notification below). Turn
-                      this on to skip that prompt and send a scrubbed diagnostic report
+                      normally ask you first (see the &quot;Error Detected&quot; notification
+                      below). Turn this on to skip that prompt and send a scrubbed diagnostic report
                       automatically instead — no personal data, IP addresses, or file paths are
                       included. Reports help the maintainer catch bugs users don't otherwise report.
                       You can still send a one-off report manually from the Logs page at any time,

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -23,6 +23,7 @@ import {
   Bell,
   Ghost,
   Monitor,
+  Radio,
 } from "lucide-react";
 import { NexusModsIcon } from "@/components/NexusModsIcon";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -83,6 +84,7 @@ const NOTIFICATION_EVENT_ROWS: { key: NotificationEvent; label: string; group: s
   { key: "gameUpdates", label: "Game Updates Available", group: "downloads" },
   { key: "xrelRelease", label: "Scene/P2P Release (xREL)", group: "integrations" },
   { key: "steamSync", label: "Steam Wishlist Synced", group: "integrations" },
+  { key: "errorDetected", label: "Error Detected", group: "system" },
 ];
 
 export default function SettingsPage() {
@@ -193,6 +195,7 @@ export default function SettingsPage() {
   const [xrelP2pReleases, setXrelP2pReleases] = useState(false);
   const [hideAdultContent, setHideAdultContent] = useState(true);
   const [hideAgeRestrictedContent, setHideAgeRestrictedContent] = useState(true);
+  const [telemetryEnabled, setTelemetryEnabled] = useState(false);
   const [xrelApiBase, setXrelApiBase] = useState("");
   const [discordWebhookUrl, setDiscordWebhookUrl] = useState("");
   const [showDiscordWebhook, setShowDiscordWebhook] = useState(false);
@@ -246,6 +249,7 @@ export default function SettingsPage() {
       setSteamSyncIntervalHours(userSettings.steamSyncIntervalHours ?? 24);
       setHideAdultContent(userSettings.hideAdultContent ?? true);
       setHideAgeRestrictedContent(userSettings.hideAgeRestrictedContent ?? true);
+      setTelemetryEnabled(userSettings.telemetryEnabled ?? false);
       settingsLoadedRef.current = true;
     }
     if (config?.xrel?.apiBase !== undefined) {
@@ -713,6 +717,15 @@ export default function SettingsPage() {
         hideAgeRestrictedContent,
       },
       successMessage: "Content filtering preferences have been saved.",
+    });
+  };
+
+  const handleSaveTelemetry = () => {
+    updateSettingsMutation.mutate({
+      updates: { telemetryEnabled },
+      successMessage: telemetryEnabled
+        ? "Telemetry enabled. Detected errors will be reported automatically."
+        : "Telemetry disabled.",
     });
   };
 
@@ -2331,6 +2344,62 @@ export default function SettingsPage() {
                     </div>
                   </>
                 )}
+              </CardContent>
+            </Card>
+
+            {/* Telemetry */}
+            <Card>
+              <CardHeader>
+                <div className="flex items-center space-x-3">
+                  <Radio className="h-5 w-5 text-muted-foreground" />
+                  <CardTitle className="text-lg">Telemetry</CardTitle>
+                </div>
+                <CardDescription>
+                  Help improve Questarr by automatically sharing diagnostic data when something goes
+                  wrong
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5 pr-4">
+                    <Label htmlFor="telemetry-enabled" className="text-sm font-medium">
+                      Automatically send error reports
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Off by default. When Questarr detects an unexpected server error, it will
+                      normally ask you first (see the "Error Detected" notification below). Turn
+                      this on to skip that prompt and send a scrubbed diagnostic report
+                      automatically instead — no personal data, IP addresses, or file paths are
+                      included. Reports help the maintainer catch bugs users don't otherwise report.
+                      You can still send a one-off report manually from the Logs page at any time,
+                      whatever this setting is.
+                    </p>
+                  </div>
+                  <Switch
+                    id="telemetry-enabled"
+                    checked={telemetryEnabled}
+                    onCheckedChange={setTelemetryEnabled}
+                  />
+                </div>
+                <div className="flex justify-end pt-4 border-t">
+                  <Button
+                    onClick={handleSaveTelemetry}
+                    disabled={updateSettingsMutation.isPending}
+                    className="gap-2"
+                  >
+                    {updateSettingsMutation.isPending ? (
+                      <>
+                        <RefreshCw className="h-4 w-4 animate-spin" />
+                        Saving...
+                      </>
+                    ) : (
+                      <>
+                        <Radio className="h-4 w-4" />
+                        Save Telemetry
+                      </>
+                    )}
+                  </Button>
+                </div>
               </CardContent>
             </Card>
           </TabsContent>

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -2058,6 +2058,62 @@ export default function SettingsPage() {
                 </div>
               </CardContent>
             </Card>
+
+            {/* Telemetry */}
+            <Card>
+              <CardHeader>
+                <div className="flex items-center space-x-3">
+                  <Radio className="h-5 w-5 text-muted-foreground" />
+                  <CardTitle className="text-lg">Telemetry</CardTitle>
+                </div>
+                <CardDescription>
+                  Help improve Questarr by automatically sharing diagnostic data when something goes
+                  wrong
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5 pr-4">
+                    <Label htmlFor="telemetry-enabled" className="text-sm font-medium">
+                      Automatically send error reports
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Off by default. When Questarr detects an unexpected server error, it will
+                      normally ask you first (see the "Error Detected" notification below). Turn
+                      this on to skip that prompt and send a scrubbed diagnostic report
+                      automatically instead — no personal data, IP addresses, or file paths are
+                      included. Reports help the maintainer catch bugs users don't otherwise report.
+                      You can still send a one-off report manually from the Logs page at any time,
+                      whatever this setting is.
+                    </p>
+                  </div>
+                  <Switch
+                    id="telemetry-enabled"
+                    checked={telemetryEnabled}
+                    onCheckedChange={setTelemetryEnabled}
+                  />
+                </div>
+                <div className="flex justify-end pt-4 border-t">
+                  <Button
+                    onClick={handleSaveTelemetry}
+                    disabled={updateSettingsMutation.isPending}
+                    className="gap-2"
+                  >
+                    {updateSettingsMutation.isPending ? (
+                      <>
+                        <RefreshCw className="h-4 w-4 animate-spin" />
+                        Saving...
+                      </>
+                    ) : (
+                      <>
+                        <Radio className="h-4 w-4" />
+                        Save Telemetry
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
           </TabsContent>
 
           <TabsContent value="security" className="space-y-6">
@@ -2344,62 +2400,6 @@ export default function SettingsPage() {
                     </div>
                   </>
                 )}
-              </CardContent>
-            </Card>
-
-            {/* Telemetry */}
-            <Card>
-              <CardHeader>
-                <div className="flex items-center space-x-3">
-                  <Radio className="h-5 w-5 text-muted-foreground" />
-                  <CardTitle className="text-lg">Telemetry</CardTitle>
-                </div>
-                <CardDescription>
-                  Help improve Questarr by automatically sharing diagnostic data when something goes
-                  wrong
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-6">
-                <div className="flex items-center justify-between">
-                  <div className="space-y-0.5 pr-4">
-                    <Label htmlFor="telemetry-enabled" className="text-sm font-medium">
-                      Automatically send error reports
-                    </Label>
-                    <p className="text-xs text-muted-foreground">
-                      Off by default. When Questarr detects an unexpected server error, it will
-                      normally ask you first (see the "Error Detected" notification below). Turn
-                      this on to skip that prompt and send a scrubbed diagnostic report
-                      automatically instead — no personal data, IP addresses, or file paths are
-                      included. Reports help the maintainer catch bugs users don't otherwise report.
-                      You can still send a one-off report manually from the Logs page at any time,
-                      whatever this setting is.
-                    </p>
-                  </div>
-                  <Switch
-                    id="telemetry-enabled"
-                    checked={telemetryEnabled}
-                    onCheckedChange={setTelemetryEnabled}
-                  />
-                </div>
-                <div className="flex justify-end pt-4 border-t">
-                  <Button
-                    onClick={handleSaveTelemetry}
-                    disabled={updateSettingsMutation.isPending}
-                    className="gap-2"
-                  >
-                    {updateSettingsMutation.isPending ? (
-                      <>
-                        <RefreshCw className="h-4 w-4 animate-spin" />
-                        Saving...
-                      </>
-                    ) : (
-                      <>
-                        <Radio className="h-4 w-4" />
-                        Save Telemetry
-                      </>
-                    )}
-                  </Button>
-                </div>
               </CardContent>
             </Card>
           </TabsContent>

--- a/docs/API.md
+++ b/docs/API.md
@@ -190,12 +190,16 @@ Backs the consent flow opened from an "error-detected" notification's link
 PII-scrubbed `server.log` lines when an unhandled server error is detected
 (uncaught exception, unhandled rejection, or a 5xx response); see
 `server/error-telemetry.ts`. Pending reports are held in memory only (not
-persisted) and expire after 24h.
+persisted), scoped to the user they were created for, and expire after 24h.
 
-| Method | Path                                    | Auth Required  | Request Body | Response                                                                            |
-| ------ | --------------------------------------- | -------------- | ------------ | ----------------------------------------------------------------------------------- |
-| GET    | `/api/telemetry/pending/:reportId`      | JWT (explicit) | —            | `{ lineCount, appVersion, platform, timestamp }`; 404 if expired/unknown            |
-| POST   | `/api/telemetry/pending/:reportId/send` | JWT (explicit) | —            | `{ code, issueNumber }` (same shape as the manual "Send Logs" flow); 422 on failure |
+| Method | Path                                    | Auth Required  | Request Body | Response                                                                                                                     |
+| ------ | --------------------------------------- | -------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| GET    | `/api/telemetry/pending/:reportId`      | JWT (explicit) | —            | `{ lineCount, appVersion, platform, timestamp }`; 404 if expired/unknown/not owned by the caller                             |
+| POST   | `/api/telemetry/pending/:reportId/send` | JWT (explicit) | —            | `{ code, issueNumber }` (same shape as the manual "Send Logs" flow); 404 if not owned by the caller; 422 on delivery failure |
+
+`reportId` must be a UUID (validated via express-validator); a report owned by
+another user is indistinguishable from an unknown/expired one — both return
+404 — so a caller can't probe for the existence of another user's report.
 
 Whether an error triggers a notification at all is controlled by the
 `errorDetected` notification preference; whether it's reported automatically

--- a/docs/API.md
+++ b/docs/API.md
@@ -192,14 +192,17 @@ PII-scrubbed `server.log` lines when an unhandled server error is detected
 `server/error-telemetry.ts`. Pending reports are held in memory only (not
 persisted), scoped to the user they were created for, and expire after 24h.
 
-| Method | Path                                    | Auth Required  | Request Body | Response                                                                                                                     |
-| ------ | --------------------------------------- | -------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| GET    | `/api/telemetry/pending/:reportId`      | JWT (explicit) | —            | `{ lineCount, appVersion, platform, timestamp }`; 404 if expired/unknown/not owned by the caller                             |
-| POST   | `/api/telemetry/pending/:reportId/send` | JWT (explicit) | —            | `{ code, issueNumber }` (same shape as the manual "Send Logs" flow); 404 if not owned by the caller; 422 on delivery failure |
+| Method | Path                                    | Auth Required  | Request Body | Response                                                                                                                              |
+| ------ | --------------------------------------- | -------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| GET    | `/api/telemetry/pending/:reportId`      | JWT (explicit) | —            | `{ lineCount, appVersion, platform, timestamp }`; 404 if expired/unknown/not owned by the caller                                      |
+| POST   | `/api/telemetry/pending/:reportId/send` | JWT (explicit) | —            | `{ code, issueNumber }` (same shape as the manual "Send Logs" flow); 422 if unavailable (unknown/expired/not owned) or delivery fails |
 
-`reportId` must be a UUID (validated via express-validator); a report owned by
-another user is indistinguishable from an unknown/expired one — both return
-404 — so a caller can't probe for the existence of another user's report.
+`reportId` must be a UUID (validated via express-validator). For GET, a report
+owned by another user is indistinguishable from an unknown/expired one — both
+return 404 — so a caller can't probe for the existence of another user's
+report. POST folds the same "not available" cases (unknown, expired, or not
+owned) into the 422 it already uses for delivery failures, since
+`sendPendingReport` doesn't distinguish them from the caller's perspective.
 
 Whether an error triggers a notification at all is controlled by the
 `errorDetected` notification preference; whether it's reported automatically

--- a/docs/API.md
+++ b/docs/API.md
@@ -183,6 +183,25 @@ JWT even where a table row doesn't repeat `authenticateToken`.
 | PUT    | `/api/notifications/read-all`     | JWT (explicit) | —                                              | `{ success: true }`                                                  |
 | DELETE | `/api/notifications`              | JWT (explicit) | —                                              | 204 (clears all read notifications)                                  |
 
+## Error Telemetry
+
+Backs the consent flow opened from an "error-detected" notification's link
+(`error-report:<reportId>`). Reports are built server-side from recent,
+PII-scrubbed `server.log` lines when an unhandled server error is detected
+(uncaught exception, unhandled rejection, or a 5xx response); see
+`server/error-telemetry.ts`. Pending reports are held in memory only (not
+persisted) and expire after 24h.
+
+| Method | Path                                    | Auth Required  | Request Body | Response                                                                            |
+| ------ | --------------------------------------- | -------------- | ------------ | ----------------------------------------------------------------------------------- |
+| GET    | `/api/telemetry/pending/:reportId`      | JWT (explicit) | —            | `{ lineCount, appVersion, platform, timestamp }`; 404 if expired/unknown            |
+| POST   | `/api/telemetry/pending/:reportId/send` | JWT (explicit) | —            | `{ code, issueNumber }` (same shape as the manual "Send Logs" flow); 422 on failure |
+
+Whether an error triggers a notification at all is controlled by the
+`errorDetected` notification preference; whether it's reported automatically
+(skipping the consent step above) is controlled by the per-user
+`telemetryEnabled` setting (Settings > System > Telemetry, off by default).
+
 ## xREL
 
 | Method | Path               | Auth Required | Request Body                                                                                            | Response                                                                                                 |

--- a/migrations/0028_cooing_lord_tyger.sql
+++ b/migrations/0028_cooing_lord_tyger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_settings` ADD `telemetry_enabled` integer DEFAULT false NOT NULL;

--- a/migrations/meta/0028_snapshot.json
+++ b/migrations/meta/0028_snapshot.json
@@ -1,0 +1,1774 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "370aa9cb-02fb-40fc-8db3-6ca2cd3d977c",
+  "prevId": "49bb515d-121f-4207-a52a-4682a6040aea",
+  "tables": {
+    "downloaders": {
+      "name": "downloaders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_ssl": {
+          "name": "use_ssl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "url_path": {
+          "name": "url_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "download_path": {
+          "name": "download_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'games'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'Questarr'"
+        },
+        "add_stopped": {
+          "name": "add_stopped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "remove_completed": {
+          "name": "remove_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "post_import_category": {
+          "name": "post_import_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_downloads": {
+      "name": "game_downloads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "downloader_id": {
+          "name": "downloader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_type": {
+          "name": "download_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torrent'"
+        },
+        "download_hash": {
+          "name": "download_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_title": {
+          "name": "download_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'downloading'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "game_downloads_downloader_hash_idx": {
+          "name": "game_downloads_downloader_hash_idx",
+          "columns": ["downloader_id", "download_hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "game_downloads_game_id_games_id_fk": {
+          "name": "game_downloads_game_id_games_id_fk",
+          "tableFrom": "game_downloads",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_downloads_downloader_id_downloaders_id_fk": {
+          "name": "game_downloads_downloader_id_downloaders_id_fk",
+          "tableFrom": "game_downloads",
+          "tableTo": "downloaders",
+          "columnsFrom": ["downloader_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_files": {
+      "name": "game_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "download_id": {
+          "name": "download_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stored_name": {
+          "name": "stored_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "game_files_game_id_idx": {
+          "name": "game_files_game_id_idx",
+          "columns": ["game_id"],
+          "isUnique": false
+        },
+        "game_files_download_id_idx": {
+          "name": "game_files_download_id_idx",
+          "columns": ["download_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_files_game_id_games_id_fk": {
+          "name": "game_files_game_id_games_id_fk",
+          "tableFrom": "game_files",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_files_download_id_game_downloads_id_fk": {
+          "name": "game_files_download_id_game_downloads_id_fk",
+          "tableFrom": "game_files",
+          "tableTo": "game_downloads",
+          "columnsFrom": ["download_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "games": {
+      "name": "games",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "steam_appid": {
+          "name": "steam_appid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "themes": {
+          "name": "themes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publishers": {
+          "name": "publishers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "developers": {
+          "name": "developers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "igdb_websites": {
+          "name": "igdb_websites",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "original_release_date": {
+          "name": "original_release_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_status": {
+          "name": "release_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'upcoming'"
+        },
+        "early_access": {
+          "name": "early_access",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_adult_content": {
+          "name": "is_adult_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_age_restricted": {
+          "name": "is_age_restricted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "user_rating": {
+          "name": "user_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "library_path": {
+          "name": "library_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_results_available": {
+          "name": "search_results_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "update_search_results_available": {
+          "name": "update_search_results_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "packs_search_results_available": {
+          "name": "packs_search_results_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "games_user_id_users_id_fk": {
+          "name": "games_user_id_users_id_fk",
+          "tableFrom": "games",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_task_items": {
+      "name": "import_task_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "game_title": {
+          "name": "game_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "import_task_items_task_id_idx": {
+          "name": "import_task_items_task_id_idx",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "import_task_items_task_id_import_tasks_id_fk": {
+          "name": "import_task_items_task_id_import_tasks_id_fk",
+          "tableFrom": "import_task_items",
+          "tableTo": "import_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_tasks": {
+      "name": "import_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "added_items": {
+          "name": "added_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_items": {
+          "name": "skipped_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_items": {
+          "name": "failed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "import_tasks_user_id_users_id_fk": {
+          "name": "import_tasks_user_id_users_id_fk",
+          "tableFrom": "import_tasks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexers": {
+      "name": "indexers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torznab'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "rss_enabled": {
+          "name": "rss_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_search_enabled": {
+          "name": "auto_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read": {
+          "name": "read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "path_mappings": {
+      "name": "path_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_path": {
+          "name": "remote_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_host": {
+          "name": "remote_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "platform_mappings": {
+      "name": "platform_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "igdb_platform_id": {
+          "name": "igdb_platform_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_platform_name": {
+          "name": "source_platform_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "release_blacklist": {
+      "name": "release_blacklist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_title": {
+          "name": "release_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexer_name": {
+          "name": "indexer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "release_blacklist_game_title_idx": {
+          "name": "release_blacklist_game_title_idx",
+          "columns": ["game_id", "release_title"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "release_blacklist_game_id_games_id_fk": {
+          "name": "release_blacklist_game_id_games_id_fk",
+          "tableFrom": "release_blacklist",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_feed_items": {
+      "name": "rss_feed_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feed_id": {
+          "name": "feed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pub_date": {
+          "name": "pub_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_game_id": {
+          "name": "igdb_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "igdb_game_name": {
+          "name": "igdb_game_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "rss_feed_items_feed_id_rss_feeds_id_fk": {
+          "name": "rss_feed_items_feed_id_rss_feeds_id_fk",
+          "tableFrom": "rss_feed_items",
+          "tableTo": "rss_feeds",
+          "columnsFrom": ["feed_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_feeds": {
+      "name": "rss_feeds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'custom'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "mapping": {
+          "name": "mapping",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_config": {
+      "name": "system_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auto_search_enabled": {
+          "name": "auto_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_download_enabled": {
+          "name": "auto_download_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_interval_hours": {
+          "name": "search_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 6
+        },
+        "igdb_rate_limit_per_second": {
+          "name": "igdb_rate_limit_per_second",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "download_rules": {
+          "name": "download_rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_auto_search": {
+          "name": "last_auto_search",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "xrel_scene_releases": {
+          "name": "xrel_scene_releases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "xrel_p2p_releases": {
+          "name": "xrel_p2p_releases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_search_unreleased": {
+          "name": "auto_search_unreleased",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "steam_sync_failures": {
+          "name": "steam_sync_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "steam_sync_enabled": {
+          "name": "steam_sync_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "steam_sync_interval_hours": {
+          "name": "steam_sync_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "last_steam_sync": {
+          "name": "last_steam_sync",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preferred_release_groups": {
+          "name": "preferred_release_groups",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filter_by_preferred_groups": {
+          "name": "filter_by_preferred_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "preferred_platform": {
+          "name": "preferred_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hide_adult_content": {
+          "name": "hide_adult_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "hide_age_restricted_content": {
+          "name": "hide_age_restricted_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "enable_post_processing": {
+          "name": "enable_post_processing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auto_unpack": {
+          "name": "auto_unpack",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "rename_pattern": {
+          "name": "rename_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{Title} ({Region})'"
+        },
+        "overwrite_existing": {
+          "name": "overwrite_existing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "transfer_mode": {
+          "name": "transfer_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'hardlink'"
+        },
+        "import_platform_ids": {
+          "name": "import_platform_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "ignored_extensions": {
+          "name": "ignored_extensions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "min_file_size": {
+          "name": "min_file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "library_root": {
+          "name": "library_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'/data'"
+        },
+        "auto_delete_after_import": {
+          "name": "auto_delete_after_import",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_extras": {
+          "name": "sort_extras",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "telemetry_enabled": {
+          "name": "telemetry_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "steam_id_64": {
+          "name": "steam_id_64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "xrel_notified_releases": {
+      "name": "xrel_notified_releases",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "xrel_release_id": {
+          "name": "xrel_release_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "xrel_notified_releases_game_id_games_id_fk": {
+          "name": "xrel_notified_releases_game_id_games_id_fk",
+          "tableFrom": "xrel_notified_releases",
+          "tableTo": "games",
+          "columnsFrom": ["game_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1784581013230,
       "tag": "0027_game_files",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1787149265934,
+      "tag": "0028_cooing_lord_tyger",
+      "breakpoints": true
     }
   ]
 }

--- a/server/__tests__/error_telemetry.test.ts
+++ b/server/__tests__/error_telemetry.test.ts
@@ -47,9 +47,16 @@ vi.mock("../logger.js", () => {
   };
 });
 
-const baseUser: User = {
+const userOne: User = {
   id: "user-1",
   username: "tester",
+  password: "hash",
+  createdAt: new Date(),
+} as unknown as User;
+
+const userTwo: User = {
+  id: "user-2",
+  username: "other",
   password: "hash",
   createdAt: new Date(),
 } as unknown as User;
@@ -75,6 +82,7 @@ describe("error-telemetry", () => {
   let safeFetchMock: Mock;
   let reportServerError: (typeof import("../error-telemetry.js"))["reportServerError"];
   let sendPendingReport: (typeof import("../error-telemetry.js"))["sendPendingReport"];
+  let getPendingReport: (typeof import("../error-telemetry.js"))["getPendingReport"];
 
   beforeEach(async () => {
     vi.resetModules();
@@ -95,6 +103,7 @@ describe("error-telemetry", () => {
     const errorTelemetry = await import("../error-telemetry.js");
     reportServerError = errorTelemetry.reportServerError;
     sendPendingReport = errorTelemetry.sendPendingReport;
+    getPendingReport = errorTelemetry.getPendingReport;
 
     storageMock.addNotification.mockImplementation(
       async (n: InsertNotification): Promise<Notification> =>
@@ -103,7 +112,7 @@ describe("error-telemetry", () => {
   });
 
   it("creates an actionable notification (no auto-send) when telemetryEnabled is false", async () => {
-    storageMock.getAllUsers.mockResolvedValue([baseUser]);
+    storageMock.getAllUsers.mockResolvedValue([userOne]);
     storageMock.getUserSettings.mockResolvedValue(makeSettings({ telemetryEnabled: false }));
 
     await reportServerError(new Error("boom"), { source: "expressErrorHandler" });
@@ -117,7 +126,7 @@ describe("error-telemetry", () => {
   });
 
   it("auto-sends and creates an info notification when telemetryEnabled is true", async () => {
-    storageMock.getAllUsers.mockResolvedValue([baseUser]);
+    storageMock.getAllUsers.mockResolvedValue([userOne]);
     storageMock.getUserSettings.mockResolvedValue(makeSettings({ telemetryEnabled: true }));
     safeFetchMock.mockResolvedValue({
       ok: true,
@@ -140,8 +149,66 @@ describe("error-telemetry", () => {
     expect(notification.link).toBeUndefined();
   });
 
+  it("sends the automatic report even when the errorDetected in-app preference is off", async () => {
+    storageMock.getAllUsers.mockResolvedValue([userOne]);
+    storageMock.getUserSettings.mockResolvedValue(
+      makeSettings({
+        telemetryEnabled: true,
+        notificationPreferences: JSON.stringify({
+          errorDetected: { inApp: false, apprise: false },
+        }),
+      })
+    );
+    safeFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ code: "1234", issueNumber: 42 }),
+    });
+
+    await reportServerError(new Error("boom"), { source: "expressErrorHandler" });
+
+    // Opted-in telemetry must not depend on the in-app notification preference —
+    // the report is still sent, just without a notification about it.
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+    expect(storageMock.addNotification).not.toHaveBeenCalled();
+  });
+
+  it("sends only one automatic report even when multiple users are opted in", async () => {
+    storageMock.getAllUsers.mockResolvedValue([userOne, userTwo]);
+    storageMock.getUserSettings.mockResolvedValue(makeSettings({ telemetryEnabled: true }));
+    safeFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ code: "1234", issueNumber: 42 }),
+    });
+
+    await reportServerError(new Error("boom"), { source: "expressErrorHandler" });
+
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+    expect(storageMock.addNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it("scrubs PII from the error message before including it in the auto-send banner", async () => {
+    storageMock.getAllUsers.mockResolvedValue([userOne]);
+    storageMock.getUserSettings.mockResolvedValue(makeSettings({ telemetryEnabled: true }));
+    safeFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ code: "1234", issueNumber: 42 }),
+    });
+
+    await reportServerError(new Error("failed for user alice@example.com"), {
+      source: "expressErrorHandler",
+    });
+
+    const [, requestInit] = safeFetchMock.mock.calls[0];
+    const body = JSON.parse(requestInit.body as string);
+    expect(body.logs).not.toContain("alice@example.com");
+    expect(body.logs).toContain("[email]");
+  });
+
   it("skips users who disabled the errorDetected notification", async () => {
-    storageMock.getAllUsers.mockResolvedValue([baseUser]);
+    storageMock.getAllUsers.mockResolvedValue([userOne]);
     storageMock.getUserSettings.mockResolvedValue(
       makeSettings({
         notificationPreferences: JSON.stringify({
@@ -157,7 +224,7 @@ describe("error-telemetry", () => {
   });
 
   it("does not report again within the cooldown window", async () => {
-    storageMock.getAllUsers.mockResolvedValue([baseUser]);
+    storageMock.getAllUsers.mockResolvedValue([userOne]);
     storageMock.getUserSettings.mockResolvedValue(makeSettings());
 
     await reportServerError(new Error("first"), { source: "expressErrorHandler" });
@@ -168,7 +235,7 @@ describe("error-telemetry", () => {
   });
 
   it("sendPendingReport reports an unknown/expired report id as not available", async () => {
-    const result = await sendPendingReport("does-not-exist");
+    const result = await sendPendingReport("does-not-exist", "user-1");
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.message).toMatch(/no longer available/i);
@@ -176,8 +243,26 @@ describe("error-telemetry", () => {
     expect(safeFetchMock).not.toHaveBeenCalled();
   });
 
+  it("scopes pending reports to their owning user", async () => {
+    storageMock.getAllUsers.mockResolvedValue([userOne]);
+    storageMock.getUserSettings.mockResolvedValue(makeSettings({ telemetryEnabled: false }));
+    await reportServerError(new Error("boom"), { source: "expressErrorHandler" });
+
+    const notification = storageMock.addNotification.mock.calls[0][0] as InsertNotification;
+    const reportId = notification.link!.split(":").pop()!;
+
+    // The owning user can read it...
+    expect(getPendingReport(reportId, "user-1")).toBeDefined();
+    // ...but a different authenticated user cannot.
+    expect(getPendingReport(reportId, "user-2")).toBeUndefined();
+
+    const result = await sendPendingReport(reportId, "user-2");
+    expect(result.ok).toBe(false);
+    expect(safeFetchMock).not.toHaveBeenCalled();
+  });
+
   it("sendPendingReport sends a telemetry-prompted report for a pending id", async () => {
-    storageMock.getAllUsers.mockResolvedValue([baseUser]);
+    storageMock.getAllUsers.mockResolvedValue([userOne]);
     storageMock.getUserSettings.mockResolvedValue(makeSettings({ telemetryEnabled: false }));
     await reportServerError(new Error("boom"), { source: "expressErrorHandler" });
 
@@ -190,7 +275,7 @@ describe("error-telemetry", () => {
       json: async () => ({ code: "5678", issueNumber: 7 }),
     });
 
-    const result = await sendPendingReport(reportId);
+    const result = await sendPendingReport(reportId, "user-1");
 
     expect(result.ok).toBe(true);
     const [, requestInit] = safeFetchMock.mock.calls[0];
@@ -198,12 +283,39 @@ describe("error-telemetry", () => {
     expect(body.reportType).toBe("telemetry-prompted");
 
     // Second send for the same id should fail — it was deleted after success.
-    const secondResult = await sendPendingReport(reportId);
+    const secondResult = await sendPendingReport(reportId, "user-1");
     expect(secondResult.ok).toBe(false);
   });
 
+  it("restores the pending report if delivery fails, so the user can retry", async () => {
+    storageMock.getAllUsers.mockResolvedValue([userOne]);
+    storageMock.getUserSettings.mockResolvedValue(makeSettings({ telemetryEnabled: false }));
+    await reportServerError(new Error("boom"), { source: "expressErrorHandler" });
+
+    const notification = storageMock.addNotification.mock.calls[0][0] as InsertNotification;
+    const reportId = notification.link!.split(":").pop()!;
+
+    safeFetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      json: async () => ({ error: "bad gateway" }),
+    });
+
+    const failedResult = await sendPendingReport(reportId, "user-1");
+    expect(failedResult.ok).toBe(false);
+    expect(getPendingReport(reportId, "user-1")).toBeDefined();
+
+    safeFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ code: "9999", issueNumber: 1 }),
+    });
+    const retryResult = await sendPendingReport(reportId, "user-1");
+    expect(retryResult.ok).toBe(true);
+  });
+
   it("does not call apprise when the errorDetected apprise preference is off", async () => {
-    storageMock.getAllUsers.mockResolvedValue([baseUser]);
+    storageMock.getAllUsers.mockResolvedValue([userOne]);
     storageMock.getUserSettings.mockResolvedValue(makeSettings());
 
     await reportServerError(new Error("boom"), { source: "expressErrorHandler" });

--- a/server/__tests__/error_telemetry.test.ts
+++ b/server/__tests__/error_telemetry.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
+import type { User, UserSettings, InsertNotification, Notification } from "../../shared/schema.js";
+
+vi.mock("../storage.js", () => ({
+  storage: {
+    getAllUsers: vi.fn(),
+    getUserSettings: vi.fn(),
+    addNotification: vi.fn(),
+  },
+}));
+
+vi.mock("../socket.js", () => ({
+  notifyUser: vi.fn(),
+}));
+
+vi.mock("../apprise.js", () => ({
+  appriseClient: { send: vi.fn() },
+}));
+
+vi.mock("../ssrf.js", () => ({
+  safeFetch: vi.fn(),
+}));
+
+vi.mock("../log-file.js", () => ({
+  readLastLogLines: vi.fn().mockResolvedValue(["log line 1", "log line 2"]),
+}));
+
+vi.mock("../logger.js", () => {
+  const mockLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+  return {
+    logger: mockLogger,
+    igdbLogger: mockLogger,
+    routesLogger: mockLogger,
+    expressLogger: mockLogger,
+    downloadersLogger: mockLogger,
+    torznabLogger: mockLogger,
+    searchLogger: mockLogger,
+    telemetryLogger: mockLogger,
+  };
+});
+
+const baseUser: User = {
+  id: "user-1",
+  username: "tester",
+  password: "hash",
+  createdAt: new Date(),
+} as unknown as User;
+
+function makeSettings(overrides: Partial<UserSettings> = {}): UserSettings {
+  return {
+    id: "settings-1",
+    userId: "user-1",
+    telemetryEnabled: false,
+    notificationPreferences: null,
+    ...overrides,
+  } as UserSettings;
+}
+
+describe("error-telemetry", () => {
+  let storageMock: {
+    getAllUsers: Mock;
+    getUserSettings: Mock;
+    addNotification: Mock;
+  };
+  let notifyUserMock: Mock;
+  let appriseClientMock: { send: Mock };
+  let safeFetchMock: Mock;
+  let reportServerError: (typeof import("../error-telemetry.js"))["reportServerError"];
+  let sendPendingReport: (typeof import("../error-telemetry.js"))["sendPendingReport"];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    const storageModule = await import("../storage.js");
+    storageMock = storageModule.storage as unknown as typeof storageMock;
+
+    const socketModule = await import("../socket.js");
+    notifyUserMock = socketModule.notifyUser as unknown as Mock;
+
+    const appriseModule = await import("../apprise.js");
+    appriseClientMock = appriseModule.appriseClient as unknown as typeof appriseClientMock;
+
+    const ssrfModule = await import("../ssrf.js");
+    safeFetchMock = ssrfModule.safeFetch as unknown as Mock;
+
+    const errorTelemetry = await import("../error-telemetry.js");
+    reportServerError = errorTelemetry.reportServerError;
+    sendPendingReport = errorTelemetry.sendPendingReport;
+
+    storageMock.addNotification.mockImplementation(
+      async (n: InsertNotification): Promise<Notification> =>
+        ({ ...n, id: "notif-1", read: false, createdAt: new Date() }) as Notification
+    );
+  });
+
+  it("creates an actionable notification (no auto-send) when telemetryEnabled is false", async () => {
+    storageMock.getAllUsers.mockResolvedValue([baseUser]);
+    storageMock.getUserSettings.mockResolvedValue(makeSettings({ telemetryEnabled: false }));
+
+    await reportServerError(new Error("boom"), { source: "expressErrorHandler" });
+
+    expect(safeFetchMock).not.toHaveBeenCalled();
+    expect(storageMock.addNotification).toHaveBeenCalledTimes(1);
+    const notification = storageMock.addNotification.mock.calls[0][0] as InsertNotification;
+    expect(notification.title).toBe("An error occurred");
+    expect(notification.link).toMatch(/^error-report:/);
+    expect(notifyUserMock).toHaveBeenCalledWith("notification", expect.anything());
+  });
+
+  it("auto-sends and creates an info notification when telemetryEnabled is true", async () => {
+    storageMock.getAllUsers.mockResolvedValue([baseUser]);
+    storageMock.getUserSettings.mockResolvedValue(makeSettings({ telemetryEnabled: true }));
+    safeFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ code: "1234", issueNumber: 42 }),
+    });
+
+    await reportServerError(new Error("boom"), { source: "expressErrorHandler" });
+
+    expect(safeFetchMock).toHaveBeenCalledTimes(1);
+    const [, requestInit] = safeFetchMock.mock.calls[0];
+    const body = JSON.parse(requestInit.body as string);
+    expect(body.reportType).toBe("telemetry-auto");
+    expect(body.logs).toContain("AUTOMATED TELEMETRY REPORT");
+
+    expect(storageMock.addNotification).toHaveBeenCalledTimes(1);
+    const notification = storageMock.addNotification.mock.calls[0][0] as InsertNotification;
+    expect(notification.type).toBe("info");
+    expect(notification.title).toBe("Automated error report sent");
+    expect(notification.link).toBeUndefined();
+  });
+
+  it("skips users who disabled the errorDetected notification", async () => {
+    storageMock.getAllUsers.mockResolvedValue([baseUser]);
+    storageMock.getUserSettings.mockResolvedValue(
+      makeSettings({
+        notificationPreferences: JSON.stringify({
+          errorDetected: { inApp: false, apprise: false },
+        }),
+      })
+    );
+
+    await reportServerError(new Error("boom"), { source: "uncaughtException" });
+
+    expect(storageMock.addNotification).not.toHaveBeenCalled();
+    expect(safeFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not report again within the cooldown window", async () => {
+    storageMock.getAllUsers.mockResolvedValue([baseUser]);
+    storageMock.getUserSettings.mockResolvedValue(makeSettings());
+
+    await reportServerError(new Error("first"), { source: "expressErrorHandler" });
+    await reportServerError(new Error("second"), { source: "expressErrorHandler" });
+
+    expect(storageMock.getAllUsers).toHaveBeenCalledTimes(1);
+    expect(storageMock.addNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("sendPendingReport reports an unknown/expired report id as not available", async () => {
+    const result = await sendPendingReport("does-not-exist");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toMatch(/no longer available/i);
+    }
+    expect(safeFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("sendPendingReport sends a telemetry-prompted report for a pending id", async () => {
+    storageMock.getAllUsers.mockResolvedValue([baseUser]);
+    storageMock.getUserSettings.mockResolvedValue(makeSettings({ telemetryEnabled: false }));
+    await reportServerError(new Error("boom"), { source: "expressErrorHandler" });
+
+    const notification = storageMock.addNotification.mock.calls[0][0] as InsertNotification;
+    const reportId = notification.link!.split(":").pop()!;
+
+    safeFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ code: "5678", issueNumber: 7 }),
+    });
+
+    const result = await sendPendingReport(reportId);
+
+    expect(result.ok).toBe(true);
+    const [, requestInit] = safeFetchMock.mock.calls[0];
+    const body = JSON.parse(requestInit.body as string);
+    expect(body.reportType).toBe("telemetry-prompted");
+
+    // Second send for the same id should fail — it was deleted after success.
+    const secondResult = await sendPendingReport(reportId);
+    expect(secondResult.ok).toBe(false);
+  });
+
+  it("does not call apprise when the errorDetected apprise preference is off", async () => {
+    storageMock.getAllUsers.mockResolvedValue([baseUser]);
+    storageMock.getUserSettings.mockResolvedValue(makeSettings());
+
+    await reportServerError(new Error("boom"), { source: "expressErrorHandler" });
+
+    expect(appriseClientMock.send).not.toHaveBeenCalled();
+  });
+});

--- a/server/__tests__/security_error_handling.test.ts
+++ b/server/__tests__/security_error_handling.test.ts
@@ -18,6 +18,13 @@ vi.mock("../storage.js", () => ({
   },
 }));
 
+// The error handler fires the automatic error-telemetry pipeline for 5xx errors
+// (fire-and-forget). Mock it out here — these tests only care about the HTTP
+// response the error handler produces, not telemetry reporting.
+vi.mock("../error-telemetry.js", () => ({
+  reportServerError: vi.fn(),
+}));
+
 describe("Security Error Handling", () => {
   it("should sanitize 500 errors in production", async () => {
     const app = express();

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -2,6 +2,7 @@ import { storage } from "./storage.js";
 import { igdbClient, IGDB_EARLY_ACCESS_STATUS } from "./igdb.js";
 import { igdbLogger } from "./logger.js";
 import { notifyUser } from "./socket.js";
+import { resolvePrefs } from "./notification-prefs.js";
 import { DownloaderManager } from "./downloaders.js";
 import { resolveDownloadRelativePath } from "./downloaders/utils.js";
 import { torznabClient } from "./torznab.js";
@@ -47,21 +48,6 @@ const GAME_UPDATE_TITLE_TO_EVENT: Record<string, NotificationEvent> = {
   "Game Released": "gameReleased",
   "Game Delayed": "gameDelayed",
 };
-
-function resolvePrefs(
-  settings: { notificationPreferences?: string | null } | null | undefined
-): NotificationPreferences {
-  if (!settings?.notificationPreferences) return DEFAULT_NOTIFICATION_PREFERENCES;
-  try {
-    return { ...DEFAULT_NOTIFICATION_PREFERENCES, ...JSON.parse(settings.notificationPreferences) };
-  } catch {
-    igdbLogger.warn(
-      { value: settings.notificationPreferences },
-      "Failed to parse notification preferences, using defaults"
-    );
-    return DEFAULT_NOTIFICATION_PREFERENCES;
-  }
-}
 
 function buildRemoteImportPath(downloadDir: string, name: string): string {
   const normalizedDir = downloadDir.replace(/[\\/]+$/, "");

--- a/server/error-telemetry.ts
+++ b/server/error-telemetry.ts
@@ -12,6 +12,9 @@
  *    (see server/routes.ts) and `SendErrorReportDialog`.
  *
  * A global cooldown prevents notification/telemetry spam during a crash loop.
+ * The automatic-telemetry report (when enabled) is sent at most once per
+ * detected error — never once per opted-in user — and its result is shared
+ * across every opted-in user's notification.
  */
 import { randomUUID } from "node:crypto";
 import path from "node:path";
@@ -23,9 +26,9 @@ import { appriseClient } from "./apprise.js";
 import { resolvePrefs } from "./notification-prefs.js";
 import { safeFetch } from "./ssrf.js";
 import { telemetryLogger } from "./logger.js";
-import { scrubLogLines } from "../shared/log-scrub.js";
+import { scrubPii, scrubLogLines } from "../shared/log-scrub.js";
 import { SUPPORT_WORKER_URL } from "../shared/support-config.js";
-import type { InsertNotification } from "../shared/schema.js";
+import type { InsertNotification, NotificationPreferences, User } from "../shared/schema.js";
 
 const ERROR_REPORT_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes
 const LOG_CONTEXT_LINES = 150;
@@ -43,6 +46,7 @@ export interface ErrorContext {
 }
 
 export interface PendingErrorReport {
+  userId: string;
   logs: string;
   lineCount: number;
   appVersion: string;
@@ -56,19 +60,25 @@ const pendingReports = new Map<string, PendingErrorReport>();
 
 function purgeExpiredReports(): void {
   const cutoff = Date.now() - PENDING_REPORT_TTL_MS;
-  for (const [id, report] of pendingReports) {
+  for (const [id, report] of Array.from(pendingReports.entries())) {
     if (report.createdAt < cutoff) pendingReports.delete(id);
   }
 }
 
-/** Used by GET /api/telemetry/pending/:reportId */
-export function getPendingReport(reportId: string): PendingErrorReport | undefined {
-  return pendingReports.get(reportId);
-}
-
-/** Used by POST /api/telemetry/pending/:reportId/send after a successful (or exhausted) attempt */
-export function deletePendingReport(reportId: string): void {
-  pendingReports.delete(reportId);
+/**
+ * Used by GET /api/telemetry/pending/:reportId. Only returns the report when
+ * it exists, hasn't expired, and belongs to the requesting user — an
+ * authenticated user must not be able to read another user's report by
+ * guessing/observing its id.
+ */
+export function getPendingReport(reportId: string, userId: string): PendingErrorReport | undefined {
+  const report = pendingReports.get(reportId);
+  if (!report || report.userId !== userId) return undefined;
+  if (Date.now() - report.createdAt > PENDING_REPORT_TTL_MS) {
+    pendingReports.delete(reportId);
+    return undefined;
+  }
+  return report;
 }
 
 type WorkerSendResult =
@@ -111,18 +121,28 @@ async function sendToSupportWorker(
   }
 }
 
-/** Sends the confirmed pending report (user clicked "Send" in SendErrorReportDialog). */
-export async function sendPendingReport(reportId: string): Promise<WorkerSendResult> {
-  const report = getPendingReport(reportId);
+/**
+ * Sends the confirmed pending report (user clicked "Send" in SendErrorReportDialog).
+ * The report is reserved (removed from the map) before the outbound request so two
+ * concurrent submissions can't both send it; it's restored only if delivery fails,
+ * so the user can retry.
+ */
+export async function sendPendingReport(
+  reportId: string,
+  userId: string
+): Promise<WorkerSendResult> {
+  const report = getPendingReport(reportId, userId);
   if (!report) {
     return { ok: false, message: "This report is no longer available." };
   }
+  pendingReports.delete(reportId);
 
   const banner =
-    "=== QUESTARR AUTOMATED TELEMETRY REPORT (user-confirmed) ===\n" +
-    'Sent after the user clicked "Send" on an error-detected notification.';
+    '=== QUESTARR AUTOMATED TELEMETRY REPORT (user-confirmed) ===\nSent after the user clicked "Send" on an error-detected notification.';
   const result = await sendToSupportWorker(report.logs, "telemetry-prompted", banner);
-  if (result.ok) deletePendingReport(reportId);
+  if (!result.ok) {
+    pendingReports.set(reportId, report);
+  }
   return result;
 }
 
@@ -135,6 +155,99 @@ async function buildScrubbedLogBundle(): Promise<{ logs: string; lineCount: numb
     telemetryLogger.warn({ error: err }, "Failed to read server.log for error telemetry");
     return { logs: "", lineCount: 0 };
   }
+}
+
+function buildAutoSendBanner(errorMessage: string, context: ErrorContext): string {
+  const location = context.path ? ` (${context.method} ${context.path})` : "";
+  const trigger = `${context.source}${location}`;
+  return (
+    "=== QUESTARR AUTOMATED TELEMETRY REPORT (auto-sent, no user confirmation) ===\n" +
+    `Trigger: ${trigger}\n` +
+    `Error: ${errorMessage}`
+  );
+}
+
+interface UserTelemetryContext {
+  user: User;
+  prefs: NotificationPreferences;
+  telemetryEnabled: boolean;
+}
+
+async function loadUserTelemetryContexts(users: User[]): Promise<UserTelemetryContext[]> {
+  const contexts: UserTelemetryContext[] = [];
+  for (const user of users) {
+    const settings = await storage.getUserSettings(user.id);
+    contexts.push({
+      user,
+      prefs: resolvePrefs(settings),
+      telemetryEnabled: settings?.telemetryEnabled === true,
+    });
+  }
+  return contexts;
+}
+
+/**
+ * Builds (and, for a user, persists) the notification for one user's telemetry
+ * context, reusing a single shared auto-send result across every opted-in user
+ * so the Worker only receives one submission per detected error. Telemetry
+ * auto-send runs independently of the "Error Detected" in-app preference —
+ * that preference only gates whether a notification is created, not whether
+ * an opted-in report is sent.
+ */
+function buildNotificationFor(
+  ctx: UserTelemetryContext,
+  autoSendResult: WorkerSendResult | null,
+  pending: { logs: string; lineCount: number; timestamp: string } | null
+): InsertNotification | null {
+  const { user, prefs, telemetryEnabled } = ctx;
+
+  if (telemetryEnabled) {
+    if (!autoSendResult || !prefs.errorDetected.inApp) return null;
+    return autoSendResult.ok
+      ? {
+          userId: user.id,
+          type: "info",
+          title: "Automated error report sent",
+          message: `Questarr detected an error and automatically sent a diagnostic report. Support code: ${autoSendResult.code}.`,
+        }
+      : {
+          userId: user.id,
+          type: "warning",
+          title: "Automated error report failed",
+          message: `Questarr detected an error but could not send the automatic diagnostic report (${autoSendResult.message}).`,
+        };
+  }
+
+  if (!prefs.errorDetected.inApp || !pending) return null;
+
+  const reportId = randomUUID();
+  pendingReports.set(reportId, {
+    userId: user.id,
+    logs: pending.logs,
+    lineCount: pending.lineCount,
+    appVersion: APP_VERSION,
+    platform: "server",
+    timestamp: pending.timestamp,
+    createdAt: Date.now(),
+  });
+
+  return {
+    userId: user.id,
+    type: "warning",
+    title: "An error occurred",
+    message:
+      "Questarr encountered an unexpected error. Click to review and optionally send a diagnostic report to help fix it.",
+    link: `error-report:${reportId}`,
+  };
+}
+
+async function dispatchNotification(
+  ctx: UserTelemetryContext,
+  notification: InsertNotification
+): Promise<void> {
+  const created = await storage.addNotification(notification);
+  notifyUser("notification", created);
+  if (ctx.prefs.errorDetected.apprise) appriseClient.send(created);
 }
 
 /**
@@ -152,66 +265,30 @@ export async function reportServerError(err: unknown, context: ErrorContext): Pr
   try {
     purgeExpiredReports();
 
-    const errorMessage = err instanceof Error ? err.message : String(err);
+    const errorMessage = scrubPii(err instanceof Error ? err.message : String(err));
     const { logs, lineCount } = await buildScrubbedLogBundle();
     const timestamp = new Date().toISOString();
 
     const users = await storage.getAllUsers();
-    for (const user of users) {
+    const contexts = await loadUserTelemetryContexts(users);
+
+    const anyoneOptedIn = contexts.some((ctx) => ctx.telemetryEnabled);
+    const autoSendResult = anyoneOptedIn
+      ? await sendToSupportWorker(
+          logs,
+          "telemetry-auto",
+          buildAutoSendBanner(errorMessage, context)
+        )
+      : null;
+    const pending = { logs, lineCount, timestamp };
+
+    for (const ctx of contexts) {
       try {
-        const settings = await storage.getUserSettings(user.id);
-        const prefs = resolvePrefs(settings);
-        if (!prefs.errorDetected.inApp) continue;
-
-        let notification: InsertNotification;
-
-        if (settings?.telemetryEnabled) {
-          const banner =
-            "=== QUESTARR AUTOMATED TELEMETRY REPORT (auto-sent, no user confirmation) ===\n" +
-            `Trigger: ${context.source}${context.path ? ` (${context.method} ${context.path})` : ""}\n` +
-            `Error: ${errorMessage}`;
-          const result = await sendToSupportWorker(logs, "telemetry-auto", banner);
-
-          notification = result.ok
-            ? {
-                userId: user.id,
-                type: "info",
-                title: "Automated error report sent",
-                message: `Questarr detected an error and automatically sent a diagnostic report. Support code: ${result.code}.`,
-              }
-            : {
-                userId: user.id,
-                type: "warning",
-                title: "Automated error report failed",
-                message: `Questarr detected an error but could not send the automatic diagnostic report (${result.message}).`,
-              };
-        } else {
-          const reportId = randomUUID();
-          pendingReports.set(reportId, {
-            logs,
-            lineCount,
-            appVersion: APP_VERSION,
-            platform: "server",
-            timestamp,
-            createdAt: now,
-          });
-
-          notification = {
-            userId: user.id,
-            type: "warning",
-            title: "An error occurred",
-            message:
-              "Questarr encountered an unexpected error. Click to review and optionally send a diagnostic report to help fix it.",
-            link: `error-report:${reportId}`,
-          };
-        }
-
-        const created = await storage.addNotification(notification);
-        notifyUser("notification", created);
-        if (prefs.errorDetected.apprise) appriseClient.send(created);
+        const notification = buildNotificationFor(ctx, autoSendResult, pending);
+        if (notification) await dispatchNotification(ctx, notification);
       } catch (userError) {
         telemetryLogger.error(
-          { error: userError, userId: user.id },
+          { error: userError, userId: ctx.user.id },
           "Failed to process error telemetry for user"
         );
       }

--- a/server/error-telemetry.ts
+++ b/server/error-telemetry.ts
@@ -1,0 +1,222 @@
+/**
+ * Automatic error-telemetry pipeline.
+ *
+ * Detects unhandled server errors (uncaught exceptions, unhandled promise
+ * rejections, and 5xx responses from the global Express error handler) and,
+ * per-user, either:
+ *  - sends a diagnostic report to the same support-log Worker used by the
+ *    manual "Send Logs" flow (`client/src/lib/send-logs.ts`), when the user has
+ *    opted into automatic telemetry (`userSettings.telemetryEnabled`), or
+ *  - creates an actionable in-app notification asking for consent first,
+ *    which the client resolves via GET/POST /api/telemetry/pending/:reportId
+ *    (see server/routes.ts) and `SendErrorReportDialog`.
+ *
+ * A global cooldown prevents notification/telemetry spam during a crash loop.
+ */
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import { storage } from "./storage.js";
+import { readLastLogLines } from "./log-file.js";
+import { notifyUser } from "./socket.js";
+import { appriseClient } from "./apprise.js";
+import { resolvePrefs } from "./notification-prefs.js";
+import { safeFetch } from "./ssrf.js";
+import { telemetryLogger } from "./logger.js";
+import { scrubLogLines } from "../shared/log-scrub.js";
+import { SUPPORT_WORKER_URL } from "../shared/support-config.js";
+import type { InsertNotification } from "../shared/schema.js";
+
+const ERROR_REPORT_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes
+const LOG_CONTEXT_LINES = 150;
+const PENDING_REPORT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const WORKER_TIMEOUT_MS = 10_000;
+
+const { version: APP_VERSION } = JSON.parse(
+  readFileSync(path.resolve(process.cwd(), "package.json"), "utf-8")
+) as { version: string };
+
+export interface ErrorContext {
+  path?: string;
+  method?: string;
+  source: "uncaughtException" | "unhandledRejection" | "expressErrorHandler";
+}
+
+export interface PendingErrorReport {
+  logs: string;
+  lineCount: number;
+  appVersion: string;
+  platform: string;
+  timestamp: string;
+  createdAt: number;
+}
+
+let lastReportedAt = 0;
+const pendingReports = new Map<string, PendingErrorReport>();
+
+function purgeExpiredReports(): void {
+  const cutoff = Date.now() - PENDING_REPORT_TTL_MS;
+  for (const [id, report] of pendingReports) {
+    if (report.createdAt < cutoff) pendingReports.delete(id);
+  }
+}
+
+/** Used by GET /api/telemetry/pending/:reportId */
+export function getPendingReport(reportId: string): PendingErrorReport | undefined {
+  return pendingReports.get(reportId);
+}
+
+/** Used by POST /api/telemetry/pending/:reportId/send after a successful (or exhausted) attempt */
+export function deletePendingReport(reportId: string): void {
+  pendingReports.delete(reportId);
+}
+
+type WorkerSendResult =
+  { ok: true; code: string; issueNumber: number } | { ok: false; message: string };
+
+async function sendToSupportWorker(
+  logs: string,
+  reportType: "telemetry-auto" | "telemetry-prompted",
+  banner: string
+): Promise<WorkerSendResult> {
+  if (SUPPORT_WORKER_URL.includes("REPLACE_ME")) {
+    return { ok: false, message: "Log upload is not configured for this build." };
+  }
+
+  try {
+    const response = await safeFetch(SUPPORT_WORKER_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        logs: `${banner}\n\n${logs}`,
+        appVersion: APP_VERSION,
+        platform: "server",
+        timestamp: new Date().toISOString(),
+        reportType,
+      }),
+      timeoutMs: WORKER_TIMEOUT_MS,
+    });
+
+    if (!response.ok) {
+      return { ok: false, message: `Telemetry worker returned HTTP ${response.status}` };
+    }
+
+    const data = (await response.json()) as { code: string; issueNumber: number };
+    return { ok: true, code: data.code, issueNumber: data.issueNumber };
+  } catch (err) {
+    return {
+      ok: false,
+      message: err instanceof Error ? err.message : "Network error while sending telemetry report",
+    };
+  }
+}
+
+/** Sends the confirmed pending report (user clicked "Send" in SendErrorReportDialog). */
+export async function sendPendingReport(reportId: string): Promise<WorkerSendResult> {
+  const report = getPendingReport(reportId);
+  if (!report) {
+    return { ok: false, message: "This report is no longer available." };
+  }
+
+  const banner =
+    "=== QUESTARR AUTOMATED TELEMETRY REPORT (user-confirmed) ===\n" +
+    'Sent after the user clicked "Send" on an error-detected notification.';
+  const result = await sendToSupportWorker(report.logs, "telemetry-prompted", banner);
+  if (result.ok) deletePendingReport(reportId);
+  return result;
+}
+
+async function buildScrubbedLogBundle(): Promise<{ logs: string; lineCount: number }> {
+  try {
+    const logPath = path.resolve(process.cwd(), "server.log");
+    const lines = await readLastLogLines(logPath, LOG_CONTEXT_LINES);
+    return { logs: scrubLogLines(lines), lineCount: lines.length };
+  } catch (err) {
+    telemetryLogger.warn({ error: err }, "Failed to read server.log for error telemetry");
+    return { logs: "", lineCount: 0 };
+  }
+}
+
+/**
+ * Entry point called on every unhandled server error. Rate-limited by a single
+ * global cooldown (not per-error-signature) to keep this simple and avoid
+ * spamming users during a crash loop or a burst of related errors.
+ */
+export async function reportServerError(err: unknown, context: ErrorContext): Promise<void> {
+  const now = Date.now();
+  if (now - lastReportedAt < ERROR_REPORT_COOLDOWN_MS) {
+    return;
+  }
+  lastReportedAt = now;
+
+  try {
+    purgeExpiredReports();
+
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    const { logs, lineCount } = await buildScrubbedLogBundle();
+    const timestamp = new Date().toISOString();
+
+    const users = await storage.getAllUsers();
+    for (const user of users) {
+      try {
+        const settings = await storage.getUserSettings(user.id);
+        const prefs = resolvePrefs(settings);
+        if (!prefs.errorDetected.inApp) continue;
+
+        let notification: InsertNotification;
+
+        if (settings?.telemetryEnabled) {
+          const banner =
+            "=== QUESTARR AUTOMATED TELEMETRY REPORT (auto-sent, no user confirmation) ===\n" +
+            `Trigger: ${context.source}${context.path ? ` (${context.method} ${context.path})` : ""}\n` +
+            `Error: ${errorMessage}`;
+          const result = await sendToSupportWorker(logs, "telemetry-auto", banner);
+
+          notification = result.ok
+            ? {
+                userId: user.id,
+                type: "info",
+                title: "Automated error report sent",
+                message: `Questarr detected an error and automatically sent a diagnostic report. Support code: ${result.code}.`,
+              }
+            : {
+                userId: user.id,
+                type: "warning",
+                title: "Automated error report failed",
+                message: `Questarr detected an error but could not send the automatic diagnostic report (${result.message}).`,
+              };
+        } else {
+          const reportId = randomUUID();
+          pendingReports.set(reportId, {
+            logs,
+            lineCount,
+            appVersion: APP_VERSION,
+            platform: "server",
+            timestamp,
+            createdAt: now,
+          });
+
+          notification = {
+            userId: user.id,
+            type: "warning",
+            title: "An error occurred",
+            message:
+              "Questarr encountered an unexpected error. Click to review and optionally send a diagnostic report to help fix it.",
+            link: `error-report:${reportId}`,
+          };
+        }
+
+        const created = await storage.addNotification(notification);
+        notifyUser("notification", created);
+        if (prefs.errorDetected.apprise) appriseClient.send(created);
+      } catch (userError) {
+        telemetryLogger.error(
+          { error: userError, userId: user.id },
+          "Failed to process error telemetry for user"
+        );
+      }
+    }
+  } catch (reportingError) {
+    telemetryLogger.error({ error: reportingError }, "Failed to process automatic error report");
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,8 +16,34 @@ import { nexusmodsClient } from "./nexusmods.js";
 import { appriseClient, readAppriseSettings } from "./apprise.js";
 import { storage } from "./storage.js";
 import { platformMappingService } from "./services/index.js";
+import { reportServerError } from "./error-telemetry.js";
+import { logger } from "./logger.js";
 
 const app = createApp();
+
+// Best-effort error telemetry for crashes that never reach Express (startup code,
+// timers, unawaited promises, etc). This does NOT change Node's default crash
+// behavior: uncaughtException still terminates the process after we've had a
+// bounded window to report it, and unhandledRejection still just logs (as it did
+// before this handler existed — no handler here previously changed nothing).
+process.on("uncaughtException", (err) => {
+  logger.fatal({ err }, "Uncaught exception — process will exit");
+  Promise.race([
+    reportServerError(err, { source: "uncaughtException" }),
+    new Promise((resolve) => setTimeout(resolve, 5000)),
+  ])
+    .catch(() => {
+      // reportServerError already swallows its own errors; this is defensive only.
+    })
+    .finally(() => {
+      process.exit(1);
+    });
+});
+
+process.on("unhandledRejection", (reason) => {
+  logger.error({ err: reason }, "Unhandled promise rejection");
+  void reportServerError(reason, { source: "unhandledRejection" });
+});
 
 (async () => {
   try {

--- a/server/index.ts
+++ b/server/index.ts
@@ -22,14 +22,17 @@ import { logger } from "./logger.js";
 const app = createApp();
 
 // Best-effort error telemetry for crashes that never reach Express (startup code,
-// timers, unawaited promises, etc). This does NOT change Node's default crash
-// behavior: uncaughtException still terminates the process after we've had a
-// bounded window to report it, and unhandledRejection still just logs (as it did
-// before this handler existed — no handler here previously changed nothing).
-process.on("uncaughtException", (err) => {
-  logger.fatal({ err }, "Uncaught exception — process will exit");
+// timers, unawaited promises, etc). Both handlers keep Node's default fatal
+// behavior for these events — a bounded window to report the error, then
+// process.exit(1) — rather than letting the process linger in a decayed state.
+function handleFatalError(source: "uncaughtException" | "unhandledRejection", err: unknown): void {
+  const message =
+    source === "uncaughtException"
+      ? "Uncaught exception — process will exit"
+      : "Unhandled promise rejection — process will exit";
+  logger.fatal({ err }, message);
   Promise.race([
-    reportServerError(err, { source: "uncaughtException" }),
+    reportServerError(err, { source }),
     new Promise((resolve) => setTimeout(resolve, 5000)),
   ])
     .catch(() => {
@@ -38,12 +41,10 @@ process.on("uncaughtException", (err) => {
     .finally(() => {
       process.exit(1);
     });
-});
+}
 
-process.on("unhandledRejection", (reason) => {
-  logger.error({ err: reason }, "Unhandled promise rejection");
-  void reportServerError(reason, { source: "unhandledRejection" });
-});
+process.on("uncaughtException", (err) => handleFatalError("uncaughtException", err));
+process.on("unhandledRejection", (reason) => handleFatalError("unhandledRejection", reason));
 
 (async () => {
   try {

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -80,3 +80,4 @@ export const expressLogger = logger.child({ module: "express" });
 export const downloadersLogger = logger.child({ module: "downloaders" });
 export const torznabLogger = logger.child({ module: "torznab" });
 export const searchLogger = logger.child({ module: "search" });
+export const telemetryLogger = logger.child({ module: "telemetry" });

--- a/server/middleware.ts
+++ b/server/middleware.ts
@@ -4,6 +4,7 @@ import type { Request, Response, NextFunction } from "express";
 import { TORRENT_DOWNLOADER_TYPES, USENET_DOWNLOADER_TYPES } from "../shared/downloader-types.js";
 import { storage } from "./storage.js";
 import { expressLogger } from "./logger.js";
+import { reportServerError } from "./error-telemetry.js";
 
 const DOWNLOADER_TYPES = [...TORRENT_DOWNLOADER_TYPES, ...USENET_DOWNLOADER_TYPES];
 
@@ -532,6 +533,13 @@ export const errorHandler = (err: any, req: Request, res: Response, next: NextFu
   // Use error level for 5xx, warn/info for client errors
   if (status >= 500) {
     expressLogger.error({ err, path: req.path, method: req.method }, "Request error");
+    // Fire-and-forget: detect + report unhandled server errors for the automatic
+    // error-telemetry pipeline. Never let this delay or fail the response.
+    void reportServerError(err, {
+      source: "expressErrorHandler",
+      path: req.path,
+      method: req.method,
+    });
   } else {
     expressLogger.warn({ err, path: req.path, method: req.method }, "Request error");
   }

--- a/server/notification-prefs.ts
+++ b/server/notification-prefs.ts
@@ -1,0 +1,28 @@
+import { igdbLogger } from "./logger.js";
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  type NotificationPreferences,
+} from "../shared/schema.js";
+
+/**
+ * Parses a user's stored `notificationPreferences` JSON blob, falling back to
+ * `DEFAULT_NOTIFICATION_PREFERENCES` (merged in, so new event types added after a
+ * user's preferences were last saved still get a sane default) if missing/invalid.
+ *
+ * Shared between cron.ts (game/download/xREL/steam notifications) and
+ * error-telemetry.ts (automatic error-detected notifications).
+ */
+export function resolvePrefs(
+  settings: { notificationPreferences?: string | null } | null | undefined
+): NotificationPreferences {
+  if (!settings?.notificationPreferences) return DEFAULT_NOTIFICATION_PREFERENCES;
+  try {
+    return { ...DEFAULT_NOTIFICATION_PREFERENCES, ...JSON.parse(settings.notificationPreferences) };
+  } catch {
+    igdbLogger.warn(
+      { value: settings.notificationPreferences },
+      "Failed to parse notification preferences, using defaults"
+    );
+    return DEFAULT_NOTIFICATION_PREFERENCES;
+  }
+}

--- a/server/notification-prefs.ts
+++ b/server/notification-prefs.ts
@@ -20,7 +20,7 @@ export function resolvePrefs(
     return { ...DEFAULT_NOTIFICATION_PREFERENCES, ...JSON.parse(settings.notificationPreferences) };
   } catch {
     igdbLogger.warn(
-      { value: settings.notificationPreferences },
+      { length: settings.notificationPreferences?.length ?? 0 },
       "Failed to parse notification preferences, using defaults"
     );
     return DEFAULT_NOTIFICATION_PREFERENCES;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3466,32 +3466,50 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // ── Automatic error-telemetry routes ────────────────────────────────────────
   // Backs the consent flow opened from an "error-detected" notification's link
   // (`error-report:<reportId>`), see SendErrorReportDialog and error-telemetry.ts.
+  // Reports are scoped to the authenticated user: getPendingReport/sendPendingReport
+  // only return a report that belongs to req.user!.id.
 
-  app.get("/api/telemetry/pending/:reportId", authenticateToken, (req, res) => {
-    const report = getPendingReport(req.params.reportId);
-    if (!report) {
-      return res.status(404).json({ error: "This report is no longer available." });
-    }
-    res.json({
-      lineCount: report.lineCount,
-      appVersion: report.appVersion,
-      platform: report.platform,
-      timestamp: report.timestamp,
-    });
-  });
+  const telemetryReportIdValidation = [
+    param("reportId").trim().isUUID().withMessage("Invalid report ID format"),
+  ];
 
-  app.post("/api/telemetry/pending/:reportId/send", authenticateToken, async (req, res) => {
-    try {
-      const result = await sendPendingReport(req.params.reportId);
-      if (!result.ok) {
-        return res.status(422).json({ error: result.message });
+  app.get(
+    "/api/telemetry/pending/:reportId",
+    authenticateToken,
+    telemetryReportIdValidation,
+    validateRequest,
+    (req: Request, res: Response) => {
+      const report = getPendingReport(req.params.reportId, req.user!.id);
+      if (!report) {
+        return res.status(404).json({ error: "This report is no longer available." });
       }
-      res.json({ code: result.code, issueNumber: result.issueNumber });
-    } catch (error) {
-      routesLogger.error({ error }, "error sending pending telemetry report");
-      res.status(500).json({ error: "Failed to send diagnostic report" });
+      res.json({
+        lineCount: report.lineCount,
+        appVersion: report.appVersion,
+        platform: report.platform,
+        timestamp: report.timestamp,
+      });
     }
-  });
+  );
+
+  app.post(
+    "/api/telemetry/pending/:reportId/send",
+    authenticateToken,
+    telemetryReportIdValidation,
+    validateRequest,
+    async (req: Request, res: Response) => {
+      try {
+        const result = await sendPendingReport(req.params.reportId, req.user!.id);
+        if (!result.ok) {
+          return res.status(422).json({ error: result.message });
+        }
+        res.json({ code: result.code, issueNumber: result.issueNumber });
+      } catch (error) {
+        routesLogger.error({ error }, "error sending pending telemetry report");
+        res.status(500).json({ error: "Failed to send diagnostic report" });
+      }
+    }
+  );
 
   // IGDB Configuration endpoint
   app.get("/api/settings/igdb", sensitiveEndpointLimiter, async (req, res) => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -36,6 +36,7 @@ import { rssService } from "./rss.js";
 import { DownloaderManager } from "./downloaders.js";
 import { z } from "zod";
 import { routesLogger } from "./logger.js";
+import { getPendingReport, sendPendingReport } from "./error-telemetry.js";
 import {
   igdbRateLimiter,
   sensitiveEndpointLimiter,
@@ -3459,6 +3460,36 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       routesLogger.error({ error }, "error clearing notifications");
       res.status(500).json({ error: "Failed to clear notifications" });
+    }
+  });
+
+  // ── Automatic error-telemetry routes ────────────────────────────────────────
+  // Backs the consent flow opened from an "error-detected" notification's link
+  // (`error-report:<reportId>`), see SendErrorReportDialog and error-telemetry.ts.
+
+  app.get("/api/telemetry/pending/:reportId", authenticateToken, (req, res) => {
+    const report = getPendingReport(req.params.reportId);
+    if (!report) {
+      return res.status(404).json({ error: "This report is no longer available." });
+    }
+    res.json({
+      lineCount: report.lineCount,
+      appVersion: report.appVersion,
+      platform: report.platform,
+      timestamp: report.timestamp,
+    });
+  });
+
+  app.post("/api/telemetry/pending/:reportId/send", authenticateToken, async (req, res) => {
+    try {
+      const result = await sendPendingReport(req.params.reportId);
+      if (!result.ok) {
+        return res.status(422).json({ error: result.message });
+      }
+      res.json({ code: result.code, issueNumber: result.issueNumber });
+    } catch (error) {
+      routesLogger.error({ error }, "error sending pending telemetry report");
+      res.status(500).json({ error: "Failed to send diagnostic report" });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1135,6 +1135,7 @@ export class MemStorage implements IStorage {
       preferredPlatform: insertSettings.preferredPlatform ?? null,
       hideAdultContent: insertSettings.hideAdultContent ?? true,
       hideAgeRestrictedContent: insertSettings.hideAgeRestrictedContent ?? true,
+      telemetryEnabled: insertSettings.telemetryEnabled ?? false,
       updatedAt: new Date(),
     };
     this.userSettings.set(id, settings);

--- a/shared/log-scrub.ts
+++ b/shared/log-scrub.ts
@@ -1,0 +1,148 @@
+/**
+ * PII scrubbing for log content, shared between the client (manual "Send Logs" flow)
+ * and the server (automatic error-telemetry flow).
+ *
+ * Patterns cover what shows up in Questarr's log fields:
+ *  - Email addresses   (e.g. auth logs, Steam import errors)
+ *  - IPv4/IPv6         (e.g. express access logs, socket connections)
+ *  - UUIDs             (e.g. socket IDs formatted as UUIDs, download hashes)
+ *  - JWT tokens        (defensive — tokens should never be logged)
+ *  - OS home-dir paths (e.g. /home/alice/… or C:\Users\alice\…)
+ */
+
+// ── PII patterns ──────────────────────────────────────────────────────────────
+
+/** IPv4 candidates are validated after matching to keep the regex maintainable */
+const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
+
+/** IPv6 candidates are validated after matching to avoid an overly complex regex */
+const IPV6_RE = /(?<![A-Fa-f0-9:])[A-Fa-f0-9:]{2,}(?![A-Fa-f0-9:])/g;
+
+/** RFC-4122 UUID */
+const UUID_RE = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/g;
+
+/** JWT (three base64url segments starting with eyJ…) */
+const JWT_RE = /eyJ[A-Za-z0-9+/=_-]+\.eyJ[A-Za-z0-9+/=_-]+\.[A-Za-z0-9+/=_-]+/g;
+
+/**
+ * Unix home dir:   /home/alice/… or /Users/alice/…
+ * Windows home dir: C:\Users\alice\… (backslash or forward slash)
+ */
+const HOME_PATH_RE = /(?:\/(?:home|Users)|[A-Za-z]:\\[Uu]sers)[\\/]([^\\/\s"',:}]{1,64})/g;
+const WINDOWS_USERS_SEGMENT = String.raw`\Users`;
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Replace PII in a single log string (raw NDJSON line or plain text).
+ * Each regex is applied independently so replacements don't interfere.
+ */
+export function scrubPii(text: string): string {
+  return scrubEmailAddresses(text)
+    .replace(JWT_RE, "[jwt]") // before email — JWTs contain dots
+    .replace(IPV6_RE, (match) => (isIpv6(match) ? "[ip]" : match))
+    .replace(IPV4_RE, (match) => (isIpv4(match) ? "[ip]" : match))
+    .replace(UUID_RE, "[uuid]")
+    .replace(HOME_PATH_RE, (_match, _username: string) => {
+      const prefix = _match.startsWith("/")
+        ? "/home"
+        : _match.substring(0, 2) + WINDOWS_USERS_SEGMENT;
+      const sep = _match.includes("\\") ? "\\" : "/";
+      return `${prefix}${sep}[user]`;
+    });
+}
+
+function scrubEmailAddresses(text: string): string {
+  let result = "";
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const atIndex = text.indexOf("@", cursor);
+    if (atIndex === -1) {
+      result += text.slice(cursor);
+      break;
+    }
+
+    let start = atIndex - 1;
+    while (start >= cursor && isEmailLocalChar(text[start])) {
+      start--;
+    }
+
+    let end = atIndex + 1;
+    while (end < text.length && isEmailDomainChar(text[end])) {
+      end++;
+    }
+
+    const candidate = text.slice(start + 1, end);
+    if (isLikelyEmail(candidate)) {
+      result += text.slice(cursor, start + 1);
+      result += "[email]";
+      cursor = end;
+      continue;
+    }
+
+    result += text.slice(cursor, atIndex + 1);
+    cursor = atIndex + 1;
+  }
+
+  return result;
+}
+
+function isEmailLocalChar(char: string): boolean {
+  return /[A-Za-z0-9._%+-]/.test(char);
+}
+
+function isEmailDomainChar(char: string): boolean {
+  return /[A-Za-z0-9.-]/.test(char);
+}
+
+function isLikelyEmail(candidate: string): boolean {
+  const atIndex = candidate.indexOf("@");
+  if (atIndex <= 0 || atIndex !== candidate.lastIndexOf("@")) return false;
+
+  const domain = candidate.slice(atIndex + 1);
+  if (!domain || domain.startsWith(".") || domain.endsWith(".")) return false;
+
+  const labels = domain.split(".");
+  if (labels.length < 2) return false;
+
+  return labels.every(
+    (label) =>
+      label.length > 0 &&
+      !label.startsWith("-") &&
+      !label.endsWith("-") &&
+      /^[A-Za-z0-9-]+$/.test(label)
+  );
+}
+
+/**
+ * Scrub all lines and join them back into a newline-delimited string.
+ */
+export function scrubLogLines(lines: string[]): string {
+  return lines.map(scrubPii).join("\n");
+}
+
+function isIpv4(value: string): boolean {
+  const octets = value.split(".");
+  return (
+    octets.length === 4 &&
+    octets.every((octet) => {
+      if (!/^\d{1,3}$/.test(octet)) return false;
+      const parsed = Number(octet);
+      return parsed >= 0 && parsed <= 255;
+    })
+  );
+}
+
+function isIpv6(value: string): boolean {
+  if (!value.includes(":")) return false;
+
+  const compressedGroups = value.split("::");
+  if (compressedGroups.length > 2) return false;
+
+  const groups = value.split(":");
+  if (groups.length < 3 || groups.length > 8) return false;
+  if (compressedGroups.length === 1 && groups.length !== 8) return false;
+
+  return groups.every((group) => group === "" || /^[0-9a-fA-F]{1,4}$/.test(group));
+}

--- a/shared/log-scrub.ts
+++ b/shared/log-scrub.ts
@@ -28,7 +28,7 @@ const JWT_RE = /eyJ[A-Za-z0-9+/=_-]+\.eyJ[A-Za-z0-9+/=_-]+\.[A-Za-z0-9+/=_-]+/g;
  * Unix home dir:   /home/alice/… or /Users/alice/…
  * Windows home dir: C:\Users\alice\… (backslash or forward slash)
  */
-const HOME_PATH_RE = /(?:\/(?:home|Users)|[A-Za-z]:\\[Uu]sers)[\\/]([^\\/\s"',:}]{1,64})/g;
+const HOME_PATH_RE = /(?:\/(?:home|Users)|[A-Za-z]:[\\/][Uu]sers)[\\/]([^\\/\s"',:}]{1,64})/g;
 const WINDOWS_USERS_SEGMENT = String.raw`\Users`;
 
 // ── Public API ────────────────────────────────────────────────────────────────

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -72,6 +72,9 @@ export const userSettings = sqliteTable("user_settings", {
     .notNull()
     .default(false),
   sortExtras: integer("sort_extras", { mode: "boolean" }).notNull().default(false),
+  // Telemetry: opt-in, off by default. When enabled, automatically-detected server
+  // errors are sent as a diagnostic report without prompting (see server/error-telemetry.ts).
+  telemetryEnabled: integer("telemetry_enabled", { mode: "boolean" }).notNull().default(false),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }).default(
     sql`(strftime('%s', 'now') * 1000)`
   ),
@@ -570,7 +573,8 @@ export type NotificationEvent =
   | "multipleResults"
   | "gameUpdates"
   | "xrelRelease"
-  | "steamSync";
+  | "steamSync"
+  | "errorDetected";
 
 export type NotificationPreferences = Record<
   NotificationEvent,
@@ -588,6 +592,7 @@ export const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferences = {
   gameUpdates: { inApp: true, apprise: true },
   xrelRelease: { inApp: true, apprise: true },
   steamSync: { inApp: true, apprise: false },
+  errorDetected: { inApp: true, apprise: false },
 };
 
 export interface DownloadSummary {


### PR DESCRIPTION
## Description

When an unhandled server error occurs (uncaught exceptions, unhandled promise rejections, or a 5xx response from the global Express error handler), Questarr now notifies the user and lets them send a diagnostic report using the same support-log service that already backs the manual "Send Logs" button on the Logs page.

- **New "Error Detected" notification type**, toggleable exactly like every other notification event (in-app / Apprise, Settings → Notifications).
- **New "Telemetry" setting** (Settings → System), **off by default**: when enabled, detected errors are reported automatically without prompting. When off, an "An error occurred" notification asks for consent per incident, opening a new `SendErrorReportDialog`.
- Once a report is sent (or the notification is otherwise clicked), it's marked read like any other notification, so it doesn't keep re-prompting for the same incident. A 30-minute global cooldown additionally prevents notification/telemetry spam during a crash loop or burst of related errors.
- Reports sent through this automatic pipeline are tagged as automated telemetry — a clear banner in the log content plus a `reportType` field (`telemetry-auto` / `telemetry-prompted`) — so they read differently from a manually submitted log bundle, without requiring any change to the external log-collector Cloudflare Worker (which lives outside this repo).
- PII-scrubbing logic (`scrubPii`/`scrubLogLines`) moved to `shared/log-scrub.ts` so both the existing client-side manual flow and the new server-side automatic flow use identical rules.

### Known limitation
A distinct **GitHub label** for automatic reports would require updating the external `questarr-log-collector` Worker (not part of this repo). The `reportType` field and content banner are ready for the Worker to use for that once it's updated separately.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`docs/API.md`)
- [x] I have added tests that prove my fix is effective or that my feature works (`server/__tests__/error_telemetry.test.ts`)
- [x] New and existing unit tests pass locally with my changes (2086 tests passing)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013FZiZBCqd4VQSWdqNy1wzG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added opt-in error telemetry for server-detected errors.
  - Added notifications and a consent dialog for reviewing and sending diagnostic reports.
  - Added telemetry controls and error notification preferences in Settings.
  - Reports automatically scrub sensitive information and expire after 24 hours.
  - Added support codes and optional issue-reporting actions after submission.
  - Added automatic reporting when telemetry is enabled.

- **Documentation**
  - Documented the telemetry consent flow and API endpoints.

- **Bug Fixes**
  - Improved notification preference handling and error-report delivery reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->