### PR TITLE
Ignore subagent worktree directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ notes/
 todo.md
 .tokensave/
 .claude/.headroom_wrap_marker.json
+.claude/worktrees/


### PR DESCRIPTION
# Pull Request

## Description

`.claude/worktrees/` holds isolated git worktrees created by background subagents (Agent tool `isolation: "worktree"`). These are transient tooling state, not project content, and were showing up as untracked files. This just adds them to `.gitignore`.

No functional changes.

## Type of change

- [x] Documentation update (tooling/config housekeeping)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, `.gitignore`-only change

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhCHep3GEuETrxWEYJpJ2w)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded Claude worktree files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->