### PR TITLE
Fix TS2554 typecheck failure in SendErrorReportDialog

### DIFF
--- a/client/src/components/SendErrorReportDialog.tsx
+++ b/client/src/components/SendErrorReportDialog.tsx
@@ -127,7 +127,8 @@ export default function SendErrorReportDialog({
       });
   }, [result, toast]);
 
-  const issueUrl = result && meta ? buildGitHubIssueUrl(result.code, meta.appVersion) : null;
+  const issueUrl =
+    result && meta ? buildGitHubIssueUrl(result.code, meta.appVersion, result.issueNumber) : null;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>


### PR DESCRIPTION
# Pull Request _Template_

## Description

CI was failing on `main` (`npm run check`) with:

```
client/src/components/SendErrorReportDialog.tsx(130,37): error TS2554: Expected 3 arguments, but got 2.
```

`buildGitHubIssueUrl` (in `client/src/lib/send-logs.ts`) requires a third `issueNumber` argument to build the cross-repo issue reference, but the call site in `SendErrorReportDialog.tsx` only passed `code` and `appVersion`. The server's `SendSuccess` response already includes `issueNumber`, so this just passes it through.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`npm run check`, `npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NatVQzg19RxyWDXHqkCh9F)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error report links by including the associated issue number when creating a GitHub issue.
  * Preserved existing conditions for displaying the “Create GitHub issue” button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->