### PR TITLE
Port 3 import/download bug fixes from Adarack fork

### DIFF
--- a/client/__tests__/LinkGameModal.test.tsx
+++ b/client/__tests__/LinkGameModal.test.tsx
@@ -147,4 +147,23 @@ describe("LinkGameModal", () => {
     );
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
+
+  it("resets search and selection when the dialog is dismissed via its own close control", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      createJsonResponse([{ id: "g1", title: "Chrono Trigger", coverUrl: null }])
+    );
+
+    const { onOpenChange } = renderModal();
+
+    const searchInput = screen.getByLabelText("Search your library") as HTMLInputElement;
+    fireEvent.change(searchInput, { target: { value: "chrono" } });
+    fireEvent.click(await screen.findByText("Chrono Trigger"));
+
+    // Radix's own dismiss path (its built-in close button / Escape), distinct
+    // from our own Cancel button's onClick.
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(searchInput.value).toBe("");
+  });
 });

--- a/client/__tests__/LinkGameModal.test.tsx
+++ b/client/__tests__/LinkGameModal.test.tsx
@@ -1,0 +1,87 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LinkGameModal from "../src/components/LinkGameModal";
+import { createTestQueryClient, getRequestUrl } from "./test-utils";
+
+const { mockToast } = vi.hoisted(() => ({
+  mockToast: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+function createJsonResponse(data: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => data,
+  } as Response;
+}
+
+function renderModal(onOpenChange = vi.fn()) {
+  const client = createTestQueryClient();
+  const invalidateQueries = vi.spyOn(client, "invalidateQueries");
+  render(
+    <QueryClientProvider client={client}>
+      <LinkGameModal
+        open
+        onOpenChange={onOpenChange}
+        downloadId="dl-1"
+        downloadTitle="Orphaned.Release-GROUP"
+      />
+    </QueryClientProvider>
+  );
+  return { onOpenChange, invalidateQueries };
+}
+
+describe("LinkGameModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists the user's games and links the selected one on confirm", async () => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const href = getRequestUrl(url);
+      if (href.startsWith("/api/games")) {
+        return createJsonResponse([
+          { id: "g1", title: "Chrono Trigger", coverUrl: null },
+          { id: "g2", title: "Chrono Cross", coverUrl: null },
+        ]);
+      }
+      if (href.includes("/api/imports/dl-1/link") && init?.method === "POST") {
+        expect(JSON.parse(init.body as string)).toEqual({ gameId: "g1" });
+        return createJsonResponse({ success: true });
+      }
+      return createJsonResponse({});
+    });
+
+    const { onOpenChange, invalidateQueries } = renderModal();
+
+    expect(await screen.findByText("Chrono Trigger")).toBeInTheDocument();
+    expect(screen.getByText("Chrono Cross")).toBeInTheDocument();
+
+    // Link button starts disabled until a game is selected.
+    expect(screen.getByRole("button", { name: "Link Game" })).toBeDisabled();
+
+    fireEvent.click(screen.getByText("Chrono Trigger"));
+    expect(screen.getByRole("button", { name: "Link Game" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Link Game" }));
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["/api/imports/pending"] });
+  });
+
+  it("shows an empty state when the search returns no games", async () => {
+    globalThis.fetch = vi.fn(async () => createJsonResponse([]));
+
+    renderModal();
+
+    expect(await screen.findByText(/No games found\. Try a different search/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Link Game" })).toBeDisabled();
+  });
+});

--- a/client/__tests__/LinkGameModal.test.tsx
+++ b/client/__tests__/LinkGameModal.test.tsx
@@ -19,6 +19,7 @@ function createJsonResponse(data: unknown, ok = true): Response {
   return {
     ok,
     json: async () => data,
+    text: async () => JSON.stringify(data),
   } as Response;
 }
 
@@ -83,5 +84,67 @@ describe("LinkGameModal", () => {
 
     expect(await screen.findByText(/No games found\. Try a different search/)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Link Game" })).toBeDisabled();
+  });
+
+  it("clears the selection when the search text changes", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      createJsonResponse([{ id: "g1", title: "Chrono Trigger", coverUrl: null }])
+    );
+
+    renderModal();
+
+    fireEvent.click(await screen.findByText("Chrono Trigger"));
+    expect(screen.getByRole("button", { name: "Link Game" })).toBeEnabled();
+
+    fireEvent.change(screen.getByLabelText("Search your library"), {
+      target: { value: "chrono" },
+    });
+
+    expect(screen.getByRole("button", { name: "Link Game" })).toBeDisabled();
+  });
+
+  it("resets search and selection and calls onOpenChange when Cancel is clicked", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      createJsonResponse([{ id: "g1", title: "Chrono Trigger", coverUrl: null }])
+    );
+
+    const { onOpenChange } = renderModal();
+
+    fireEvent.change(screen.getByLabelText("Search your library"), {
+      target: { value: "chrono" },
+    });
+    fireEvent.click(await screen.findByText("Chrono Trigger"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows an error toast and stays open when linking fails", async () => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const href = getRequestUrl(url);
+      if (href.startsWith("/api/games")) {
+        return createJsonResponse([{ id: "g1", title: "Chrono Trigger", coverUrl: null }]);
+      }
+      if (href.includes("/api/imports/dl-1/link") && init?.method === "POST") {
+        return createJsonResponse({ error: "Download not found" }, false);
+      }
+      return createJsonResponse({});
+    });
+
+    const { onOpenChange } = renderModal();
+
+    fireEvent.click(await screen.findByText("Chrono Trigger"));
+    fireEvent.click(screen.getByRole("button", { name: "Link Game" }));
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Failed to Link Game",
+          variant: "destructive",
+        })
+      )
+    );
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 });

--- a/client/__tests__/PendingImportsCard.test.tsx
+++ b/client/__tests__/PendingImportsCard.test.tsx
@@ -1,18 +1,29 @@
 /** @vitest-environment jsdom */
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import PendingImportsCard from "../src/components/PendingImportsCard";
 import { createTestQueryClient, getRequestUrl } from "./test-utils";
 
+const { mockImportReviewModal, mockLinkGameModal } = vi.hoisted(() => ({
+  mockImportReviewModal: vi.fn(),
+  mockLinkGameModal: vi.fn(),
+}));
+
 vi.mock("../src/components/ImportReviewModal", () => ({
-  default: () => null,
+  default: (props: Record<string, unknown>) => {
+    mockImportReviewModal(props);
+    return <div data-testid="import-review-modal" />;
+  },
 }));
 vi.mock("../src/components/LinkGameModal", () => ({
-  default: () => null,
+  default: (props: Record<string, unknown>) => {
+    mockLinkGameModal(props);
+    return <div data-testid="link-game-modal" />;
+  },
 }));
 
 function createJsonResponse(data: unknown): Response {
@@ -31,6 +42,11 @@ function renderCard() {
 }
 
 describe("PendingImportsCard", () => {
+  beforeEach(() => {
+    mockImportReviewModal.mockClear();
+    mockLinkGameModal.mockClear();
+  });
+
   it("renders nothing when there are no pending imports", async () => {
     const fetchMock = vi.fn(async () => createJsonResponse([]));
     globalThis.fetch = fetchMock;
@@ -64,7 +80,15 @@ describe("PendingImportsCard", () => {
 
     expect(await screen.findByText("My Game")).toBeInTheDocument();
     expect(screen.getByText("Import failed: disk full")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Review" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Review" }));
+
+    expect(screen.getByTestId("import-review-modal")).toBeInTheDocument();
+    expect(screen.queryByTestId("link-game-modal")).not.toBeInTheDocument();
+    expect(mockImportReviewModal).toHaveBeenCalledWith(
+      expect.objectContaining({ downloadId: "dl-1", open: true })
+    );
+    expect(mockLinkGameModal).not.toHaveBeenCalled();
   });
 
   it("offers a Link Game action for a download whose game record is missing", async () => {
@@ -95,7 +119,22 @@ describe("PendingImportsCard", () => {
       await screen.findByText("This download's linked game could not be found")
     ).toBeInTheDocument();
     expect(screen.getAllByText("Orphaned.Release-GROUP")).toHaveLength(2);
-    expect(screen.getByRole("button", { name: "Link Game" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Review" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Link Game" }));
+
+    expect(screen.getByTestId("link-game-modal")).toBeInTheDocument();
+    expect(screen.queryByTestId("import-review-modal")).not.toBeInTheDocument();
+    expect(mockLinkGameModal).toHaveBeenCalledWith(
+      expect.objectContaining({ downloadId: "dl-2", open: true })
+    );
+    expect(mockImportReviewModal).not.toHaveBeenCalled();
+
+    // Simulate the modal closing itself (e.g. after a successful link).
+    const { onOpenChange } = mockLinkGameModal.mock.calls.at(-1)?.[0] as {
+      onOpenChange: (open: boolean) => void;
+    };
+    act(() => onOpenChange(false));
+    expect(screen.queryByTestId("link-game-modal")).not.toBeInTheDocument();
   });
 });

--- a/client/__tests__/PendingImportsCard.test.tsx
+++ b/client/__tests__/PendingImportsCard.test.tsx
@@ -11,6 +11,9 @@ import { createTestQueryClient, getRequestUrl } from "./test-utils";
 vi.mock("../src/components/ImportReviewModal", () => ({
   default: () => null,
 }));
+vi.mock("../src/components/LinkGameModal", () => ({
+  default: () => null,
+}));
 
 function createJsonResponse(data: unknown): Response {
   return {
@@ -62,5 +65,37 @@ describe("PendingImportsCard", () => {
     expect(await screen.findByText("My Game")).toBeInTheDocument();
     expect(screen.getByText("Import failed: disk full")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Review" })).toBeInTheDocument();
+  });
+
+  it("offers a Link Game action for a download whose game record is missing", async () => {
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      if (getRequestUrl(url).includes("/api/imports/pending")) {
+        return createJsonResponse([
+          {
+            id: "dl-2",
+            // The backend has no game to derive a title from for this status —
+            // gameTitle falls back to downloadTitle, so both lines render the
+            // same text.
+            gameTitle: "Orphaned.Release-GROUP",
+            downloadTitle: "Orphaned.Release-GROUP",
+            status: "game_link_required",
+            createdAt: new Date().toISOString(),
+            errorMessage: "This download's linked game could not be found",
+          },
+        ]);
+      }
+      return createJsonResponse({});
+    });
+
+    renderCard();
+
+    // No "Import failed:" prefix for this case — it isn't a failed import, it's
+    // missing a game link.
+    expect(
+      await screen.findByText("This download's linked game could not be found")
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Orphaned.Release-GROUP")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Link Game" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Review" })).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/LinkGameModal.tsx
+++ b/client/src/components/LinkGameModal.tsx
@@ -95,7 +95,13 @@ export default function LinkGameModal({
               <Input
                 id="link-game-search"
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(e) => {
+                  setSearchQuery(e.target.value);
+                  // A previously selected game may no longer be in the result
+                  // list once the search changes — don't let a stale selection
+                  // submit silently.
+                  setSelectedGameId(null);
+                }}
                 placeholder="Search by title…"
                 className="pl-8"
                 autoFocus

--- a/client/src/components/LinkGameModal.tsx
+++ b/client/src/components/LinkGameModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { useDebounce } from "@/hooks/use-debounce";
@@ -67,6 +67,51 @@ export default function LinkGameModal({
     },
   });
 
+  let resultsContent: ReactNode;
+  if (isFetching && games.length === 0) {
+    resultsContent = (
+      <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Searching…
+      </div>
+    );
+  } else if (games.length === 0) {
+    resultsContent = (
+      <div className="flex items-center justify-center h-full text-sm text-muted-foreground px-4 text-center">
+        No games found. Try a different search, or add the game to your library first.
+      </div>
+    );
+  } else {
+    resultsContent = (
+      <div className="p-1">
+        {games.map((game) => (
+          <button
+            key={game.id}
+            type="button"
+            onClick={() => setSelectedGameId(game.id)}
+            className={cn(
+              "flex items-center gap-3 w-full rounded-sm p-2 text-left hover:bg-accent transition-colors",
+              selectedGameId === game.id && "bg-accent"
+            )}
+          >
+            {game.coverUrl ? (
+              <img
+                src={game.coverUrl}
+                alt=""
+                className="h-10 w-8 rounded-sm object-cover shrink-0"
+              />
+            ) : (
+              <div className="h-10 w-8 rounded-sm bg-muted flex items-center justify-center shrink-0">
+                <Gamepad2 className="h-4 w-4 text-muted-foreground" />
+              </div>
+            )}
+            <span className="text-sm font-medium truncate">{game.title}</span>
+          </button>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <Dialog
       open={open}
@@ -109,45 +154,7 @@ export default function LinkGameModal({
             </div>
           </div>
 
-          <ScrollArea className="h-64 rounded-md border">
-            {isFetching && games.length === 0 ? (
-              <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Searching…
-              </div>
-            ) : games.length === 0 ? (
-              <div className="flex items-center justify-center h-full text-sm text-muted-foreground px-4 text-center">
-                No games found. Try a different search, or add the game to your library first.
-              </div>
-            ) : (
-              <div className="p-1">
-                {games.map((game) => (
-                  <button
-                    key={game.id}
-                    type="button"
-                    onClick={() => setSelectedGameId(game.id)}
-                    className={cn(
-                      "flex items-center gap-3 w-full rounded-sm p-2 text-left hover:bg-accent transition-colors",
-                      selectedGameId === game.id && "bg-accent"
-                    )}
-                  >
-                    {game.coverUrl ? (
-                      <img
-                        src={game.coverUrl}
-                        alt=""
-                        className="h-10 w-8 rounded-sm object-cover shrink-0"
-                      />
-                    ) : (
-                      <div className="h-10 w-8 rounded-sm bg-muted flex items-center justify-center shrink-0">
-                        <Gamepad2 className="h-4 w-4 text-muted-foreground" />
-                      </div>
-                    )}
-                    <span className="text-sm font-medium truncate">{game.title}</span>
-                  </button>
-                ))}
-              </div>
-            )}
-          </ScrollArea>
+          <ScrollArea className="h-64 rounded-md border">{resultsContent}</ScrollArea>
         </div>
 
         <DialogFooter>

--- a/client/src/components/LinkGameModal.tsx
+++ b/client/src/components/LinkGameModal.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { useDebounce } from "@/hooks/use-debounce";
+import type { Game } from "@shared/schema";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Loader2, Search, Gamepad2 } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
+
+interface LinkGameModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  downloadId: string;
+  downloadTitle: string;
+}
+
+export default function LinkGameModal({
+  open,
+  onOpenChange,
+  downloadId,
+  downloadTitle,
+}: Readonly<LinkGameModalProps>) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedGameId, setSelectedGameId] = useState<string | null>(null);
+  const debouncedSearchQuery = useDebounce(searchQuery, 300);
+
+  const { data: games = [], isFetching } = useQuery<Game[]>({
+    queryKey: ["/api/games", "link-search", debouncedSearchQuery],
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (debouncedSearchQuery.trim()) params.set("search", debouncedSearchQuery.trim());
+      const response = await apiRequest("GET", `/api/games?${params}`);
+      return response.json();
+    },
+    enabled: open,
+  });
+
+  const linkMutation = useMutation({
+    mutationFn: async (gameId: string) => {
+      await apiRequest("POST", `/api/imports/${downloadId}/link`, { gameId });
+    },
+    onSuccess: () => {
+      toast({
+        title: "Game Linked",
+        description: "Continue by reviewing the import's source and destination paths.",
+      });
+      queryClient.invalidateQueries({ queryKey: ["/api/imports/pending"] });
+      onOpenChange(false);
+    },
+    onError: (error: Error) => {
+      toast({ title: "Failed to Link Game", description: error.message, variant: "destructive" });
+    },
+  });
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) {
+          setSearchQuery("");
+          setSelectedGameId(null);
+        }
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Link to a Game</DialogTitle>
+          <DialogDescription>
+            The game originally linked to <strong>{downloadTitle}</strong> could no longer be found.
+            Select the correct game to continue importing this download.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="link-game-search">Search your library</Label>
+            <div className="relative">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                id="link-game-search"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search by title…"
+                className="pl-8"
+                autoFocus
+              />
+            </div>
+          </div>
+
+          <ScrollArea className="h-64 rounded-md border">
+            {isFetching && games.length === 0 ? (
+              <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Searching…
+              </div>
+            ) : games.length === 0 ? (
+              <div className="flex items-center justify-center h-full text-sm text-muted-foreground px-4 text-center">
+                No games found. Try a different search, or add the game to your library first.
+              </div>
+            ) : (
+              <div className="p-1">
+                {games.map((game) => (
+                  <button
+                    key={game.id}
+                    type="button"
+                    onClick={() => setSelectedGameId(game.id)}
+                    className={cn(
+                      "flex items-center gap-3 w-full rounded-sm p-2 text-left hover:bg-accent transition-colors",
+                      selectedGameId === game.id && "bg-accent"
+                    )}
+                  >
+                    {game.coverUrl ? (
+                      <img
+                        src={game.coverUrl}
+                        alt=""
+                        className="h-10 w-8 rounded-sm object-cover shrink-0"
+                      />
+                    ) : (
+                      <div className="h-10 w-8 rounded-sm bg-muted flex items-center justify-center shrink-0">
+                        <Gamepad2 className="h-4 w-4 text-muted-foreground" />
+                      </div>
+                    )}
+                    <span className="text-sm font-medium truncate">{game.title}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </ScrollArea>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            disabled={!selectedGameId || linkMutation.isPending}
+            onClick={() => selectedGameId && linkMutation.mutate(selectedGameId)}
+          >
+            {linkMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Link Game
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/PendingImportsCard.tsx
+++ b/client/src/components/PendingImportsCard.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Button } from "@/components/ui/button";
 import { AlertCircle } from "lucide-react";
 import ImportReviewModal from "./ImportReviewModal";
+import LinkGameModal from "./LinkGameModal";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { formatDistanceToNow } from "date-fns";
@@ -84,7 +85,9 @@ export default function PendingImportsCard() {
                       className="text-xs text-destructive truncate max-w-[300px]"
                       title={item.errorMessage}
                     >
-                      Import failed: {item.errorMessage}
+                      {item.status === "game_link_required"
+                        ? item.errorMessage
+                        : `Import failed: ${item.errorMessage}`}
                     </p>
                   )}
                 </div>
@@ -98,7 +101,7 @@ export default function PendingImportsCard() {
                     Skip
                   </Button>
                   <Button size="sm" onClick={() => setSelectedImport(item)}>
-                    Review
+                    {item.status === "game_link_required" ? "Link Game" : "Review"}
                   </Button>
                 </div>
               </div>
@@ -107,7 +110,15 @@ export default function PendingImportsCard() {
         </CardContent>
       </Card>
 
-      {selectedImport && (
+      {selectedImport && selectedImport.status === "game_link_required" && (
+        <LinkGameModal
+          open={!!selectedImport}
+          onOpenChange={(open) => !open && setSelectedImport(null)}
+          downloadId={selectedImport.id}
+          downloadTitle={selectedImport.downloadTitle}
+        />
+      )}
+      {selectedImport && selectedImport.status !== "game_link_required" && (
         <ImportReviewModal
           open={!!selectedImport}
           onOpenChange={(open) => !open && setSelectedImport(null)}

--- a/client/src/components/PendingImportsCard.tsx
+++ b/client/src/components/PendingImportsCard.tsx
@@ -111,7 +111,7 @@ export default function PendingImportsCard() {
         </CardContent>
       </Card>
 
-      {selectedImport && selectedImport.status === GAME_LINK_REQUIRED_STATUS && (
+      {selectedImport?.status === GAME_LINK_REQUIRED_STATUS && (
         <LinkGameModal
           open={!!selectedImport}
           onOpenChange={(open) => !open && setSelectedImport(null)}

--- a/client/src/components/PendingImportsCard.tsx
+++ b/client/src/components/PendingImportsCard.tsx
@@ -8,6 +8,7 @@ import LinkGameModal from "./LinkGameModal";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { formatDistanceToNow } from "date-fns";
+import { GAME_LINK_REQUIRED_STATUS } from "@shared/schema";
 
 interface PendingImport {
   id: string;
@@ -85,7 +86,7 @@ export default function PendingImportsCard() {
                       className="text-xs text-destructive truncate max-w-[300px]"
                       title={item.errorMessage}
                     >
-                      {item.status === "game_link_required"
+                      {item.status === GAME_LINK_REQUIRED_STATUS
                         ? item.errorMessage
                         : `Import failed: ${item.errorMessage}`}
                     </p>
@@ -101,7 +102,7 @@ export default function PendingImportsCard() {
                     Skip
                   </Button>
                   <Button size="sm" onClick={() => setSelectedImport(item)}>
-                    {item.status === "game_link_required" ? "Link Game" : "Review"}
+                    {item.status === GAME_LINK_REQUIRED_STATUS ? "Link Game" : "Review"}
                   </Button>
                 </div>
               </div>
@@ -110,7 +111,7 @@ export default function PendingImportsCard() {
         </CardContent>
       </Card>
 
-      {selectedImport && selectedImport.status === "game_link_required" && (
+      {selectedImport && selectedImport.status === GAME_LINK_REQUIRED_STATUS && (
         <LinkGameModal
           open={!!selectedImport}
           onOpenChange={(open) => !open && setSelectedImport(null)}
@@ -118,7 +119,7 @@ export default function PendingImportsCard() {
           downloadTitle={selectedImport.downloadTitle}
         />
       )}
-      {selectedImport && selectedImport.status !== "game_link_required" && (
+      {selectedImport && selectedImport.status !== GAME_LINK_REQUIRED_STATUS && (
         <ImportReviewModal
           open={!!selectedImport}
           onOpenChange={(open) => !open && setSelectedImport(null)}

--- a/server/__tests__/database_storage_extended.test.ts
+++ b/server/__tests__/database_storage_extended.test.ts
@@ -365,6 +365,57 @@ describe("DatabaseStorage Extended Coverage", () => {
       const current = await storage.getGameDownload(download!.id);
       expect(current?.gameId).toBe(firstGame.id);
     });
+
+    it("completeUnlinkedGameDownload dismisses a game_link_required download as completed", async () => {
+      const { game, downloader } = await setup();
+
+      const download = await storage.addGameDownload({
+        gameId: game.id,
+        downloaderId: downloader.id,
+        downloadHash: "hash-skip",
+        downloadTitle: "Skip-GROUP",
+        status: "game_link_required",
+        downloadType: "torrent",
+        fileSize: null,
+      } as InsertGameDownload);
+
+      const updated = await storage.completeUnlinkedGameDownload(download!.id);
+      expect(updated?.status).toBe("completed");
+      expect(updated?.completedAt).not.toBeNull();
+      expect(await storage.getUnlinkedImportReviews()).toHaveLength(0);
+    });
+
+    it("completeUnlinkedGameDownload is a no-op once already relinked (race-safe)", async () => {
+      const { userId, game, downloader } = await setup();
+      const correctGame = await storage.addGame({
+        title: "Relinked First",
+        igdbId: 6004,
+        status: "wanted",
+        hidden: false,
+        userId,
+      } as InsertGame);
+
+      const download = await storage.addGameDownload({
+        gameId: game.id,
+        downloaderId: downloader.id,
+        downloadHash: "hash-skip-race",
+        downloadTitle: "SkipRace-GROUP",
+        status: "game_link_required",
+        downloadType: "torrent",
+        fileSize: null,
+      } as InsertGameDownload);
+
+      // Simulates a concurrent POST /:id/link winning the race first.
+      await storage.relinkGameDownload(download!.id, correctGame.id);
+
+      const result = await storage.completeUnlinkedGameDownload(download!.id);
+      expect(result).toBeUndefined();
+
+      // The relink must survive untouched — not clobbered back to "completed".
+      const current = await storage.getGameDownload(download!.id);
+      expect(current?.status).toBe("manual_review_required");
+      expect(current?.gameId).toBe(correctGame.id);
+    });
   });
 
   describe("Import task history", () => {

--- a/server/__tests__/database_storage_extended.test.ts
+++ b/server/__tests__/database_storage_extended.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
-import { users, type InsertGame } from "../../shared/schema";
+import {
+  users,
+  type InsertGame,
+  type InsertDownloader,
+  type InsertGameDownload,
+} from "../../shared/schema";
 import { randomUUID } from "crypto";
 import type { DatabaseStorage } from "../storage";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
@@ -250,6 +255,115 @@ describe("DatabaseStorage Extended Coverage", () => {
       const grouped = await storage.getWantedGamesGroupedByUser();
       expect(grouped.get(userA)?.map((g) => g.title)).toEqual(["Wanted A"]);
       expect(grouped.get(userB)?.map((g) => g.title)).toEqual(["Wanted B"]);
+    });
+  });
+
+  describe("GameDownload: unlinked reviews and relinking", () => {
+    async function setup() {
+      const userId = await createUser();
+      const game = await storage.addGame({
+        title: "Original Game",
+        igdbId: 6000,
+        status: "wanted",
+        hidden: false,
+        userId,
+      } as InsertGame);
+      const downloader = await storage.addDownloader({
+        name: "qBit",
+        type: "qbittorrent",
+        url: "http://localhost:8080",
+        apiKey: "",
+        enabled: true,
+        priority: 1,
+      } as InsertDownloader);
+      return { userId, game, downloader };
+    }
+
+    it("getUnlinkedImportReviews returns only game_link_required downloads", async () => {
+      const { game, downloader } = await setup();
+
+      const unlinked = await storage.addGameDownload({
+        gameId: game.id,
+        downloaderId: downloader.id,
+        downloadHash: "hash-unlinked",
+        downloadTitle: "Orphaned-GROUP",
+        status: "game_link_required",
+        downloadType: "torrent",
+        fileSize: null,
+      } as InsertGameDownload);
+      await storage.addGameDownload({
+        gameId: game.id,
+        downloaderId: downloader.id,
+        downloadHash: "hash-reviewing",
+        downloadTitle: "Reviewing-GROUP",
+        status: "manual_review_required",
+        downloadType: "torrent",
+        fileSize: null,
+      } as InsertGameDownload);
+
+      const results = await storage.getUnlinkedImportReviews();
+      expect(results.map((d) => d.id)).toEqual([unlinked?.id]);
+    });
+
+    it("relinkGameDownload reattaches the game and returns to manual_review_required", async () => {
+      const { userId, game, downloader } = await setup();
+      const correctGame = await storage.addGame({
+        title: "Correct Game",
+        igdbId: 6001,
+        status: "wanted",
+        hidden: false,
+        userId,
+      } as InsertGame);
+
+      const download = await storage.addGameDownload({
+        gameId: game.id,
+        downloaderId: downloader.id,
+        downloadHash: "hash-relink",
+        downloadTitle: "NeedsLink-GROUP",
+        status: "game_link_required",
+        downloadType: "torrent",
+        fileSize: null,
+      } as InsertGameDownload);
+
+      const updated = await storage.relinkGameDownload(download!.id, correctGame.id);
+      expect(updated?.gameId).toBe(correctGame.id);
+      expect(updated?.status).toBe("manual_review_required");
+      expect(await storage.getUnlinkedImportReviews()).toHaveLength(0);
+    });
+
+    it("relinkGameDownload is a no-op once already relinked (race-safe)", async () => {
+      const { userId, game, downloader } = await setup();
+      const firstGame = await storage.addGame({
+        title: "First Winner",
+        igdbId: 6002,
+        status: "wanted",
+        hidden: false,
+        userId,
+      } as InsertGame);
+      const secondGame = await storage.addGame({
+        title: "Second Attempt",
+        igdbId: 6003,
+        status: "wanted",
+        hidden: false,
+        userId,
+      } as InsertGame);
+
+      const download = await storage.addGameDownload({
+        gameId: game.id,
+        downloaderId: downloader.id,
+        downloadHash: "hash-race",
+        downloadTitle: "Race-GROUP",
+        status: "game_link_required",
+        downloadType: "torrent",
+        fileSize: null,
+      } as InsertGameDownload);
+
+      await storage.relinkGameDownload(download!.id, firstGame.id);
+      const second = await storage.relinkGameDownload(download!.id, secondGame.id);
+
+      expect(second).toBeUndefined();
+      const current = await storage.getGameDownload(download!.id);
+      expect(current?.gameId).toBe(firstGame.id);
     });
   });
 

--- a/server/__tests__/downloaders_clients_regression.test.ts
+++ b/server/__tests__/downloaders_clients_regression.test.ts
@@ -1150,6 +1150,23 @@ describe("downloader client regression coverage", () => {
           DestDir: "/downloads",
         },
       ])
+      // getDownloadDetails("12")'s follow-up getHistoryDestDir call, since the
+      // download above resolved to "completed".
+      .mockResolvedValueOnce([
+        {
+          NZBID: 12,
+          Name: "Finished Game",
+          Status: "SUCCESS/ALL",
+          FileSizeMB: 30,
+          Category: "games",
+          DownloadTimeSec: 60,
+          ParStatus: "NONE",
+          UnpackStatus: "SUCCESS",
+          FailedArticles: 0,
+          DeleteStatus: "NONE",
+          DestDir: "/downloads",
+        },
+      ])
       .mockResolvedValueOnce([
         {
           NZBID: 10,
@@ -1197,6 +1214,7 @@ describe("downloader client regression coverage", () => {
     });
     await expect(client.getDownloadDetails("12")).resolves.toMatchObject({
       status: "completed",
+      downloadDir: "/downloads",
       files: [],
       filesSupport: "unsupported",
       trackers: [],

--- a/server/__tests__/downloaders_nzbget_remaining.test.ts
+++ b/server/__tests__/downloaders_nzbget_remaining.test.ts
@@ -281,4 +281,111 @@ describe("NZBGet remaining coverage", () => {
     rpcSpy.mockRejectedValueOnce(new Error("queue failed"));
     await expect(client.getAllDownloads()).resolves.toEqual([]);
   });
+
+  it("getDownloadDetails populates downloadDir from history's DestDir for completed downloads", async () => {
+    const client = new NZBGetClient(createDownloader());
+    const rpcSpy = vi.spyOn(
+      client as unknown as { makeXMLRPCRequest: typeof Function },
+      "makeXMLRPCRequest"
+    );
+
+    // getDownloadStatus: not in the live queue, falls back to history.
+    rpcSpy.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        NZBID: 9,
+        Name: "Finished Game",
+        Status: "SUCCESS/ALL",
+        FileSizeMB: 20,
+        Category: "games",
+        DownloadTimeSec: 90,
+        ParStatus: "NONE",
+        UnpackStatus: "NONE",
+        FailedArticles: 0,
+        DeleteStatus: "NONE",
+        DestDir: "/downloads/nzbget/Questarr/Finished Game",
+      },
+    ]);
+    // The subsequent getHistoryDestDir call for the same completed download.
+    rpcSpy.mockResolvedValueOnce([
+      {
+        NZBID: 9,
+        Name: "Finished Game",
+        Status: "SUCCESS/ALL",
+        FileSizeMB: 20,
+        Category: "games",
+        DownloadTimeSec: 90,
+        ParStatus: "NONE",
+        UnpackStatus: "NONE",
+        FailedArticles: 0,
+        DeleteStatus: "NONE",
+        DestDir: "/downloads/nzbget/Questarr/Finished Game",
+      },
+    ]);
+
+    await expect(client.getDownloadDetails("9")).resolves.toMatchObject({
+      status: "completed",
+      downloadDir: "/downloads/nzbget/Questarr/Finished Game",
+    });
+  });
+
+  it("getDownloadDetails leaves downloadDir unset for downloads still in progress", async () => {
+    const client = new NZBGetClient(createDownloader());
+    const rpcSpy = vi.spyOn(
+      client as unknown as { makeXMLRPCRequest: typeof Function },
+      "makeXMLRPCRequest"
+    );
+
+    rpcSpy.mockResolvedValueOnce([
+      {
+        NZBID: 10,
+        NZBName: "In Progress Game",
+        Status: "DOWNLOADING",
+        FileSizeMB: 10,
+        RemainingSizeMB: 5,
+        DownloadedSizeMB: 5,
+        Category: "games",
+        DownloadRate: 2,
+        PostInfoText: "",
+        PostStageProgress: 0,
+        PostStageTimeSec: 0,
+      },
+    ]);
+
+    const details = await client.getDownloadDetails("10");
+    expect(details).toMatchObject({ status: "downloading" });
+    expect(details?.downloadDir).toBeUndefined();
+    // No extra history round-trip should happen for a non-completed download.
+    expect(rpcSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("getHistoryDestDir logs and returns undefined when the history lookup fails", async () => {
+    const client = new NZBGetClient(createDownloader());
+    const rpcSpy = vi.spyOn(
+      client as unknown as { makeXMLRPCRequest: typeof Function },
+      "makeXMLRPCRequest"
+    );
+
+    rpcSpy
+      .mockResolvedValueOnce([]) // getDownloadStatus: not in queue
+      .mockResolvedValueOnce([
+        {
+          NZBID: 11,
+          Name: "Finished Game",
+          Status: "SUCCESS/ALL",
+          FileSizeMB: 20,
+          Category: "games",
+          DownloadTimeSec: 90,
+          ParStatus: "NONE",
+          UnpackStatus: "NONE",
+          FailedArticles: 0,
+          DeleteStatus: "NONE",
+          DestDir: "/downloads/nzbget/Questarr/Finished Game",
+        },
+      ]) // getFromHistory
+      .mockRejectedValueOnce(new Error("history failed")); // getHistoryDestDir
+
+    const details = await client.getDownloadDetails("11");
+    expect(details).toMatchObject({ status: "completed" });
+    expect(details?.downloadDir).toBeUndefined();
+  });
 });

--- a/server/__tests__/downloaders_utils_manager.test.ts
+++ b/server/__tests__/downloaders_utils_manager.test.ts
@@ -4,6 +4,7 @@ import { DelugeClient } from "../downloaders/deluge.js";
 import { DownloaderManager } from "../downloaders.js";
 import {
   DOWNLOAD_CLIENT_USER_AGENT,
+  buildRemoteImportPath,
   extractHashFromUrl,
   fetchWithMagnetDetection,
   fixNzbUrlEncoding,
@@ -91,6 +92,23 @@ describe("downloaders utils", () => {
     );
     expect(fixNzbUrlEncoding("http://indexer.local/download?flag")).toBe(
       "http://indexer.local/download?flag"
+    );
+  });
+
+  it("does not duplicate the release name when downloadDir already ends with it", () => {
+    // NZBGet/SABnzbd report downloadDir as the final content directory itself.
+    expect(
+      buildRemoteImportPath(
+        "/downloads/nzbget/Questarr/Xenoblade.Chronicles.3.Update.v2.2.1.NSW-SUXXORS",
+        "Xenoblade.Chronicles.3.Update.v2.2.1.NSW-SUXXORS"
+      )
+    ).toBe("/downloads/nzbget/Questarr/Xenoblade.Chronicles.3.Update.v2.2.1.NSW-SUXXORS");
+  });
+
+  it("appends the relative path when downloadDir is a genuine parent directory", () => {
+    // Torrent clients report downloadDir as the parent, requiring the subpath appended.
+    expect(buildRemoteImportPath("/downloads/deluge/complete", "My Game Release")).toBe(
+      "/downloads/deluge/complete/My Game Release"
     );
   });
 

--- a/server/__tests__/import_manager.test.ts
+++ b/server/__tests__/import_manager.test.ts
@@ -77,7 +77,12 @@ describe("ImportManager", () => {
     expect(storage.updateGameDownloadStatus).not.toHaveBeenCalled();
   });
 
-  it("marks download as error when game is missing", async () => {
+  it("marks download for manual review when game is missing", async () => {
+    // Not "error": that status is never re-polled (getDownloadingGameDownloads
+    // only selects "downloading") and never shown in the UI's pending-imports
+    // list (getPendingImportReviews only selects "manual_review_required"),
+    // so it would leave the download invisible and stuck forever even if the
+    // missing game was a transient/momentary condition.
     storage.getGameDownload.mockResolvedValue({
       id: "dl-1",
       gameId: "g1",
@@ -93,7 +98,11 @@ describe("ImportManager", () => {
 
     await manager.processImport("dl-1", "/remote/path");
 
-    expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith("dl-1", "error");
+    expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith(
+      "dl-1",
+      "manual_review_required",
+      "Game record not found for this download"
+    );
   });
 
   it("marks download completed when post-processing is disabled", async () => {

--- a/server/__tests__/import_manager.test.ts
+++ b/server/__tests__/import_manager.test.ts
@@ -77,12 +77,15 @@ describe("ImportManager", () => {
     expect(storage.updateGameDownloadStatus).not.toHaveBeenCalled();
   });
 
-  it("marks download for manual review when game is missing", async () => {
+  it("marks download game_link_required when game is missing", async () => {
     // Not "error": that status is never re-polled (getDownloadingGameDownloads
     // only selects "downloading") and never shown in the UI's pending-imports
-    // list (getPendingImportReviews only selects "manual_review_required"),
-    // so it would leave the download invisible and stuck forever even if the
-    // missing game was a transient/momentary condition.
+    // list, so it would leave the download invisible and stuck forever even if
+    // the missing game was a transient/momentary condition.
+    //
+    // Also not "manual_review_required": that flow only ever asks the user to
+    // confirm source/destination paths for an existing game and has no way to
+    // recover when there's no game to import into at all.
     storage.getGameDownload.mockResolvedValue({
       id: "dl-1",
       gameId: "g1",
@@ -100,8 +103,8 @@ describe("ImportManager", () => {
 
     expect(storage.updateGameDownloadStatus).toHaveBeenCalledWith(
       "dl-1",
-      "manual_review_required",
-      "Game record not found for this download"
+      "game_link_required",
+      "This download's linked game could not be found — select a game to continue importing it."
     );
   });
 

--- a/server/__tests__/import_manager.test.ts
+++ b/server/__tests__/import_manager.test.ts
@@ -250,6 +250,35 @@ describe("ImportManager", () => {
     ).rejects.toThrow("Proposed path is outside configured library root");
   });
 
+  it("confirmImport: source path no longer exists on disk → throws a descriptive error", async () => {
+    storage.getGameDownload.mockResolvedValue({ id: "dl-1", gameId: "g1", downloaderId: "d1" });
+    storage.getGame.mockResolvedValue({
+      id: "g1",
+      title: "Game",
+      userId: "u1",
+      status: "wanted",
+      platforms: [6],
+    });
+    storage.getImportConfig.mockResolvedValue({ ...baseConfig, libraryRoot: "/safe/root" });
+    fsMock.pathExists.mockResolvedValueOnce(false);
+
+    const manager = new ImportManager(
+      storage as never, // NOSONAR
+      pathService as never, // NOSONAR
+      platformService as never, // NOSONAR
+      archiveService as never // NOSONAR
+    );
+
+    await expect(
+      manager.confirmImport("dl-1", {
+        strategy: "pc",
+        originalPath: "/downloads/vanished-folder",
+        proposedPath: "/safe/root/PC/Game",
+        needsReview: false,
+      })
+    ).rejects.toThrow("Source path not found: /downloads/vanished-folder");
+  });
+
   it("executes confirmImport for pc strategy and updates statuses", async () => {
     storage.getGameDownload.mockResolvedValue({ id: "dl-1", gameId: "g1", downloaderId: "d1" });
     storage.getGame.mockResolvedValue({

--- a/server/__tests__/import_routes_additional.test.ts
+++ b/server/__tests__/import_routes_additional.test.ts
@@ -6,6 +6,9 @@ const { mockStorage, mockImportManager, mockPlatformMappingService, fsMock } = v
     getImportConfig: vi.fn(),
     getEnabledDownloaders: vi.fn(),
     getPendingImportReviews: vi.fn(),
+    getUnlinkedImportReviews: vi.fn(),
+    relinkGameDownload: vi.fn(),
+    getGameDownload: vi.fn(),
     getGame: vi.fn(),
     getPlatformMappings: vi.fn(),
     getPathMappings: vi.fn(),
@@ -50,6 +53,7 @@ describe("importRouter additional coverage", () => {
     mockStorage.getEnabledDownloaders.mockResolvedValue([]);
     mockStorage.getImportConfig.mockResolvedValue(makeImportConfig({ overwriteExisting: true }));
     mockStorage.getPathMappings.mockResolvedValue([]);
+    mockStorage.getUnlinkedImportReviews.mockResolvedValue([]);
   });
 
   const createApp = (withUser = true) => createImportTestApp(importRouter, withUser);
@@ -85,6 +89,126 @@ describe("importRouter additional coverage", () => {
         status: "manual_review_required",
       }),
     ]);
+  });
+
+  it("merges game-link-required downloads ahead of path reviews, without a game lookup", async () => {
+    mockStorage.getPendingImportReviews.mockResolvedValue([
+      {
+        id: "d-path",
+        gameId: "g1",
+        downloadTitle: "Path Review-GROUP",
+        status: "manual_review_required",
+        downloaderId: "down-1",
+        addedAt: "2026-01-01",
+      },
+    ]);
+    mockStorage.getGame.mockResolvedValueOnce({ title: "Known Game" });
+    mockStorage.getUnlinkedImportReviews.mockResolvedValue([
+      {
+        id: "d-unlinked",
+        gameId: "gone",
+        downloadTitle: "Orphaned-GROUP",
+        status: "game_link_required",
+        downloaderId: "down-1",
+        addedAt: "2026-01-02",
+        errorMessage: "This download's linked game could not be found",
+      },
+    ]);
+
+    const app = createApp();
+    const response = await request(app).get("/api/imports/pending");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([
+      expect.objectContaining({
+        id: "d-unlinked",
+        gameTitle: "Orphaned-GROUP",
+        status: "game_link_required",
+      }),
+      expect.objectContaining({
+        id: "d-path",
+        gameTitle: "Known Game",
+        status: "manual_review_required",
+      }),
+    ]);
+    // The unlinked entry's title never goes through storage.getGame — there's no
+    // game row to look up.
+    expect(mockStorage.getGame).toHaveBeenCalledTimes(1);
+  });
+
+  describe("POST /:id/link", () => {
+    it("links a game_link_required download to the given game", async () => {
+      mockStorage.getGameDownload.mockResolvedValue({
+        id: "d1",
+        gameId: "gone",
+        status: "game_link_required",
+      });
+      mockStorage.getGame.mockResolvedValue({ id: "g2", title: "Correct Game" });
+      mockStorage.relinkGameDownload.mockResolvedValue({
+        id: "d1",
+        gameId: "g2",
+        status: "manual_review_required",
+      });
+
+      const app = createApp();
+      const response = await request(app).post("/api/imports/d1/link").send({ gameId: "g2" });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        download: { id: "d1", gameId: "g2", status: "manual_review_required" },
+      });
+      expect(mockStorage.relinkGameDownload).toHaveBeenCalledWith("d1", "g2");
+    });
+
+    it("returns 404 when the download does not exist", async () => {
+      mockStorage.getGameDownload.mockResolvedValue(undefined);
+
+      const app = createApp();
+      const response = await request(app).post("/api/imports/missing/link").send({ gameId: "g2" });
+
+      expect(response.status).toBe(404);
+      expect(mockStorage.relinkGameDownload).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when the download isn't awaiting a game link", async () => {
+      mockStorage.getGameDownload.mockResolvedValue({
+        id: "d1",
+        gameId: "g1",
+        status: "manual_review_required",
+      });
+
+      const app = createApp();
+      const response = await request(app).post("/api/imports/d1/link").send({ gameId: "g2" });
+
+      expect(response.status).toBe(400);
+      expect(mockStorage.relinkGameDownload).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the target game does not exist", async () => {
+      mockStorage.getGameDownload.mockResolvedValue({
+        id: "d1",
+        gameId: "gone",
+        status: "game_link_required",
+      });
+      mockStorage.getGame.mockResolvedValue(undefined);
+
+      const app = createApp();
+      const response = await request(app)
+        .post("/api/imports/d1/link")
+        .send({ gameId: "nonexistent" });
+
+      expect(response.status).toBe(404);
+      expect(mockStorage.relinkGameDownload).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 for a missing gameId", async () => {
+      const app = createApp();
+      const response = await request(app).post("/api/imports/d1/link").send({});
+
+      expect(response.status).toBe(400);
+      expect(mockStorage.getGameDownload).not.toHaveBeenCalled();
+    });
   });
 
   it("initializes platform mappings via /mappings/platforms/init", async () => {

--- a/server/__tests__/import_routes_additional.test.ts
+++ b/server/__tests__/import_routes_additional.test.ts
@@ -209,6 +209,33 @@ describe("importRouter additional coverage", () => {
       expect(response.status).toBe(400);
       expect(mockStorage.getGameDownload).not.toHaveBeenCalled();
     });
+
+    it("returns 409 when another request already relinked the download first", async () => {
+      // Passed the status check (still game_link_required at that instant), but
+      // storage's conditional update matched nothing by the time it ran — a
+      // concurrent request won the race.
+      mockStorage.getGameDownload.mockResolvedValue({
+        id: "d1",
+        gameId: "gone",
+        status: "game_link_required",
+      });
+      mockStorage.getGame.mockResolvedValue({ id: "g2", title: "Correct Game" });
+      mockStorage.relinkGameDownload.mockResolvedValue(undefined);
+
+      const app = createApp();
+      const response = await request(app).post("/api/imports/d1/link").send({ gameId: "g2" });
+
+      expect(response.status).toBe(409);
+    });
+
+    it("returns 500 when the storage layer throws unexpectedly", async () => {
+      mockStorage.getGameDownload.mockRejectedValue(new Error("db failure"));
+
+      const app = createApp();
+      const response = await request(app).post("/api/imports/d1/link").send({ gameId: "g2" });
+
+      expect(response.status).toBe(500);
+    });
   });
 
   it("initializes platform mappings via /mappings/platforms/init", async () => {

--- a/server/__tests__/import_routes_coverage.test.ts
+++ b/server/__tests__/import_routes_coverage.test.ts
@@ -19,6 +19,7 @@ const { mockStorage, mockImportManager, mockPlatformMappingService, fsMock } = v
     createUserSettings: vi.fn(),
     getGameDownload: vi.fn(),
     updateGameDownloadStatus: vi.fn(),
+    completeUnlinkedGameDownload: vi.fn(),
   },
   mockImportManager: {
     confirmImport: vi.fn(),
@@ -395,7 +396,8 @@ describe("DELETE /api/imports/:id", () => {
   it("skips a game_link_required download via the unscoped fallback lookup", async () => {
     // The userId-scoped lookup can never find a game_link_required download
     // (it has no game row to join ownership through), so it must fall back
-    // to an unscoped lookup that only accepts a game_link_required record.
+    // to an unscoped lookup that only accepts a game_link_required record,
+    // then complete it via the atomic completeUnlinkedGameDownload path.
     mockStorage.getGameDownload
       .mockResolvedValueOnce(undefined) // scoped lookup: getGameDownload(id, userId)
       .mockResolvedValueOnce({
@@ -403,6 +405,10 @@ describe("DELETE /api/imports/:id", () => {
         gameId: "missing-game",
         status: "game_link_required",
       }); // unscoped fallback: getGameDownload(id)
+    mockStorage.completeUnlinkedGameDownload.mockResolvedValue({
+      id: "dl-unlinked",
+      status: "completed",
+    });
 
     const res = await request(createApp()).delete("/api/imports/dl-unlinked");
 
@@ -410,7 +416,24 @@ describe("DELETE /api/imports/:id", () => {
     expect(res.body.success).toBe(true);
     expect(mockStorage.getGameDownload).toHaveBeenCalledTimes(2);
     expect(mockStorage.getGameDownload).toHaveBeenNthCalledWith(2, "dl-unlinked");
-    expect(mockStorage.updateGameDownloadStatus).toHaveBeenCalledWith("dl-unlinked", "completed");
+    expect(mockStorage.completeUnlinkedGameDownload).toHaveBeenCalledWith("dl-unlinked");
+    expect(mockStorage.updateGameDownloadStatus).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when a game_link_required download is relinked before it can be skipped", async () => {
+    // A concurrent POST /:id/link raced ahead and relinked this download
+    // between the fallback lookup and the completion write — the atomic
+    // conditional update loses that race and must not silently overwrite
+    // the relink with "completed".
+    mockStorage.getGameDownload
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ id: "dl-race", gameId: "g1", status: "game_link_required" });
+    mockStorage.completeUnlinkedGameDownload.mockResolvedValue(undefined);
+
+    const res = await request(createApp()).delete("/api/imports/dl-race");
+
+    expect(res.status).toBe(409);
+    expect(mockStorage.updateGameDownloadStatus).not.toHaveBeenCalled();
   });
 
   it("does not use the unscoped fallback for a download that isn't game_link_required", async () => {

--- a/server/__tests__/import_routes_coverage.test.ts
+++ b/server/__tests__/import_routes_coverage.test.ts
@@ -391,6 +391,41 @@ describe("DELETE /api/imports/:id", () => {
 
     expect(res.status).toBe(500);
   });
+
+  it("skips a game_link_required download via the unscoped fallback lookup", async () => {
+    // The userId-scoped lookup can never find a game_link_required download
+    // (it has no game row to join ownership through), so it must fall back
+    // to an unscoped lookup that only accepts a game_link_required record.
+    mockStorage.getGameDownload
+      .mockResolvedValueOnce(undefined) // scoped lookup: getGameDownload(id, userId)
+      .mockResolvedValueOnce({
+        id: "dl-unlinked",
+        gameId: "missing-game",
+        status: "game_link_required",
+      }); // unscoped fallback: getGameDownload(id)
+
+    const res = await request(createApp()).delete("/api/imports/dl-unlinked");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockStorage.getGameDownload).toHaveBeenCalledTimes(2);
+    expect(mockStorage.getGameDownload).toHaveBeenNthCalledWith(2, "dl-unlinked");
+    expect(mockStorage.updateGameDownloadStatus).toHaveBeenCalledWith("dl-unlinked", "completed");
+  });
+
+  it("does not use the unscoped fallback for a download that isn't game_link_required", async () => {
+    // A download that's simply outside the caller's ownership (e.g. belongs
+    // to another user, or genuinely doesn't exist) must stay 404 — the
+    // fallback is only a carve-out for the ownerless game_link_required case.
+    mockStorage.getGameDownload
+      .mockResolvedValueOnce(undefined) // scoped lookup fails
+      .mockResolvedValueOnce({ id: "dl-2", gameId: "g2", status: "manual_review_required" }); // exists, but not unlinked
+
+    const res = await request(createApp()).delete("/api/imports/dl-2");
+
+    expect(res.status).toBe(404);
+    expect(mockStorage.updateGameDownloadStatus).not.toHaveBeenCalled();
+  });
 });
 
 // ─── POST /:id/confirm — additional coverage ──────────────────────────────────

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -773,6 +773,51 @@ describe("MemStorage", () => {
         const current = await storage.getGameDownload(download.id);
         expect(current?.gameId).toBe(otherGame.id);
       });
+
+      it("completeUnlinkedGameDownload dismisses a game_link_required download as completed", async () => {
+        const download = await storage.addGameDownload({
+          gameId,
+          downloaderId,
+          downloadHash: "hash-to-skip",
+          downloadTitle: "Skip-GROUP",
+          status: "game_link_required",
+          downloadType: "torrent",
+          fileSize: null,
+        } as InsertGameDownload);
+
+        const updated = await storage.completeUnlinkedGameDownload(download.id);
+
+        expect(updated?.status).toBe("completed");
+        expect(updated?.completedAt).not.toBeNull();
+        expect(await storage.getUnlinkedImportReviews()).toHaveLength(0);
+      });
+
+      it("completeUnlinkedGameDownload returns undefined for a nonexistent download", async () => {
+        const result = await storage.completeUnlinkedGameDownload("nonexistent-id");
+        expect(result).toBeUndefined();
+      });
+
+      it("completeUnlinkedGameDownload is a no-op once the download has already been relinked", async () => {
+        const download = await storage.addGameDownload({
+          gameId,
+          downloaderId,
+          downloadHash: "hash-skip-race",
+          downloadTitle: "SkipRace-GROUP",
+          status: "game_link_required",
+          downloadType: "torrent",
+          fileSize: null,
+        } as InsertGameDownload);
+
+        // Simulates a concurrent POST /:id/link winning the race first.
+        await storage.relinkGameDownload(download.id, gameId);
+
+        const result = await storage.completeUnlinkedGameDownload(download.id);
+        expect(result).toBeUndefined();
+
+        // The relink must survive untouched — not clobbered back to "completed".
+        const current = await storage.getGameDownload(download.id);
+        expect(current?.status).toBe("manual_review_required");
+      });
     });
 
     describe("getTrackedDownloadKeys", () => {

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -676,6 +676,75 @@ describe("MemStorage", () => {
       expect(downloads[0].downloaderName).toBeNull();
     });
 
+    describe("getUnlinkedImportReviews / relinkGameDownload", () => {
+      it("returns downloads with status game_link_required regardless of their gameId", async () => {
+        const unlinked = await storage.addGameDownload({
+          gameId,
+          downloaderId,
+          downloadHash: "hash-unlinked",
+          downloadTitle: "Orphaned-GROUP",
+          status: "game_link_required",
+          downloadType: "torrent",
+          fileSize: null,
+        } as InsertGameDownload);
+        await storage.addGameDownload({
+          gameId,
+          downloaderId,
+          downloadHash: "hash-reviewing",
+          downloadTitle: "Reviewing-GROUP",
+          status: "manual_review_required",
+          downloadType: "torrent",
+          fileSize: null,
+        } as InsertGameDownload);
+
+        const results = await storage.getUnlinkedImportReviews();
+        expect(results).toHaveLength(1);
+        expect(results[0].id).toBe(unlinked.id);
+      });
+
+      it("relinkGameDownload updates the gameId and returns to manual_review_required", async () => {
+        const otherGame = await storage.addGame({
+          title: "Correct Game",
+          igdbId: 5002,
+          status: "wanted",
+          hidden: false,
+          userId,
+        } as InsertGame);
+
+        const download = await storage.addGameDownload({
+          gameId,
+          downloaderId,
+          downloadHash: "hash-to-relink",
+          downloadTitle: "NeedsLink-GROUP",
+          status: "game_link_required",
+          downloadType: "torrent",
+          fileSize: null,
+        } as InsertGameDownload);
+        await storage.updateGameDownloadStatus(
+          download.id,
+          "game_link_required",
+          "This download's linked game could not be found"
+        );
+
+        const updated = await storage.relinkGameDownload(download.id, otherGame.id);
+
+        expect(updated?.gameId).toBe(otherGame.id);
+        expect(updated?.status).toBe("manual_review_required");
+        expect(updated?.errorMessage).toBeNull();
+
+        // No longer surfaced as needing a game link…
+        expect(await storage.getUnlinkedImportReviews()).toHaveLength(0);
+        // …and now surfaces in the normal path-review list instead.
+        const pending = await storage.getPendingImportReviews(userId);
+        expect(pending.some((d) => d.id === download.id)).toBe(true);
+      });
+
+      it("relinkGameDownload returns undefined for a nonexistent download", async () => {
+        const result = await storage.relinkGameDownload("nonexistent-id", gameId);
+        expect(result).toBeUndefined();
+      });
+    });
+
     describe("getTrackedDownloadKeys", () => {
       it("returns an empty set when there are no game downloads", async () => {
         const keys = await storage.getTrackedDownloadKeys();

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -743,6 +743,36 @@ describe("MemStorage", () => {
         const result = await storage.relinkGameDownload("nonexistent-id", gameId);
         expect(result).toBeUndefined();
       });
+
+      it("relinkGameDownload is a no-op once the download has already moved past game_link_required", async () => {
+        const otherGame = await storage.addGame({
+          title: "Second Correct Game",
+          igdbId: 5003,
+          status: "wanted",
+          hidden: false,
+          userId,
+        } as InsertGame);
+
+        const download = await storage.addGameDownload({
+          gameId,
+          downloaderId,
+          downloadHash: "hash-race",
+          downloadTitle: "Race-GROUP",
+          status: "game_link_required",
+          downloadType: "torrent",
+          fileSize: null,
+        } as InsertGameDownload);
+
+        // Simulates a concurrent request winning the race first.
+        await storage.relinkGameDownload(download.id, otherGame.id);
+
+        const secondAttempt = await storage.relinkGameDownload(download.id, gameId);
+        expect(secondAttempt).toBeUndefined();
+
+        // The first relink's choice of game must survive untouched.
+        const current = await storage.getGameDownload(download.id);
+        expect(current?.gameId).toBe(otherGame.id);
+      });
     });
 
     describe("getTrackedDownloadKeys", () => {

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -4,7 +4,7 @@ import { igdbLogger } from "./logger.js";
 import { notifyUser } from "./socket.js";
 import { resolvePrefs } from "./notification-prefs.js";
 import { DownloaderManager } from "./downloaders.js";
-import { resolveDownloadRelativePath } from "./downloaders/utils.js";
+import { resolveDownloadRelativePath, buildRemoteImportPath } from "./downloaders/utils.js";
 import { torznabClient } from "./torznab.js";
 import { newznabClient } from "./newznab.js";
 import { searchAllIndexers, filterBlacklistedReleases, type SearchItem } from "./search.js";
@@ -48,16 +48,6 @@ const GAME_UPDATE_TITLE_TO_EVENT: Record<string, NotificationEvent> = {
   "Game Released": "gameReleased",
   "Game Delayed": "gameDelayed",
 };
-
-function buildRemoteImportPath(downloadDir: string, name: string): string {
-  const normalizedDir = downloadDir.replace(/[\\/]+$/, "");
-  const normalizedName = name.replace(/^[\\/]+/, "");
-  const lastSegment = normalizedDir.split(/[\\/]/).pop()?.toLowerCase();
-  if (lastSegment && lastSegment === normalizedName.toLowerCase()) {
-    return normalizedDir;
-  }
-  return `${normalizedDir}/${normalizedName}`;
-}
 
 type DownloadSortBy = "seeders" | "date" | "size";
 

--- a/server/downloaders/nzbget.ts
+++ b/server/downloaders/nzbget.ts
@@ -442,13 +442,34 @@ export class NZBGetClient implements DownloaderClient {
     }
   }
 
+  // `getDownloadStatus`/`getFromHistory` return a `DownloadStatus`, which has
+  // no `downloadDir` field (only `DownloadDetails` does), so the history
+  // item's `DestDir` never made it out of those methods even though NZBGet's
+  // API provides it. Without it, ImportManager can never be handed a path to
+  // import from, and every completed NZBGet download was stuck logging
+  // "no remote path was available for import" and requiring manual review.
+  private async getHistoryDestDir(id: string): Promise<string | undefined> {
+    try {
+      const history = (await this.makeXMLRPCRequest("history")) as NZBGetHistoryResult[];
+      const item = history.find((h) => h.NZBID.toString() === id);
+      return item?.DestDir || undefined;
+    } catch (error) {
+      downloadersLogger.error({ error }, "Failed to get NZBGet history destination directory");
+      return undefined;
+    }
+  }
+
   async getDownloadDetails(id: string): Promise<DownloadDetails | null> {
     const status = await this.getDownloadStatus(id);
     if (!status) return null;
 
+    const downloadDir =
+      status.status === "completed" ? await this.getHistoryDestDir(id) : undefined;
+
     // NZBGet doesn't provide detailed file information easily
     return {
       ...status,
+      downloadDir,
       files: [],
       filesSupport: "unsupported",
       filesSupportReason: "NZBGet API does not expose per-file details for grouped downloads.",

--- a/server/downloaders/utils.ts
+++ b/server/downloaders/utils.ts
@@ -331,8 +331,19 @@ export async function logDownloaderDebugResponse(
  * genuine parent. Naively appending the relative path in that case produces
  * a nonexistent nested path like ".../Release Name/Release Name".
  */
+// Trims trailing path separators with a plain character scan instead of a
+// `[\\/]+$`-style regex, which SonarCloud flags as having super-linear
+// worst-case backtracking on inputs that don't end in a separator.
+function stripTrailingPathSeparators(value: string): string {
+  let end = value.length;
+  while (end > 0 && (value[end - 1] === "\\" || value[end - 1] === "/")) {
+    end--;
+  }
+  return value.slice(0, end);
+}
+
 export function buildRemoteImportPath(downloadDir: string, relativePath: string): string {
-  const normalizedDir = downloadDir.replace(/[\\/]+$/, "");
+  const normalizedDir = stripTrailingPathSeparators(downloadDir);
   const normalizedRelative = relativePath.replace(/^[\\/]+/, "");
   const lastSegment = normalizedDir.split(/[\\/]/).pop()?.toLowerCase();
   if (lastSegment && lastSegment === normalizedRelative.toLowerCase()) {

--- a/server/downloaders/utils.ts
+++ b/server/downloaders/utils.ts
@@ -319,3 +319,24 @@ export async function logDownloaderDebugResponse(
     );
   }
 }
+
+/**
+ * Joins a download's directory with its resolved relative path, without
+ * duplicating a segment that's already present.
+ *
+ * Usenet clients (NZBGet, SABnzbd) don't expose per-file details, so
+ * resolveDownloadRelativePath() always falls back to the release name — but
+ * for those clients `downloadDir` already IS the final content directory
+ * (its own name is the release name), unlike torrent clients where it's a
+ * genuine parent. Naively appending the relative path in that case produces
+ * a nonexistent nested path like ".../Release Name/Release Name".
+ */
+export function buildRemoteImportPath(downloadDir: string, relativePath: string): string {
+  const normalizedDir = downloadDir.replace(/[\\/]+$/, "");
+  const normalizedRelative = relativePath.replace(/^[\\/]+/, "");
+  const lastSegment = normalizedDir.split(/[\\/]/).pop()?.toLowerCase();
+  if (lastSegment && lastSegment === normalizedRelative.toLowerCase()) {
+    return normalizedDir;
+  }
+  return `${normalizedDir}/${normalizedRelative}`;
+}

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -464,7 +464,19 @@ importRouter.delete("/:id", async (req, res) => {
   const { id } = req.params;
   try {
     const userId = res.locals.userId as string;
-    const download = await storage.getGameDownload(id, userId);
+    let download = await storage.getGameDownload(id, userId);
+    if (!download) {
+      // getGameDownload(id, userId) scopes ownership by joining through the
+      // download's game — but a game_link_required download has no game row
+      // to join against (that's the whole point of the status), so it can
+      // never be found that way. Fall back to an unscoped lookup, but only
+      // accept it if the record is actually game_link_required, so this
+      // can't be used to bypass ownership scoping for any other download.
+      const unscoped = await storage.getGameDownload(id);
+      if (unscoped?.status === GAME_LINK_REQUIRED_STATUS) {
+        download = unscoped;
+      }
+    }
     if (!download) {
       return res.status(404).json({ error: "Download not found" });
     }

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -464,24 +464,35 @@ importRouter.delete("/:id", async (req, res) => {
   const { id } = req.params;
   try {
     const userId = res.locals.userId as string;
-    let download = await storage.getGameDownload(id, userId);
-    if (!download) {
-      // getGameDownload(id, userId) scopes ownership by joining through the
-      // download's game — but a game_link_required download has no game row
-      // to join against (that's the whole point of the status), so it can
-      // never be found that way. Fall back to an unscoped lookup, but only
-      // accept it if the record is actually game_link_required, so this
-      // can't be used to bypass ownership scoping for any other download.
-      const unscoped = await storage.getGameDownload(id);
-      if (unscoped?.status === GAME_LINK_REQUIRED_STATUS) {
-        download = unscoped;
-      }
+    const download = await storage.getGameDownload(id, userId);
+    if (download) {
+      await storage.updateGameDownloadStatus(id, "completed");
+      return res.json({ success: true });
     }
-    if (!download) {
+
+    // getGameDownload(id, userId) scopes ownership by joining through the
+    // download's game — but a game_link_required download has no game row
+    // to join against (that's the whole point of the status), so it can
+    // never be found that way. Fall back to an unscoped lookup, but only
+    // accept it if the record is actually game_link_required, so this can't
+    // be used to bypass ownership scoping for any other download.
+    const unscoped = await storage.getGameDownload(id);
+    if (unscoped?.status !== GAME_LINK_REQUIRED_STATUS) {
       return res.status(404).json({ error: "Download not found" });
     }
-    await storage.updateGameDownloadStatus(id, "completed");
-    res.json({ success: true });
+
+    // Transition atomically (conditional on still being game_link_required)
+    // rather than check-then-set: a concurrent POST /:id/link could relink
+    // this same download in the gap between the check above and a plain
+    // update, and an unconditional "completed" write here would silently
+    // clobber that relink instead of just dismissing an unlinked download.
+    const skipped = await storage.completeUnlinkedGameDownload(id);
+    if (!skipped) {
+      return res
+        .status(409)
+        .json({ error: "Download was linked to a game before it could be skipped" });
+    }
+    return res.json({ success: true });
   } catch (error) {
     logger.error({ error }, "Error skipping import");
     res.status(500).json({ error: "Internal server error" });

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -10,6 +10,7 @@ import {
   updatePathMappingSchema,
   importTransferModeSchema,
   IMPORT_TRANSFER_MODES,
+  GAME_LINK_REQUIRED_STATUS,
 } from "../../shared/schema.js";
 import path from "node:path";
 import fs from "fs-extra";
@@ -488,7 +489,7 @@ importRouter.post("/:id/link", async (req, res) => {
     if (!download) {
       return res.status(404).json({ error: "Download not found" });
     }
-    if (download.status !== "game_link_required") {
+    if (download.status !== GAME_LINK_REQUIRED_STATUS) {
       return res.status(400).json({ error: "This download does not need to be linked to a game" });
     }
 
@@ -498,6 +499,14 @@ importRouter.post("/:id/link", async (req, res) => {
     }
 
     const updated = await storage.relinkGameDownload(id, gameId);
+    if (!updated) {
+      // Passed the game_link_required check above but the conditional update
+      // still matched nothing — another request already relinked (or otherwise
+      // moved on) this download between the check and the write.
+      return res
+        .status(409)
+        .json({ error: "This download was already linked to a game by another request" });
+    }
     res.json({ success: true, download: updated });
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/server/routes/import.ts
+++ b/server/routes/import.ts
@@ -419,10 +419,16 @@ importRouter.get("/hardlink/check", async (req, res) => {
 importRouter.get("/pending", async (req, res) => {
   try {
     const userId = res.locals.userId as string;
-    const pending = await storage.getPendingImportReviews(userId);
+    const [pathReviews, gameLinkReviews] = await Promise.all([
+      storage.getPendingImportReviews(userId),
+      // Not scoped by userId — a download whose game record is missing has no
+      // game row left to determine ownership from. Fine for Questarr's
+      // single-user model.
+      storage.getUnlinkedImportReviews(),
+    ]);
 
-    const results = await Promise.all(
-      pending.map(async (d) => {
+    const pathResults = await Promise.all(
+      pathReviews.map(async (d) => {
         const game = await storage.getGame(d.gameId);
         return {
           id: d.id,
@@ -436,7 +442,17 @@ importRouter.get("/pending", async (req, res) => {
       })
     );
 
-    res.json(results);
+    const gameLinkResults = gameLinkReviews.map((d) => ({
+      id: d.id,
+      gameTitle: d.downloadTitle,
+      downloadTitle: d.downloadTitle,
+      status: d.status,
+      downloaderId: d.downloaderId,
+      createdAt: d.addedAt,
+      errorMessage: d.errorMessage,
+    }));
+
+    res.json([...gameLinkResults, ...pathResults]);
   } catch (error) {
     logger.error({ error }, "Error fetching pending imports");
     res.status(500).json({ error: "Internal server error" });
@@ -455,6 +471,39 @@ importRouter.delete("/:id", async (req, res) => {
     res.json({ success: true });
   } catch (error) {
     logger.error({ error }, "Error skipping import");
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// Links a "game_link_required" download to the given game, then drops it back
+// into the normal manual_review_required path-review flow (GET /:id/plan,
+// POST /:id/confirm) so the rest of the import pipeline is reused unchanged.
+importRouter.post("/:id/link", async (req, res) => {
+  const { id } = req.params;
+  try {
+    const schema = z.object({ gameId: z.string().min(1) });
+    const { gameId } = schema.parse(req.body);
+
+    const download = await storage.getGameDownload(id);
+    if (!download) {
+      return res.status(404).json({ error: "Download not found" });
+    }
+    if (download.status !== "game_link_required") {
+      return res.status(400).json({ error: "This download does not need to be linked to a game" });
+    }
+
+    const game = await storage.getGame(gameId);
+    if (!game) {
+      return res.status(404).json({ error: "Game not found" });
+    }
+
+    const updated = await storage.relinkGameDownload(id, gameId);
+    res.json({ success: true, download: updated });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: zodErrorMessage(error) });
+    }
+    logger.error({ error }, "Error linking download to game");
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/server/services/ImportManager.ts
+++ b/server/services/ImportManager.ts
@@ -340,10 +340,18 @@ export class ImportManager {
       // selects "manual_review_required") - a download that lands here would
       // sit invisibly forever even if the underlying issue (e.g. a
       // transiently missing game row) was momentary.
+      //
+      // This is deliberately its own status rather than "manual_review_required":
+      // that review flow (ImportReviewModal) only ever asks the user to confirm
+      // source/destination paths for an *existing* game — it has no way to
+      // recover from there being no game to import into at all. "game_link_required"
+      // is surfaced separately so the user is prompted to pick the right game first;
+      // relinking (POST /api/imports/:id/link) then drops the download back into the
+      // normal "manual_review_required" path-review flow once a game is attached.
       await this.storage.updateGameDownloadStatus(
         downloadId,
-        "manual_review_required",
-        "Game record not found for this download"
+        "game_link_required",
+        "This download's linked game could not be found — select a game to continue importing it."
       );
       return;
     }

--- a/server/services/ImportManager.ts
+++ b/server/services/ImportManager.ts
@@ -9,7 +9,7 @@ import {
   sanitizeFsName,
 } from "./ImportStrategies.js";
 import { DownloaderManager } from "../downloaders.js";
-import { resolveDownloadRelativePath } from "../downloaders/utils.js";
+import { resolveDownloadRelativePath, buildRemoteImportPath } from "../downloaders/utils.js";
 import fs from "fs-extra";
 import path from "node:path";
 import { parseReleaseMetadata } from "../../shared/title-utils.js";
@@ -468,7 +468,10 @@ export class ImportManager {
     const details = await DownloaderManager.getDownloadDetails(downloader, download.downloadHash);
     if (!details?.downloadDir) return undefined;
 
-    const remotePath = `${details.downloadDir}/${resolveDownloadRelativePath(details)}`;
+    const remotePath = buildRemoteImportPath(
+      details.downloadDir,
+      resolveDownloadRelativePath(details)
+    );
     const remoteHost = this.extractRemoteHost(downloader.url);
     return this.pathService.translatePath(remotePath, remoteHost);
   }
@@ -570,6 +573,10 @@ export class ImportManager {
       throw new Error(
         "Source path could not be resolved — the download may no longer be tracked by the download client. Please specify the source path manually."
       );
+    }
+
+    if (!(await fs.pathExists(resolvedOriginalPath))) {
+      throw new Error(`Source path not found: ${resolvedOriginalPath}`);
     }
 
     const game = await this.storage.getGame(download.gameId);

--- a/server/services/ImportManager.ts
+++ b/server/services/ImportManager.ts
@@ -334,7 +334,17 @@ export class ImportManager {
     const game = await this.storage.getGame(download.gameId);
     if (!game) {
       logger.error({ downloadId }, "[ImportManager] Game not found for download");
-      await this.storage.updateGameDownloadStatus(downloadId, "error");
+      // "error" is a dead end: unlike "manual_review_required", nothing ever
+      // re-polls or surfaces it in the UI (getDownloadingGameDownloads only
+      // selects status="downloading", and getPendingImportReviews only
+      // selects "manual_review_required") - a download that lands here would
+      // sit invisibly forever even if the underlying issue (e.g. a
+      // transiently missing game row) was momentary.
+      await this.storage.updateGameDownloadStatus(
+        downloadId,
+        "manual_review_required",
+        "Game record not found for this download"
+      );
       return;
     }
 

--- a/server/services/ImportManager.ts
+++ b/server/services/ImportManager.ts
@@ -13,6 +13,7 @@ import { resolveDownloadRelativePath, buildRemoteImportPath } from "../downloade
 import fs from "fs-extra";
 import path from "node:path";
 import { parseReleaseMetadata } from "../../shared/title-utils.js";
+import { GAME_LINK_REQUIRED_STATUS } from "../../shared/schema.js";
 import { logger } from "../logger.js";
 import { extractHostnameFromUrl } from "../url-utils.js";
 import { isSensitivePath } from "../path-security.js";
@@ -350,7 +351,7 @@ export class ImportManager {
       // normal "manual_review_required" path-review flow once a game is attached.
       await this.storage.updateGameDownloadStatus(
         downloadId,
-        "game_link_required",
+        GAME_LINK_REQUIRED_STATUS,
         "This download's linked game could not be found — select a game to continue importing it."
       );
       return;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -205,11 +205,18 @@ export interface IStorage {
   // GameDownload methods
   getDownloadingGameDownloads(): Promise<GameDownload[]>;
   getPendingImportReviews(userId: string): Promise<GameDownload[]>;
+  // Downloads whose linked game record couldn't be found (status "game_link_required").
+  // Unlike getPendingImportReviews, this can't be scoped by userId — there's no game
+  // row left to join against to determine ownership.
+  getUnlinkedImportReviews(): Promise<GameDownload[]>;
   getGameDownload(id: string, userId?: string): Promise<GameDownload | undefined>;
   getDownloadsByGameId(
     gameId: string
   ): Promise<(GameDownload & { downloaderName: string | null })[]>;
   updateGameDownloadStatus(id: string, status: string, errorMessage?: string | null): Promise<void>;
+  // Attaches a "game_link_required" download to the given game and drops it back into
+  // the normal "manual_review_required" path-review flow.
+  relinkGameDownload(id: string, gameId: string): Promise<GameDownload | undefined>;
   addGameDownload(gameDownload: InsertGameDownload): Promise<GameDownload | undefined>;
   removeGameDownload(id: string, gameId: string): Promise<boolean>;
   getDownloadSummaryByGame(userId: string): Promise<Record<string, DownloadSummary>>;
@@ -827,6 +834,23 @@ export class MemStorage implements IStorage {
       const game = this.games.get(d.gameId);
       return game?.userId === userId;
     });
+  }
+
+  async getUnlinkedImportReviews(): Promise<GameDownload[]> {
+    return Array.from(this.gameDownloads.values()).filter((d) => d.status === "game_link_required");
+  }
+
+  async relinkGameDownload(id: string, gameId: string): Promise<GameDownload | undefined> {
+    const gd = this.gameDownloads.get(id);
+    if (!gd) return undefined;
+    const updated: GameDownload = {
+      ...gd,
+      gameId,
+      status: "manual_review_required",
+      errorMessage: null,
+    };
+    this.gameDownloads.set(id, updated);
+    return updated;
   }
 
   async getGameDownload(id: string, userId?: string): Promise<GameDownload | undefined> {
@@ -2064,6 +2088,7 @@ export class DatabaseStorage implements IStorage {
             "error",
             "imported",
             "manual_review_required",
+            "game_link_required",
           ])
         )
       );
@@ -2076,6 +2101,19 @@ export class DatabaseStorage implements IStorage {
       .innerJoin(games, eq(gameDownloads.gameId, games.id))
       .where(and(eq(gameDownloads.status, "manual_review_required"), eq(games.userId, userId)));
     return rows.map((r) => r.gameDownloads);
+  }
+
+  async getUnlinkedImportReviews(): Promise<GameDownload[]> {
+    return db.select().from(gameDownloads).where(eq(gameDownloads.status, "game_link_required"));
+  }
+
+  async relinkGameDownload(id: string, gameId: string): Promise<GameDownload | undefined> {
+    const [updated] = await db
+      .update(gameDownloads)
+      .set({ gameId, status: "manual_review_required", errorMessage: null })
+      .where(eq(gameDownloads.id, id))
+      .returning();
+    return updated;
   }
 
   async getGameDownload(id: string, userId?: string): Promise<GameDownload | undefined> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -218,6 +218,10 @@ export interface IStorage {
   // Attaches a "game_link_required" download to the given game and drops it back into
   // the normal "manual_review_required" path-review flow.
   relinkGameDownload(id: string, gameId: string): Promise<GameDownload | undefined>;
+  // Dismisses a "game_link_required" download without linking it to a game.
+  // Conditional on the download still being game_link_required at write time,
+  // so it can't race with a concurrent relinkGameDownload for the same id.
+  completeUnlinkedGameDownload(id: string): Promise<GameDownload | undefined>;
   addGameDownload(gameDownload: InsertGameDownload): Promise<GameDownload | undefined>;
   removeGameDownload(id: string, gameId: string): Promise<boolean>;
   getDownloadSummaryByGame(userId: string): Promise<Record<string, DownloadSummary>>;
@@ -856,6 +860,14 @@ export class MemStorage implements IStorage {
       status: "manual_review_required",
       errorMessage: null,
     };
+    this.gameDownloads.set(id, updated);
+    return updated;
+  }
+
+  async completeUnlinkedGameDownload(id: string): Promise<GameDownload | undefined> {
+    const gd = this.gameDownloads.get(id);
+    if (gd?.status !== GAME_LINK_REQUIRED_STATUS) return undefined;
+    const updated: GameDownload = { ...gd, status: "completed", completedAt: new Date() };
     this.gameDownloads.set(id, updated);
     return updated;
   }
@@ -2126,6 +2138,18 @@ export class DatabaseStorage implements IStorage {
     const [updated] = await db
       .update(gameDownloads)
       .set({ gameId, status: "manual_review_required", errorMessage: null })
+      .where(and(eq(gameDownloads.id, id), eq(gameDownloads.status, GAME_LINK_REQUIRED_STATUS)))
+      .returning();
+    return updated;
+  }
+
+  async completeUnlinkedGameDownload(id: string): Promise<GameDownload | undefined> {
+    // Same conditional-update pattern as relinkGameDownload: only transitions
+    // rows still game_link_required, so this can't race with a concurrent
+    // relink for the same download silently discarding it.
+    const [updated] = await db
+      .update(gameDownloads)
+      .set({ status: "completed", completedAt: new Date() })
       .where(and(eq(gameDownloads.id, id), eq(gameDownloads.status, GAME_LINK_REQUIRED_STATUS)))
       .returning();
     return updated;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -849,7 +849,7 @@ export class MemStorage implements IStorage {
     // concurrent relink requests for the same download can't race: only the
     // first to observe this status wins, the second sees it already moved on
     // and returns undefined instead of silently overwriting the first pick.
-    if (!gd || gd.status !== GAME_LINK_REQUIRED_STATUS) return undefined;
+    if (gd?.status !== GAME_LINK_REQUIRED_STATUS) return undefined;
     const updated: GameDownload = {
       ...gd,
       gameId,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -54,6 +54,7 @@ import {
   type GameFile,
   type InsertGameFile,
   gameFiles,
+  GAME_LINK_REQUIRED_STATUS,
 } from "../shared/schema.js";
 import { randomUUID } from "crypto";
 import { db } from "./db.js";
@@ -837,12 +838,18 @@ export class MemStorage implements IStorage {
   }
 
   async getUnlinkedImportReviews(): Promise<GameDownload[]> {
-    return Array.from(this.gameDownloads.values()).filter((d) => d.status === "game_link_required");
+    return Array.from(this.gameDownloads.values()).filter(
+      (d) => d.status === GAME_LINK_REQUIRED_STATUS
+    );
   }
 
   async relinkGameDownload(id: string, gameId: string): Promise<GameDownload | undefined> {
     const gd = this.gameDownloads.get(id);
-    if (!gd) return undefined;
+    // Conditional on still being game_link_required, not just present, so two
+    // concurrent relink requests for the same download can't race: only the
+    // first to observe this status wins, the second sees it already moved on
+    // and returns undefined instead of silently overwriting the first pick.
+    if (!gd || gd.status !== GAME_LINK_REQUIRED_STATUS) return undefined;
     const updated: GameDownload = {
       ...gd,
       gameId,
@@ -2088,7 +2095,7 @@ export class DatabaseStorage implements IStorage {
             "error",
             "imported",
             "manual_review_required",
-            "game_link_required",
+            GAME_LINK_REQUIRED_STATUS,
           ])
         )
       );
@@ -2104,14 +2111,22 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getUnlinkedImportReviews(): Promise<GameDownload[]> {
-    return db.select().from(gameDownloads).where(eq(gameDownloads.status, "game_link_required"));
+    return db
+      .select()
+      .from(gameDownloads)
+      .where(eq(gameDownloads.status, GAME_LINK_REQUIRED_STATUS));
   }
 
   async relinkGameDownload(id: string, gameId: string): Promise<GameDownload | undefined> {
+    // Conditional on still being game_link_required, not just id, so two
+    // concurrent relink requests for the same download can't race: only the
+    // first to match this predicate updates anything, the second's WHERE
+    // matches zero rows and it returns undefined instead of silently
+    // overwriting the first pick.
     const [updated] = await db
       .update(gameDownloads)
       .set({ gameId, status: "manual_review_required", errorMessage: null })
-      .where(eq(gameDownloads.id, id))
+      .where(and(eq(gameDownloads.id, id), eq(gameDownloads.status, GAME_LINK_REQUIRED_STATUS)))
       .returning();
     return updated;
   }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -122,6 +122,14 @@ export interface ImportConfig {
   sortExtras: boolean;
 }
 
+// gameDownloads.status value for a download whose linked game record can't be
+// found. Kept as a shared constant (rather than the literal repeated across
+// server and client) since it's the join key between ImportManager, the
+// storage layer's getUnlinkedImportReviews/relinkGameDownload, the /link
+// route, and the pending-imports UI that decides whether to open
+// LinkGameModal or the regular ImportReviewModal.
+export const GAME_LINK_REQUIRED_STATUS = "game_link_required";
+
 export const IMPORT_TRANSFER_MODES = ["move", "copy", "hardlink", "symlink"] as const;
 
 export type ImportTransferMode = (typeof IMPORT_TRANSFER_MODES)[number];


### PR DESCRIPTION
## Description

Ports three narrow, verified bug fixes from the [Adarack/Questarr fork](https://github.com/Adarack/Questarr), which independently hit and fixed real issues in the download/import pipeline. Each was validated against this repo's current `main` before porting — I confirmed the underlying bug is still present here and the fix applies cleanly to the current code (not just the fork's older snapshot). See fork commits `772eee1`, `17aa5c0`, and `743541d`.

1. **Downloads stuck without a way to resolve them when their game record is missing** — `ImportManager.processImport()` originally set a download's status to `"error"` when its associated game record couldn't be found. That status is a dead end: it's excluded from the cron re-poll query (`getDownloadingGameDownloads`) and never surfaced by `getPendingImportReviews()` (which only selects `manual_review_required`), so an affected download sits invisibly forever with no retry path.

   Rather than routing this into the existing `manual_review_required` flow (which only ever asks the user to confirm source/destination paths for an *existing* game, and has no way to recover when there's no game to import into at all), this now has its own dedicated status, `game_link_required`. It's surfaced separately in the pending-imports list with a **Link Game** action that opens a new `LinkGameModal` for picking the correct game from the library. `POST /api/imports/:id/link` reattaches the download to that game and drops it back into the normal `manual_review_required` path-review flow, reusing the existing plan/confirm pipeline unchanged. `getUnlinkedImportReviews()` can't be scoped by userId the way `getPendingImportReviews()` is — there's no game row left to join against to determine ownership — which is fine for Questarr's single-user model.

2. **Duplicated source path for NZBGet/SABnzbd manual imports** — `resolveConfirmOriginalPath()` (used by the manual review plan/confirm flow) naively concatenated `downloadDir + release name`, which only holds for torrent clients where `downloadDir` is a genuine parent directory. NZBGet and SABnzbd report `downloadDir` as the completed job's own final directory, so the naive join produced a nonexistent nested path — the plan endpoint silently returned an empty file list, and confirm crashed with an unhandled ENOENT surfaced as a generic 500. `cron.ts`'s automatic import path already guarded against this locally; this exports that guard as `buildRemoteImportPath()` in `downloaders/utils.ts` and reuses it in both places, plus adds an explicit source-path existence check in `confirmImport` that fails with a clear "Source path not found" message instead of a raw ENOENT.

   Note: PR #915 addresses part of the same underlying SABnzbd symptom from a different angle (deriving `downloadDir` correctly at the source in `sabnzbd.ts`, plus changing confirm-failure handling to `manual_review_required`) — but that PR currently has no code pushed yet (just a plan). This fix is complementary either way: it's a general guard that also covers NZBGet (which #915 doesn't touch) and stays useful as defense-in-depth if the SABnzbd source-field derivation ever regresses.

3. **NZBGet downloads never populating `downloadDir` on completion** — every other downloader client (deluge, qbittorrent, rtorrent, sabnzbd, synology, transmission) sets `DownloadDetails.downloadDir` from that client's own equivalent field; NZBGet never did. `getDownloadDetails()` just spread the status object without ever reading history's `DestDir` field. Effect: every successfully completed NZBGet download hit cron's `if (details?.downloadDir)` check as false, unconditionally, and got logged as "no remote path was available for import" instead of ever reaching `ImportManager` — regardless of how correctly downloader paths were configured. Mirrors the pattern SABnzbd's client already uses: one extra history lookup for the destination directory, only when status is `"completed"`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`npm run check`, `npm run lint`, and full `vitest run` all pass)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149euj8Lg522kNthvVJsdRw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to link pending imports to a game by searching the game library.
  * Pending imports requiring a game link now show a dedicated “Link Game” action.
  * Completed NZBGet downloads now include their destination directory.
  * Import paths are reconstructed more reliably, avoiding duplicate folder segments.

* **Bug Fixes**
  * Import confirmation verifies that the source path still exists.
  * Missing games and failed imports now provide clearer review guidance.
  * In-progress downloads avoid unnecessary history lookups.

* **Tests**
  * Expanded coverage for game linking, import validation, NZBGet details, and path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->