### PR TITLE
Raise the Logs page history limit from 200 to 1000 lines

### DIFF
--- a/client/src/pages/logs.tsx
+++ b/client/src/pages/logs.tsx
@@ -56,7 +56,7 @@ const LEVEL_MAP: Record<number, { label: string; className: string }> = {
   60: { label: "FATAL", className: "bg-red-900 text-red-100" },
 };
 
-const MAX_LINES = 2000;
+const MAX_LINES = 5000;
 const ROW_HEIGHT = 32;
 const OVERSCAN_ROWS = 10;
 const DEFAULT_VIEWPORT_HEIGHT = 400;
@@ -488,7 +488,7 @@ export default function LogsPage() {
   const { data: initialData, isLoading } = useQuery<{ lines: string[] }>({
     queryKey: ["/api/logs"],
     queryFn: async () => {
-      const res = await apiRequest("GET", "/api/logs?limit=200");
+      const res = await apiRequest("GET", "/api/logs?limit=1000");
       return res.json();
     },
     staleTime: Infinity,

--- a/server/__tests__/api_routes_extended.test.ts
+++ b/server/__tests__/api_routes_extended.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import express from "express";
 import request from "supertest";
+import fs from "fs";
 import {
   mockConfig,
   createStorageMock,
@@ -27,8 +28,10 @@ import { torznabClient } from "../torznab.js";
 import { newznabClient } from "../newznab.js";
 import { DownloaderManager } from "../downloaders.js";
 import { xrelClient } from "../xrel.js";
+import { readLastLogLines } from "../log-file.js";
 import type { Downloader, Indexer, Game } from "../../shared/schema.js";
 
+vi.mock("../log-file.js", () => ({ readLastLogLines: vi.fn().mockResolvedValue([]) }));
 vi.mock("../storage.js", () => ({ storage: createStorageMock() }));
 vi.mock("../igdb.js", () => ({ igdbClient: createIgdbMock() }));
 vi.mock("../auth.js", () => createAuthMock());
@@ -351,16 +354,46 @@ describe("API Routes - Additional Coverage", () => {
   });
 
   describe("GET /api/logs", () => {
-    it("returns a lines array", async () => {
-      const res = await request(app).get("/api/logs");
-      expect(res.status).toBe(200);
-      expect(Array.isArray(res.body.lines)).toBe(true);
+    let statSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      statSpy = vi.spyOn(fs.promises, "stat").mockResolvedValue({ size: 1 } as fs.Stats);
+      vi.mocked(readLastLogLines).mockResolvedValue([]);
     });
 
-    it("clamps an out-of-range limit query param", async () => {
+    afterEach(() => {
+      statSpy.mockRestore();
+    });
+
+    it("returns a lines array", async () => {
+      vi.mocked(readLastLogLines).mockResolvedValue(["line one", "line two"]);
+      const res = await request(app).get("/api/logs");
+      expect(res.status).toBe(200);
+      expect(res.body.lines).toEqual(["line one", "line two"]);
+    });
+
+    it("defaults to a 1000-line limit when none is provided", async () => {
+      const res = await request(app).get("/api/logs");
+      expect(res.status).toBe(200);
+      expect(readLastLogLines).toHaveBeenCalledWith(expect.stringContaining("server.log"), 1000);
+    });
+
+    it("honors an explicit limit within range", async () => {
+      const res = await request(app).get("/api/logs?limit=3000");
+      expect(res.status).toBe(200);
+      expect(readLastLogLines).toHaveBeenCalledWith(expect.stringContaining("server.log"), 3000);
+    });
+
+    it("clamps an out-of-range limit query param to the 5000-line maximum", async () => {
       const res = await request(app).get("/api/logs?limit=99999");
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body.lines)).toBe(true);
+      expect(readLastLogLines).toHaveBeenCalledWith(expect.stringContaining("server.log"), 5000);
+    });
+
+    it("falls back to the default limit for a non-numeric limit value", async () => {
+      const res = await request(app).get("/api/logs?limit=not-a-number");
+      expect(res.status).toBe(200);
+      expect(readLastLogLines).toHaveBeenCalledWith(expect.stringContaining("server.log"), 1000);
     });
   });
 

--- a/server/__tests__/api_routes_extended.test.ts
+++ b/server/__tests__/api_routes_extended.test.ts
@@ -358,7 +358,7 @@ describe("API Routes - Additional Coverage", () => {
 
     beforeEach(() => {
       statSpy = vi.spyOn(fs.promises, "stat").mockResolvedValue({ size: 1 } as fs.Stats);
-      vi.mocked(readLastLogLines).mockResolvedValue([]);
+      vi.mocked(readLastLogLines).mockClear().mockResolvedValue([]);
     });
 
     afterEach(() => {

--- a/server/__tests__/api_routes_extended.test.ts
+++ b/server/__tests__/api_routes_extended.test.ts
@@ -372,28 +372,24 @@ describe("API Routes - Additional Coverage", () => {
       expect(res.body.lines).toEqual(["line one", "line two"]);
     });
 
-    it("defaults to a 1000-line limit when none is provided", async () => {
-      const res = await request(app).get("/api/logs");
+    it.each([
+      { desc: "no limit provided defaults to 1000", queryLimit: undefined, expectedLimit: 1000 },
+      { desc: "an in-range limit is honored", queryLimit: "3000", expectedLimit: 3000 },
+      { desc: "an out-of-range limit clamps to 5000", queryLimit: "99999", expectedLimit: 5000 },
+      {
+        desc: "a non-numeric limit falls back to 1000",
+        queryLimit: "not-a-number",
+        expectedLimit: 1000,
+      },
+    ])("$desc", async ({ queryLimit, expectedLimit }) => {
+      const res = await request(app).get(
+        queryLimit === undefined ? "/api/logs" : `/api/logs?limit=${queryLimit}`
+      );
       expect(res.status).toBe(200);
-      expect(readLastLogLines).toHaveBeenCalledWith(expect.stringContaining("server.log"), 1000);
-    });
-
-    it("honors an explicit limit within range", async () => {
-      const res = await request(app).get("/api/logs?limit=3000");
-      expect(res.status).toBe(200);
-      expect(readLastLogLines).toHaveBeenCalledWith(expect.stringContaining("server.log"), 3000);
-    });
-
-    it("clamps an out-of-range limit query param to the 5000-line maximum", async () => {
-      const res = await request(app).get("/api/logs?limit=99999");
-      expect(res.status).toBe(200);
-      expect(readLastLogLines).toHaveBeenCalledWith(expect.stringContaining("server.log"), 5000);
-    });
-
-    it("falls back to the default limit for a non-numeric limit value", async () => {
-      const res = await request(app).get("/api/logs?limit=not-a-number");
-      expect(res.status).toBe(200);
-      expect(readLastLogLines).toHaveBeenCalledWith(expect.stringContaining("server.log"), 1000);
+      expect(readLastLogLines).toHaveBeenCalledWith(
+        expect.stringContaining("server.log"),
+        expectedLimit
+      );
     });
   });
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -523,8 +523,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/logs", authenticateToken, async (req, res) => {
     try {
       const rawLimit =
-        typeof req.query.limit === "string" ? Number.parseInt(req.query.limit, 10) : 200;
-      const limit = Number.isNaN(rawLimit) || rawLimit < 1 ? 200 : Math.min(rawLimit, 1000);
+        typeof req.query.limit === "string" ? Number.parseInt(req.query.limit, 10) : 1000;
+      const limit = Number.isNaN(rawLimit) || rawLimit < 1 ? 1000 : Math.min(rawLimit, 5000);
 
       const logPath = path.resolve(process.cwd(), "server.log");
 


### PR DESCRIPTION
## Description

The Logs page only ever loaded/kept the last 200 lines of server history, which was often too short to see enough context around an error. This raises that limit.

- `GET /api/logs`: default `limit` raised from 200 to 1000; the max allowed value raised from 1000 to 5000. It's still a bounded, chunked backward read (`readLastLogLines`), so this stays cheap even at the new cap.
- Logs page: the initial page-load fetch now requests 1000 lines instead of 200. The client-side rolling buffer that live-streamed lines get appended to (`MAX_LINES`) is raised from 2000 to 5000 to match, so the live view can hold as much history as a fresh page load provides.
- The log list was already manually virtualized (windowed rendering by scroll position), so this doesn't introduce a rendering-performance regression on desktop. The existing mobile render cap (200 rows shown at once on mobile) is untouched — that's a separate rendering safeguard, not the history limit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes (2079 tests passing)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013FZiZBCqd4VQSWdqNy1wzG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Log views now load up to 1,000 lines initially, providing more context without additional requests.
  * Streaming logs can retain up to 5,000 lines, allowing longer-running activity to remain visible.
  * Log retrieval supports requests for up to 5,000 lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->