### PR TITLE
Fix import modeUsed reporting only the last per-file fallback

### DIFF
--- a/server/__tests__/import_strategies.test.ts
+++ b/server/__tests__/import_strategies.test.ts
@@ -251,12 +251,14 @@ describe("ImportStrategies", () => {
       await fs.writeFile(path.join(sourceDir, "Game DLC Pack.nsp"), "dlc");
 
       // Only the DLC file's hardlink fails; the base game file hardlinks fine.
-      vi.spyOn(fs, "link").mockImplementation(async (src) => {
+      const originalLink = fs.link.bind(fs);
+      vi.spyOn(fs, "link").mockImplementation(async (src, dest) => {
         if (String(src).endsWith("Game DLC Pack.nsp")) {
           const err: NodeJS.ErrnoException = new Error("cross-device");
           err.code = "EXDEV";
           throw err;
         }
+        return originalLink(src, dest);
       });
 
       const strategy = new PCImportStrategy();
@@ -279,6 +281,7 @@ describe("ImportStrategies", () => {
       expect(result.modeUsed).toBe("hardlink");
       expect(result.conflictsResolved).toEqual(["Game DLC Pack.nsp (mode fallback: copy)"]);
       expect(await fs.pathExists(path.join(destination, "dlc", "Game DLC Pack.nsp"))).toBe(true);
+      expect(await fs.pathExists(path.join(destination, "game.exe"))).toBe(true);
     });
 
     it("keeps the existing flat destination for a single file when sorting is enabled", async () => {

--- a/server/__tests__/import_strategies.test.ts
+++ b/server/__tests__/import_strategies.test.ts
@@ -281,7 +281,13 @@ describe("ImportStrategies", () => {
       expect(result.modeUsed).toBe("hardlink");
       expect(result.conflictsResolved).toEqual(["Game DLC Pack.nsp (mode fallback: copy)"]);
       expect(await fs.pathExists(path.join(destination, "dlc", "Game DLC Pack.nsp"))).toBe(true);
-      expect(await fs.pathExists(path.join(destination, "game.exe"))).toBe(true);
+
+      // Confirm the base game file is an actual hardlink (same inode), not
+      // merely a file that happens to exist at the destination.
+      const sourceStat = await fs.stat(path.join(sourceDir, "game.exe"));
+      const destStat = await fs.stat(path.join(destination, "game.exe"));
+      expect(destStat.ino).toBe(sourceStat.ino);
+      expect(destStat.dev).toBe(sourceStat.dev);
     });
 
     it("keeps the existing flat destination for a single file when sorting is enabled", async () => {

--- a/server/__tests__/import_strategies.test.ts
+++ b/server/__tests__/import_strategies.test.ts
@@ -242,6 +242,45 @@ describe("ImportStrategies", () => {
       expect(await fs.pathExists(path.join(destination, "dlc", "Game DLC Pack.nsp"))).toBe(false);
     });
 
+    it("reports the requested batch mode even when a single file falls back", async () => {
+      const root = tempDir();
+      const sourceDir = path.join(root, "downloads", "game-folder");
+      const destination = path.join(root, "library", "PC", "My Game");
+      await fs.ensureDir(sourceDir);
+      await fs.writeFile(path.join(sourceDir, "game.exe"), "main");
+      await fs.writeFile(path.join(sourceDir, "Game DLC Pack.nsp"), "dlc");
+
+      // Only the DLC file's hardlink fails; the base game file hardlinks fine.
+      vi.spyOn(fs, "link").mockImplementation(async (src) => {
+        if (String(src).endsWith("Game DLC Pack.nsp")) {
+          const err: NodeJS.ErrnoException = new Error("cross-device");
+          err.code = "EXDEV";
+          throw err;
+        }
+      });
+
+      const strategy = new PCImportStrategy();
+      const result = await strategy.executeImport(
+        {
+          needsReview: false,
+          originalPath: sourceDir,
+          proposedPath: destination,
+          strategy: "pc",
+          fileCategories: [
+            { name: "game.exe", category: "main" },
+            { name: "Game DLC Pack.nsp", category: "dlc" },
+          ],
+        },
+        "hardlink"
+      );
+
+      // modeUsed reflects the requested batch mode, not just the last file's
+      // fallback; the per-file fallback is still visible in conflictsResolved.
+      expect(result.modeUsed).toBe("hardlink");
+      expect(result.conflictsResolved).toEqual(["Game DLC Pack.nsp (mode fallback: copy)"]);
+      expect(await fs.pathExists(path.join(destination, "dlc", "Game DLC Pack.nsp"))).toBe(true);
+    });
+
     it("keeps the existing flat destination for a single file when sorting is enabled", async () => {
       const root = tempDir();
       const source = path.join(root, "downloads", "game.exe");

--- a/server/services/ImportStrategies.ts
+++ b/server/services/ImportStrategies.ts
@@ -208,7 +208,10 @@ export class PCImportStrategy implements ImportStrategy {
     if (review.fileCategories && review.fileCategories.length > 0) {
       const filesPlaced: string[] = [];
       const conflictsResolved: string[] = [];
-      let modeUsed: TransferMode = transferMode;
+      // Keep modeUsed as the originally-requested batch mode: a per-file fallback
+      // (e.g. hardlink -> copy for one file among many) is recorded per-entry in
+      // conflictsResolved instead, so it isn't lost by being overwritten here.
+      const modeUsed: TransferMode = transferMode;
 
       const plannedTransfers = review.fileCategories.map((entry) => ({
         entry,
@@ -234,7 +237,6 @@ export class PCImportStrategy implements ImportStrategy {
         const entryMode = await transferFile(sourceFile, destinationFile, transferMode);
         filesPlaced.push(destinationFile);
         if (entryMode !== transferMode) {
-          modeUsed = entryMode;
           conflictsResolved.push(`${entry.name} (mode fallback: ${entryMode})`);
         }
       }


### PR DESCRIPTION
# Pull Request _Template_

## Description

`PCImportStrategy.executeImport()` overwrote `modeUsed` on every per-file hardlink→copy fallback during a categorized (sortExtras) import, so `ImportResult.modeUsed` reflected only the *last* file that needed a fallback instead of the batch as a whole — e.g. if file 1 of 10 fell back from `hardlink` to `copy` but the remaining 9 hardlinked successfully, the result still reported `modeUsed: "copy"` for the whole import, which can mislead any UI/log consumer about how the import actually ran.

This keeps `modeUsed` as the originally-requested batch transfer mode; each per-file fallback is still recorded individually in `conflictsResolved`, so no information is lost.

This was flagged in review on #877 (`server/services/ImportStrategies.ts` — non-blocking efficiency/accuracy nit). That PR is otherwise superseded: the `sortExtras` feature it implemented was independently merged via #891 before #877 could be rebased, so #877 is being closed as a duplicate rather than merged. This PR carries forward the one genuine improvement from it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batch imports now consistently report the originally selected transfer mode, even when individual files require a fallback.
  * Fallback transfer details remain accurately recorded for affected files.

* **Tests**
  * Added coverage for mixed transfer outcomes within a batch hardlink import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->