### PR TITLE
IGDB: canonicalize/dedupe game editions in search results

### DIFF
--- a/server/__tests__/igdb.test.ts
+++ b/server/__tests__/igdb.test.ts
@@ -199,13 +199,13 @@ describe("IGDBClient - Fallback Mechanism", { timeout: 20000 }, () => {
       (call) => typeof call[0] === "string" && call[0].includes("api.igdb.com/v4/games")
     );
     const body = String(gameRequest?.[1]?.body);
-    expect(body).not.toContain("platforms = (8)");
-    expect(body).not.toContain("first_release_date >=");
-    expect(body).not.toContain("first_release_date <");
-    // With local filters active, the upstream request asks for more than
-    // the caller's `limit` (capped, here 10 * 2 = 20) so there's headroom
-    // left after local platform/year filtering and edition->parent dedupe.
-    expect(body).toContain("limit 20");
+    const whereClause = /where ([^;]*);/.exec(body)?.[1] ?? "";
+    expect(whereClause).not.toMatch(/platforms/);
+    expect(whereClause).not.toMatch(/first_release_date/);
+    // The upstream request asks for more than the caller's `limit` (capped,
+    // here 10 * 2 = 20) so there's headroom left after local platform/year
+    // filtering and edition->parent dedupe.
+    expect(body).toMatch(/limit 20;/);
   });
 
   it("should return empty array when all search approaches fail", async () => {

--- a/server/__tests__/igdb.test.ts
+++ b/server/__tests__/igdb.test.ts
@@ -188,7 +188,17 @@ describe("IGDBClient - Fallback Mechanism", { timeout: 20000 }, () => {
     const emptyResponse = { ok: true, json: async () => [] };
     const successResponse = {
       ok: true,
-      json: async () => [{ id: 1, name: "God of War", first_release_date: 1110844800 }],
+      json: async () => [
+        {
+          id: 1,
+          name: "God of War",
+          first_release_date: 1110844800,
+          // Must match the requested platformId (8) -- otherwise local
+          // post-filtering discards this row and search falls through to
+          // further approaches, which this test doesn't mock responses for.
+          platforms: [{ id: 8, name: "PlayStation 2" }],
+        },
+      ],
     };
 
     // Approach 1 (full-text search, no category filter) emits no `where`
@@ -646,6 +656,54 @@ describe("IGDBClient - canonicalization runs before filtering/sorting (edition v
     // The edition matched platformId 5, but the canonical parent it resolves
     // to does not -- the parent's own metadata must govern the filter.
     expect(results).toHaveLength(0);
+  });
+
+  it("continues to the next search approach when local post-processing filters the first approach down to nothing", async () => {
+    // Regression test: postProcessSearchResults can legitimately return an
+    // empty array even when the raw IGDB response for an approach wasn't
+    // empty (canonicalization + platformId filtering collapses this
+    // approach's only row onto a non-matching parent). searchGames must not
+    // treat that as "found nothing more to look for" and stop -- it should
+    // fall through to the next search approach instead.
+    const approach1Response = {
+      ok: true,
+      json: async () => [
+        {
+          id: 20,
+          name: "Test Game 6: Deluxe Edition",
+          platforms: [{ id: 5, name: "PlayStation 5" }],
+          version_parent: { id: 200, name: "Test Game 6" },
+        },
+      ],
+    };
+    // Parent doesn't match the requested platformId -- approach 1's single
+    // row gets filtered out entirely after canonicalization.
+    const parentResponse = {
+      ok: true,
+      json: async () => [
+        { id: 200, name: "Test Game 6", platforms: [{ id: 6, name: "PC (Microsoft Windows)" }] },
+      ],
+    };
+    // Approach 2 (category-filtered search) returns a different game that
+    // does match, with no version_parent -- no further canonicalization needed.
+    const approach2Response = {
+      ok: true,
+      json: async () => [
+        { id: 201, name: "Test Game 6 Sequel", platforms: [{ id: 5, name: "PlayStation 5" }] },
+      ],
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(authResponse)
+      .mockResolvedValueOnce(approach1Response)
+      .mockResolvedValueOnce(parentResponse)
+      .mockResolvedValueOnce(approach2Response);
+
+    const { igdbClient } = await import("../igdb.js");
+    const results = await igdbClient.searchGames("Test Game 6", 20, { platformId: 5 });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ id: 201, name: "Test Game 6 Sequel" });
   });
 
   it("filters out a canonicalized result whose parent release year doesn't match releaseYear, even though the edition's did", async () => {

--- a/server/__tests__/igdb.test.ts
+++ b/server/__tests__/igdb.test.ts
@@ -185,27 +185,42 @@ describe("IGDBClient - Fallback Mechanism", { timeout: 20000 }, () => {
         token_type: "bearer",
       }),
     };
+    const emptyResponse = { ok: true, json: async () => [] };
     const successResponse = {
       ok: true,
       json: async () => [{ id: 1, name: "God of War", first_release_date: 1110844800 }],
     };
 
-    fetchMock.mockResolvedValueOnce(authResponse).mockResolvedValueOnce(successResponse);
+    // Approach 1 (full-text search, no category filter) emits no `where`
+    // clause at all, so it can't exercise the platforms/first_release_date
+    // assertions below. Make it return empty so search falls through to
+    // approach 2, which does have a `where` clause (category = 0).
+    fetchMock
+      .mockResolvedValueOnce(authResponse)
+      .mockResolvedValueOnce(emptyResponse)
+      .mockResolvedValueOnce(successResponse);
 
     const { igdbClient } = await import("../igdb.js");
     await igdbClient.searchGames("God of War", 10, { platformId: 8, releaseYear: 2005 });
 
-    const gameRequest = fetchMock.mock.calls.find(
+    const gameRequests = fetchMock.mock.calls.filter(
       (call) => typeof call[0] === "string" && call[0].includes("api.igdb.com/v4/games")
     );
-    const body = String(gameRequest?.[1]?.body);
-    const whereClause = /where ([^;]*);/.exec(body)?.[1] ?? "";
+    expect(gameRequests).toHaveLength(2);
+    const body = String(gameRequests[1]?.[1]?.body);
+    const whereClauseMatch = /where ([^;]*);/.exec(body);
+    // Confirm a `where` clause was actually emitted before asserting what it
+    // excludes -- otherwise a vacuous (null) match would make the two
+    // negative assertions below pass without checking anything.
+    expect(whereClauseMatch).not.toBeNull();
+    const whereClause = whereClauseMatch?.[1] ?? "";
     expect(whereClause).not.toMatch(/platforms/);
     expect(whereClause).not.toMatch(/first_release_date/);
-    // The upstream request asks for more than the caller's `limit` (capped,
-    // here 10 * 2 = 20) so there's headroom left after local platform/year
-    // filtering and edition->parent dedupe.
-    expect(body).toMatch(/limit 20;/);
+    // The upstream request asks for more than the caller's `limit` when a
+    // local platform/year filter is active (capped, here 10 * 5 = 50) so
+    // there's enough headroom left after that filter discards non-matching
+    // rows and edition->parent dedupe runs.
+    expect(body).toMatch(/limit 50;/);
   });
 
   it("should return empty array when all search approaches fail", async () => {

--- a/server/__tests__/igdb.test.ts
+++ b/server/__tests__/igdb.test.ts
@@ -443,6 +443,134 @@ describe("IGDBClient - Batch Operations", () => {
   });
 });
 
+describe("IGDBClient - canonicalizeVersionedGames (edition/version dedup)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    const { safeFetch } = await import("../ssrf.js");
+    fetchMock = vi.mocked(safeFetch);
+  });
+
+  const authResponse = {
+    ok: true,
+    json: async () => ({
+      access_token: "test-token",
+      expires_in: 3600,
+      token_type: "bearer",
+    }),
+  };
+
+  it("collapses editions sharing the same version_parent into a single canonical result", async () => {
+    const searchResponse = {
+      ok: true,
+      json: async () => [
+        {
+          id: 10,
+          name: "Cyberpunk 2077: Ultimate Edition",
+          first_release_date: 1704067200,
+          version_parent: { id: 100, name: "Cyberpunk 2077" },
+        },
+        {
+          id: 11,
+          name: "Cyberpunk 2077: Digital Deluxe",
+          first_release_date: 1609459200,
+          version_parent: { id: 100, name: "Cyberpunk 2077" },
+        },
+      ],
+    };
+    const parentResponse = {
+      ok: true,
+      json: async () => [{ id: 100, name: "Cyberpunk 2077", first_release_date: 1577836800 }],
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(authResponse)
+      .mockResolvedValueOnce(searchResponse)
+      .mockResolvedValueOnce(parentResponse);
+
+    const { igdbClient } = await import("../igdb.js");
+    const results = await igdbClient.searchGames("Cyberpunk 2077", 20);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ id: 100, name: "Cyberpunk 2077" });
+    // auth + search + one batch fetch of the shared canonical parent
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does NOT merge similarly-named results that lack a version_parent (no name-similarity matching)", async () => {
+    const searchResponse = {
+      ok: true,
+      json: async () => [
+        { id: 20, name: "Halo Infinite", first_release_date: 1704067200 },
+        { id: 21, name: "Halo Infinite: Campaign Edition", first_release_date: 1609459200 },
+      ],
+    };
+
+    fetchMock.mockResolvedValueOnce(authResponse).mockResolvedValueOnce(searchResponse);
+
+    const { igdbClient } = await import("../igdb.js");
+    const results = await igdbClient.searchGames("Halo Infinite", 20);
+
+    expect(results).toHaveLength(2);
+    expect(results.map((g) => g.id).sort()).toEqual([20, 21]);
+    // No version_parent on either result -- must not trigger a parent lookup fetch.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to the original uncanonicalized entries if fetching the parent game fails", async () => {
+    const searchResponse = {
+      ok: true,
+      json: async () => [
+        {
+          id: 10,
+          name: "Some Game: Special Edition",
+          first_release_date: 1704067200,
+          version_parent: { id: 100, name: "Some Game" },
+        },
+      ],
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(authResponse)
+      .mockResolvedValueOnce(searchResponse)
+      .mockRejectedValueOnce(new Error("network down"));
+
+    const { igdbClient } = await import("../igdb.js");
+    const results = await igdbClient.searchGames("Some Game", 20);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(10);
+    expect(results[0].name).toBe("Some Game: Special Edition");
+  });
+
+  it("does not fetch a parent that's already present among the raw results", async () => {
+    const searchResponse = {
+      ok: true,
+      json: async () => [
+        { id: 100, name: "Some Game", first_release_date: 1577836800 },
+        {
+          id: 10,
+          name: "Some Game: Special Edition",
+          first_release_date: 1704067200,
+          version_parent: { id: 100, name: "Some Game" },
+        },
+      ],
+    };
+
+    fetchMock.mockResolvedValueOnce(authResponse).mockResolvedValueOnce(searchResponse);
+
+    const { igdbClient } = await import("../igdb.js");
+    const results = await igdbClient.searchGames("Some Game", 20);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(100);
+    // No extra fetch for the parent -- it was already in the result set.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("IGDBClient - formatGameData metadata fields", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 

--- a/server/__tests__/igdb.test.ts
+++ b/server/__tests__/igdb.test.ts
@@ -571,6 +571,155 @@ describe("IGDBClient - canonicalizeVersionedGames (edition/version dedup)", () =
   });
 });
 
+describe("IGDBClient - canonicalization runs before filtering/sorting (edition vs. parent metadata mismatch)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    const { safeFetch } = await import("../ssrf.js");
+    fetchMock = vi.mocked(safeFetch);
+  });
+
+  const authResponse = {
+    ok: true,
+    json: async () => ({
+      access_token: "test-token",
+      expires_in: 3600,
+      token_type: "bearer",
+    }),
+  };
+
+  it("filters out a canonicalized result whose parent platforms don't match platformId, even though the edition's did", async () => {
+    const searchResponse = {
+      ok: true,
+      json: async () => [
+        {
+          id: 10,
+          name: "Test Game: Deluxe Edition",
+          platforms: [{ id: 5, name: "PlayStation 5" }],
+          version_parent: { id: 100, name: "Test Game" },
+        },
+      ],
+    };
+    // Parent has a completely different platform list than the edition.
+    const parentResponse = {
+      ok: true,
+      json: async () => [
+        { id: 100, name: "Test Game", platforms: [{ id: 6, name: "PC (Microsoft Windows)" }] },
+      ],
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(authResponse)
+      .mockResolvedValueOnce(searchResponse)
+      .mockResolvedValueOnce(parentResponse);
+
+    const { igdbClient } = await import("../igdb.js");
+    const results = await igdbClient.searchGames("Test Game", 20, { platformId: 5 });
+
+    // The edition matched platformId 5, but the canonical parent it resolves
+    // to does not -- the parent's own metadata must govern the filter.
+    expect(results).toHaveLength(0);
+  });
+
+  it("filters out a canonicalized result whose parent release year doesn't match releaseYear, even though the edition's did", async () => {
+    const searchResponse = {
+      ok: true,
+      json: async () => [
+        {
+          id: 11,
+          name: "Test Game 2: Game of the Year Edition",
+          first_release_date: 1577836800, // 2020-01-01
+          version_parent: { id: 101, name: "Test Game 2" },
+        },
+      ],
+    };
+    // Parent released in a different year than the edition.
+    const parentResponse = {
+      ok: true,
+      json: async () => [
+        { id: 101, name: "Test Game 2", first_release_date: 1420070400 }, // 2015-01-01
+      ],
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(authResponse)
+      .mockResolvedValueOnce(searchResponse)
+      .mockResolvedValueOnce(parentResponse);
+
+    const { igdbClient } = await import("../igdb.js");
+    const results = await igdbClient.searchGames("Test Game 2", 20, { releaseYear: 2020 });
+
+    expect(results).toHaveLength(0);
+  });
+
+  it("excludes a canonicalized result with includeUndated:false when the parent is undated, even though the edition was dated", async () => {
+    const searchResponse = {
+      ok: true,
+      json: async () => [
+        {
+          id: 12,
+          name: "Test Game 3: Special Edition",
+          first_release_date: 1577836800,
+          version_parent: { id: 102, name: "Test Game 3" },
+        },
+      ],
+    };
+    // Parent has no release date at all.
+    const parentResponse = {
+      ok: true,
+      json: async () => [{ id: 102, name: "Test Game 3" }],
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(authResponse)
+      .mockResolvedValueOnce(searchResponse)
+      .mockResolvedValueOnce(parentResponse);
+
+    const { igdbClient } = await import("../igdb.js");
+    const results = await igdbClient.searchGames("Test Game 3", 20, { includeUndated: false });
+
+    expect(results).toHaveLength(0);
+  });
+
+  it("sorts a canonicalized result by the parent's release date, not treated as undated just because the edition lacked one", async () => {
+    const searchResponse = {
+      ok: true,
+      json: async () => [
+        { id: 200, name: "Already Released Game", first_release_date: 1577836800 }, // 2020-01-01
+        {
+          id: 13,
+          name: "Test Game 4: Ultimate Edition",
+          // The edition itself has no first_release_date.
+          version_parent: { id: 103, name: "Test Game 4" },
+        },
+      ],
+    };
+    // Parent has a real (later) release date.
+    const parentResponse = {
+      ok: true,
+      json: async () => [{ id: 103, name: "Test Game 4", first_release_date: 1704067200 }], // 2024-01-01
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(authResponse)
+      .mockResolvedValueOnce(searchResponse)
+      .mockResolvedValueOnce(parentResponse);
+
+    const { igdbClient } = await import("../igdb.js");
+    const results = await igdbClient.searchGames("Test Game 4", 20, {
+      includeUndated: true,
+      undatedFirst: true,
+    });
+
+    // The canonicalized parent is dated (2024), so it sorts by that date
+    // alongside the other dated result rather than being pulled to the
+    // front as "undated" just because the edition lacked a date.
+    expect(results.map((game) => game.name)).toEqual(["Test Game 4", "Already Released Game"]);
+  });
+});
+
 describe("IGDBClient - formatGameData metadata fields", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 

--- a/server/__tests__/igdb.test.ts
+++ b/server/__tests__/igdb.test.ts
@@ -169,7 +169,14 @@ describe("IGDBClient - Fallback Mechanism", { timeout: 20000 }, () => {
     expect(results.map((game) => game.name)).toEqual(["Undated Game", "Newer Game", "Older Game"]);
   });
 
-  it("applies platform and release year filters before the IGDB result limit", async () => {
+  it("does not send platformId/releaseYear as an upstream IGDB `where` clause, and requests extra headroom for local filtering", async () => {
+    // platformId/releaseYear must NOT be baked into the upstream query: an
+    // edition's own platform list / first_release_date can differ from its
+    // canonical version_parent's, so if IGDB filtered upstream it could
+    // exclude an edition whose parent *would* match before canonicalization
+    // ever runs. Filtering happens locally instead, against the
+    // canonicalized (parent) metadata -- see the "canonicalization runs
+    // before filtering/sorting" describe block below.
     const authResponse = {
       ok: true,
       json: async () => ({
@@ -192,10 +199,13 @@ describe("IGDBClient - Fallback Mechanism", { timeout: 20000 }, () => {
       (call) => typeof call[0] === "string" && call[0].includes("api.igdb.com/v4/games")
     );
     const body = String(gameRequest?.[1]?.body);
-    expect(body).toContain("platforms = (8)");
-    expect(body).toContain("first_release_date >= 1104537600");
-    expect(body).toContain("first_release_date < 1136073600");
-    expect(body.indexOf("platforms = (8)")).toBeLessThan(body.indexOf("limit 10"));
+    expect(body).not.toContain("platforms = (8)");
+    expect(body).not.toContain("first_release_date >=");
+    expect(body).not.toContain("first_release_date <");
+    // With local filters active, the upstream request asks for more than
+    // the caller's `limit` (capped, here 10 * 2 = 20) so there's headroom
+    // left after local platform/year filtering and edition->parent dedupe.
+    expect(body).toContain("limit 20");
   });
 
   it("should return empty array when all search approaches fail", async () => {
@@ -717,6 +727,83 @@ describe("IGDBClient - canonicalization runs before filtering/sorting (edition v
     // alongside the other dated result rather than being pulled to the
     // front as "undated" just because the edition lacked a date.
     expect(results.map((game) => game.name)).toEqual(["Test Game 4", "Already Released Game"]);
+  });
+
+  it("keeps a canonicalized result whose parent's platforms match platformId, even though the edition's own platforms did not", async () => {
+    // Regression test: platformId must not be sent as an upstream IGDB
+    // `where` clause. If it were, IGDB itself would drop this edition from
+    // the response (its own platform list doesn't include platformId)
+    // before canonicalizeVersionedGames ever gets a chance to resolve it to
+    // a parent that does match -- the edition would never reach local
+    // filtering at all. Here the mocked upstream response includes the
+    // edition regardless of its own platforms, simulating an unfiltered
+    // upstream query, and the parent (which DOES match) must survive.
+    const searchResponse = {
+      ok: true,
+      json: async () => [
+        {
+          id: 14,
+          name: "Test Game 5: Gold Edition",
+          // Edition's own platform list does NOT include the requested platformId.
+          platforms: [{ id: 999, name: "Some Other Platform" }],
+          version_parent: { id: 104, name: "Test Game 5" },
+        },
+      ],
+    };
+    // Parent's platform list DOES include the requested platformId.
+    const parentResponse = {
+      ok: true,
+      json: async () => [
+        { id: 104, name: "Test Game 5", platforms: [{ id: 5, name: "PlayStation 5" }] },
+      ],
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(authResponse)
+      .mockResolvedValueOnce(searchResponse)
+      .mockResolvedValueOnce(parentResponse);
+
+    const { igdbClient } = await import("../igdb.js");
+    const results = await igdbClient.searchGames("Test Game 5", 20, { platformId: 5 });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ id: 104, name: "Test Game 5" });
+  });
+
+  it("keeps a canonicalized result whose parent's release year matches releaseYear, even though the edition's own release date did not", async () => {
+    // Same regression as above, for releaseYear: the edition's own release
+    // date falls outside the requested year, but its canonical parent's
+    // falls inside it. The edition must still reach local filtering (i.e.
+    // releaseYear must not be sent as an upstream `where` clause either),
+    // and the parent must be returned.
+    const searchResponse = {
+      ok: true,
+      json: async () => [
+        {
+          id: 15,
+          name: "Test Game 6: Anniversary Edition",
+          first_release_date: 1420070400, // 2015-01-01 -- outside the requested year
+          version_parent: { id: 105, name: "Test Game 6" },
+        },
+      ],
+    };
+    const parentResponse = {
+      ok: true,
+      json: async () => [
+        { id: 105, name: "Test Game 6", first_release_date: 1577836800 }, // 2020-01-01 -- matches
+      ],
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(authResponse)
+      .mockResolvedValueOnce(searchResponse)
+      .mockResolvedValueOnce(parentResponse);
+
+    const { igdbClient } = await import("../igdb.js");
+    const results = await igdbClient.searchGames("Test Game 6", 20, { releaseYear: 2020 });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ id: 105, name: "Test Game 6" });
   });
 });
 

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -575,7 +575,18 @@ class IGDBClient {
             { approach: i + 1, query: sanitizedQuery, resultCount: results.length },
             `search approach ${i + 1} found ${results.length} results`
           );
-          return await this.postProcessSearchResults(results, limit, options);
+          // postProcessSearchResults can legitimately return an empty array
+          // even though the raw response wasn't empty -- canonicalization
+          // can collapse this approach's rows onto parents that don't match
+          // a platformId/releaseYear filter, or dedupe collapses everything
+          // onto ids already excluded. Only return here if there's something
+          // to show; otherwise fall through to the next search approach
+          // instead of returning an empty result out from under a query
+          // that a later, less-targeted approach might still satisfy.
+          const processedResults = await this.postProcessSearchResults(results, limit, options);
+          if (processedResults.length > 0) {
+            return processedResults;
+          }
         }
       } catch {
         igdbLogger.warn(

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -508,19 +508,20 @@ class IGDBClient {
     // postProcessSearchResults applies platformId/releaseYear filtering
     // locally, after canonicalization, against the resolved parent's
     // metadata.
-    const filters: string[] = [];
-    const withFilters = (conditions: string[] = []) => {
-      const allConditions = [...conditions, ...filters];
-      return allConditions.length > 0 ? `where ${allConditions.join(" & ")}; ` : "";
-    };
+    const withFilters = (conditions: string[] = []) =>
+      conditions.length > 0 ? `where ${conditions.join(" & ")}; ` : "";
 
-    // When platformId/releaseYear filtering will run locally post-canonicalization,
-    // request more raw results from IGDB than `limit` so there's enough headroom
-    // left after filtering out non-matching games and deduping editions down to
-    // their canonical parent. Capped at MAX_LIMIT (IGDB's own relevance ranking
-    // keeps this tractable without needing a larger multiplier).
-    const hasLocalFilters = Boolean(options.platformId || options.releaseYear);
-    const requestLimit = hasLocalFilters ? Math.min(limit * 2, MAX_LIMIT) : limit;
+    // Request more raw results from IGDB than `limit` so there's enough
+    // headroom left after canonicalizeVersionedGames collapses editions down
+    // to their canonical parent (which can shrink the result count even for
+    // an unfiltered search) and, when platformId/releaseYear are set, after
+    // local filtering against the resolved parent's metadata. Capped at
+    // MAX_LIMIT (IGDB's own relevance ranking keeps this tractable without
+    // needing a larger multiplier).
+    const requestLimit = Math.min(limit * 2, MAX_LIMIT);
+
+    const exactNameCondition = `name ~= "${sanitizedQuery}"`;
+    const partialNameCondition = `name ~ *"${sanitizedQuery}"*`;
 
     // Try multiple search approaches to maximize results
     const searchApproaches = [
@@ -531,10 +532,10 @@ class IGDBClient {
       `search "${sanitizedQuery}"; fields ${IGDB_GAME_FIELDS}; ${withFilters(["category = 0"])}limit ${requestLimit};`,
 
       // Approach 3: Case-insensitive name matching without category
-      `fields ${IGDB_GAME_FIELDS}; ${withFilters([`name ~= "${sanitizedQuery}"`])}limit ${requestLimit};`,
+      `fields ${IGDB_GAME_FIELDS}; ${withFilters([exactNameCondition])}limit ${requestLimit};`,
 
       // Approach 4: Partial name matching without category
-      `fields ${IGDB_GAME_FIELDS}; ${withFilters([`name ~ *"${sanitizedQuery}"*`])}sort rating desc; limit ${requestLimit};`,
+      `fields ${IGDB_GAME_FIELDS}; ${withFilters([partialNameCondition])}sort rating desc; limit ${requestLimit};`,
     ];
 
     for (let i = 0; i < searchApproaches.length && attemptCount < MAX_SEARCH_ATTEMPTS; i++) {
@@ -598,7 +599,8 @@ class IGDBClient {
           const sanitizedWord = sanitizeIgdbInput(word);
           if (!sanitizedWord) return [];
 
-          const wordQuery = `fields ${IGDB_GAME_FIELDS}; ${withFilters([`name ~ *"${sanitizedWord}"*`])}sort rating desc; limit ${requestLimit};`;
+          const wordCondition = `name ~ *"${sanitizedWord}"*`;
+          const wordQuery = `fields ${IGDB_GAME_FIELDS}; ${withFilters([wordCondition])}sort rating desc; limit ${requestLimit};`;
           // Cache word search results for 15 minutes
           return await this.makeRequest<IGDBGame[]>("games", wordQuery, 15 * 60 * 1000);
         } catch (error) {

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -16,7 +16,7 @@ export const IGDB_EARLY_ACCESS_STATUS = 4;
 
 // Shared field list for all IGDB game queries
 const IGDB_GAME_FIELDS =
-  "name, summary, cover.url, first_release_date, rating, aggregated_rating, aggregated_rating_count, platforms.name, genres.name, themes.name, age_ratings.category, age_ratings.rating, screenshots.url, websites.url, websites.category, involved_companies.company.name, involved_companies.developer, involved_companies.publisher, status, game_type, category, version_parent.name, expansions.name, expansions.cover.url, expansions.first_release_date, expansions.game_type";
+  "name, summary, cover.url, first_release_date, rating, aggregated_rating, aggregated_rating_count, platforms.name, genres.name, themes.name, age_ratings.category, age_ratings.rating, screenshots.url, websites.url, websites.category, involved_companies.company.name, involved_companies.developer, involved_companies.publisher, status, game_type, category, version_parent.id, version_parent.name, expansions.name, expansions.cover.url, expansions.first_release_date, expansions.game_type";
 
 // IGDB theme name flagged as adult content (Erotic)
 const ADULT_THEME_NAMES = new Set(["Erotic"]);
@@ -288,7 +288,17 @@ class IGDBClient {
     let fetchedParentsById = new Map<number, IGDBGame>();
     if (parentIdsToFetch.length > 0) {
       try {
-        const parents = await this.getGamesByIds(parentIdsToFetch);
+        // getGamesByIds does its own internal chunking/rate-limit pacing and
+        // deliberately skips the shared per-request queue for that (see its
+        // `skipQueue: true` makeRequest calls) so its batches aren't
+        // serialized one-request-at-a-time like everything else. That's fine
+        // for a single call, but two concurrent searchGames() calls can each
+        // reach here at once and race on the shared lastRequestTime it reads
+        // to pace itself, so their batches can overlap and jointly exceed
+        // the configured rate limit. Route the whole call through the shared
+        // queue so at most one canonicalization parent-fetch (and no other
+        // queued IGDB request) runs at a time.
+        const parents = await this.queueRequest(() => this.getGamesByIds(parentIdsToFetch));
         fetchedParentsById = new Map(parents.map((game) => [game.id, game] as const));
       } catch (error) {
         igdbLogger.warn(

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -207,9 +207,13 @@ class IGDBClient {
     // ordering. An edition's platform list or first_release_date can
     // differ from its canonical parent's, so those filters/sort must be
     // evaluated against the actual game being returned to the caller, not
-    // against the edition metadata that happened to match the original
-    // IGDB query. Truncation to `limit` happens only once, at the very
-    // end, after filtering and ordering are finalized.
+    // against the edition's own metadata. This is also why searchGames
+    // deliberately omits platformId/releaseYear from the upstream IGDB
+    // `where` clause: filtering upstream would let IGDB drop an edition
+    // whose own metadata doesn't match before it ever reaches this
+    // function, even when its canonical parent would. Truncation to
+    // `limit` happens only once, at the very end, after filtering and
+    // ordering are finalized.
     const canonicalResults = await this.canonicalizeVersionedGames(results);
 
     let yearRange: { start: number; end: number } | null = null;
@@ -494,34 +498,43 @@ class IGDBClient {
 
     let attemptCount = 0;
 
+    // NOTE: platformId/releaseYear are intentionally NOT turned into `where`
+    // clauses here. An edition (e.g. "Game: Gold Edition") can carry its own
+    // platform list / first_release_date that differs from its canonical
+    // version_parent's -- if we filtered upstream, IGDB would exclude such
+    // editions from the response before canonicalizeVersionedGames ever gets
+    // a chance to resolve them to a parent that DOES match. Instead, the
+    // upstream query is left unfiltered on these fields and
+    // postProcessSearchResults applies platformId/releaseYear filtering
+    // locally, after canonicalization, against the resolved parent's
+    // metadata.
     const filters: string[] = [];
-    if (options.platformId) {
-      filters.push(`platforms = (${options.platformId})`);
-    }
-    if (options.releaseYear) {
-      const yearStart = Math.floor(Date.UTC(options.releaseYear, 0, 1) / 1000);
-      const nextYearStart = Math.floor(Date.UTC(options.releaseYear + 1, 0, 1) / 1000);
-      filters.push(`first_release_date >= ${yearStart}`);
-      filters.push(`first_release_date < ${nextYearStart}`);
-    }
     const withFilters = (conditions: string[] = []) => {
       const allConditions = [...conditions, ...filters];
       return allConditions.length > 0 ? `where ${allConditions.join(" & ")}; ` : "";
     };
 
+    // When platformId/releaseYear filtering will run locally post-canonicalization,
+    // request more raw results from IGDB than `limit` so there's enough headroom
+    // left after filtering out non-matching games and deduping editions down to
+    // their canonical parent. Capped at MAX_LIMIT (IGDB's own relevance ranking
+    // keeps this tractable without needing a larger multiplier).
+    const hasLocalFilters = Boolean(options.platformId || options.releaseYear);
+    const requestLimit = hasLocalFilters ? Math.min(limit * 2, MAX_LIMIT) : limit;
+
     // Try multiple search approaches to maximize results
     const searchApproaches = [
       // Approach 1: Full text search without category filter
-      `search "${sanitizedQuery}"; fields ${IGDB_GAME_FIELDS}; ${withFilters()}limit ${limit};`,
+      `search "${sanitizedQuery}"; fields ${IGDB_GAME_FIELDS}; ${withFilters()}limit ${requestLimit};`,
 
       // Approach 2: Full text search with category filter
-      `search "${sanitizedQuery}"; fields ${IGDB_GAME_FIELDS}; ${withFilters(["category = 0"])}limit ${limit};`,
+      `search "${sanitizedQuery}"; fields ${IGDB_GAME_FIELDS}; ${withFilters(["category = 0"])}limit ${requestLimit};`,
 
       // Approach 3: Case-insensitive name matching without category
-      `fields ${IGDB_GAME_FIELDS}; ${withFilters([`name ~= "${sanitizedQuery}"`])}limit ${limit};`,
+      `fields ${IGDB_GAME_FIELDS}; ${withFilters([`name ~= "${sanitizedQuery}"`])}limit ${requestLimit};`,
 
       // Approach 4: Partial name matching without category
-      `fields ${IGDB_GAME_FIELDS}; ${withFilters([`name ~ *"${sanitizedQuery}"*`])}sort rating desc; limit ${limit};`,
+      `fields ${IGDB_GAME_FIELDS}; ${withFilters([`name ~ *"${sanitizedQuery}"*`])}sort rating desc; limit ${requestLimit};`,
     ];
 
     for (let i = 0; i < searchApproaches.length && attemptCount < MAX_SEARCH_ATTEMPTS; i++) {
@@ -585,7 +598,7 @@ class IGDBClient {
           const sanitizedWord = sanitizeIgdbInput(word);
           if (!sanitizedWord) return [];
 
-          const wordQuery = `fields ${IGDB_GAME_FIELDS}; ${withFilters([`name ~ *"${sanitizedWord}"*`])}sort rating desc; limit ${limit};`;
+          const wordQuery = `fields ${IGDB_GAME_FIELDS}; ${withFilters([`name ~ *"${sanitizedWord}"*`])}sort rating desc; limit ${requestLimit};`;
           // Cache word search results for 15 minutes
           return await this.makeRequest<IGDBGame[]>("games", wordQuery, 15 * 60 * 1000);
         } catch (error) {

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -16,7 +16,7 @@ export const IGDB_EARLY_ACCESS_STATUS = 4;
 
 // Shared field list for all IGDB game queries
 const IGDB_GAME_FIELDS =
-  "name, summary, cover.url, first_release_date, rating, aggregated_rating, aggregated_rating_count, platforms.name, genres.name, themes.name, age_ratings.category, age_ratings.rating, screenshots.url, websites.url, websites.category, involved_companies.company.name, involved_companies.developer, involved_companies.publisher, status, game_type, expansions.name, expansions.cover.url, expansions.first_release_date, expansions.game_type";
+  "name, summary, cover.url, first_release_date, rating, aggregated_rating, aggregated_rating_count, platforms.name, genres.name, themes.name, age_ratings.category, age_ratings.rating, screenshots.url, websites.url, websites.category, involved_companies.company.name, involved_companies.developer, involved_companies.publisher, status, game_type, category, version_parent.name, expansions.name, expansions.cover.url, expansions.first_release_date, expansions.game_type";
 
 // IGDB theme name flagged as adult content (Erotic)
 const ADULT_THEME_NAMES = new Set(["Erotic"]);
@@ -89,6 +89,15 @@ export interface IGDBGame {
   }>;
   status?: number;
   game_type?: number;
+  // IGDB's "category" field on the game entity itself (distinct from
+  // download-categorizer's DownloadCategory): 0 = main game, 8 = remake,
+  // 9 = remaster, etc. Not used for filtering today, just carried through.
+  category?: number;
+  // Present when this game entity is an edition/version of another game
+  // (e.g. "Cyberpunk 2077: Ultimate Edition" -> version_parent points at
+  // "Cyberpunk 2077"). Used by canonicalizeVersionedGames to collapse
+  // editions into a single canonical search result.
+  version_parent?: { id: number; name?: string };
   expansions?: Array<{
     id: number;
     name: string;
@@ -188,24 +197,86 @@ class IGDBClient {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private cache = new Map<string, CacheEntry<any>>();
 
-  private postProcessSearchResults(
+  private async postProcessSearchResults(
     results: IGDBGame[],
     limit: number,
     options: SearchGamesOptions = {}
-  ): IGDBGame[] {
+  ): Promise<IGDBGame[]> {
     const datedResults = results
       .filter((game) => typeof game.first_release_date === "number")
       .sort((left, right) => (right.first_release_date ?? 0) - (left.first_release_date ?? 0));
 
     if (options.includeUndated === false) {
-      return datedResults.slice(0, limit);
+      return this.canonicalizeVersionedGames(datedResults, limit);
     }
 
     const undatedResults = results.filter((game) => typeof game.first_release_date !== "number");
     const orderedResults = options.undatedFirst
       ? [...undatedResults, ...datedResults]
       : [...datedResults, ...undatedResults];
-    return orderedResults.slice(0, limit);
+    // Canonicalize (collapse edition/version entries into their base game)
+    // as the very last step, after sort order is decided but before
+    // truncating to `limit`, so editions that collapse into an
+    // already-listed game don't waste result slots that a genuinely
+    // different game could otherwise fill.
+    return this.canonicalizeVersionedGames(orderedResults, limit);
+  }
+
+  /**
+   * IGDB models editions ("Gold Edition", "Deluxe Edition", ...) as separate
+   * game entities linked to their base game via `version_parent`. Collapse
+   * every edition in `results` down to its canonical (base) game, batch
+   * fetching any canonical games not already present in `results`, then
+   * dedupe by canonical id (first occurrence wins, so `results`' existing
+   * order determines which edition's position each canonical game keeps)
+   * and truncate to `limit`.
+   *
+   * Never throws: if fetching parent games fails, this logs and falls back
+   * to the original (uncanonicalized) entries.
+   */
+  private async canonicalizeVersionedGames(
+    results: IGDBGame[],
+    limit: number
+  ): Promise<IGDBGame[]> {
+    const resultById = new Map(results.map((game) => [game.id, game] as const));
+    const parentIdsToFetch = Array.from(
+      new Set(
+        results
+          .map((game) => game.version_parent?.id)
+          .filter((id): id is number => id != null && !resultById.has(id))
+      )
+    );
+
+    let fetchedParentsById = new Map<number, IGDBGame>();
+    if (parentIdsToFetch.length > 0) {
+      try {
+        const parents = await this.getGamesByIds(parentIdsToFetch);
+        fetchedParentsById = new Map(parents.map((game) => [game.id, game] as const));
+      } catch (error) {
+        igdbLogger.warn(
+          { error, parentIdsToFetch },
+          "failed to fetch version_parent games for canonicalization; falling back to uncanonicalized results"
+        );
+        return results.slice(0, limit);
+      }
+    }
+
+    const seenCanonicalIds = new Set<number>();
+    const canonical: IGDBGame[] = [];
+    for (const game of results) {
+      const parentId = game.version_parent?.id;
+      const canonicalGame =
+        parentId != null
+          ? (resultById.get(parentId) ?? fetchedParentsById.get(parentId) ?? game)
+          : game;
+
+      if (seenCanonicalIds.has(canonicalGame.id)) continue;
+      seenCanonicalIds.add(canonicalGame.id);
+      canonical.push(canonicalGame);
+      if (canonical.length >= limit) break;
+    }
+
+    return canonical;
   }
 
   private async getCredentials(): Promise<{

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -202,24 +202,56 @@ class IGDBClient {
     limit: number,
     options: SearchGamesOptions = {}
   ): Promise<IGDBGame[]> {
-    const datedResults = results
+    // Canonicalize (collapse edition/version entries into their base game)
+    // FIRST, before platformId/releaseYear filtering and date-based
+    // ordering. An edition's platform list or first_release_date can
+    // differ from its canonical parent's, so those filters/sort must be
+    // evaluated against the actual game being returned to the caller, not
+    // against the edition metadata that happened to match the original
+    // IGDB query. Truncation to `limit` happens only once, at the very
+    // end, after filtering and ordering are finalized.
+    const canonicalResults = await this.canonicalizeVersionedGames(results);
+
+    let yearRange: { start: number; end: number } | null = null;
+    if (options.releaseYear) {
+      yearRange = {
+        start: Math.floor(Date.UTC(options.releaseYear, 0, 1) / 1000),
+        end: Math.floor(Date.UTC(options.releaseYear + 1, 0, 1) / 1000),
+      };
+    }
+
+    const filteredResults = canonicalResults.filter((game) => {
+      if (options.platformId && !game.platforms?.some((p) => p.id === options.platformId)) {
+        return false;
+      }
+      if (yearRange) {
+        if (
+          typeof game.first_release_date !== "number" ||
+          game.first_release_date < yearRange.start ||
+          game.first_release_date >= yearRange.end
+        ) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    const datedResults = filteredResults
       .filter((game) => typeof game.first_release_date === "number")
       .sort((left, right) => (right.first_release_date ?? 0) - (left.first_release_date ?? 0));
 
     if (options.includeUndated === false) {
-      return this.canonicalizeVersionedGames(datedResults, limit);
+      return datedResults.slice(0, limit);
     }
 
-    const undatedResults = results.filter((game) => typeof game.first_release_date !== "number");
+    const undatedResults = filteredResults.filter(
+      (game) => typeof game.first_release_date !== "number"
+    );
     const orderedResults = options.undatedFirst
       ? [...undatedResults, ...datedResults]
       : [...datedResults, ...undatedResults];
-    // Canonicalize (collapse edition/version entries into their base game)
-    // as the very last step, after sort order is decided but before
-    // truncating to `limit`, so editions that collapse into an
-    // already-listed game don't waste result slots that a genuinely
-    // different game could otherwise fill.
-    return this.canonicalizeVersionedGames(orderedResults, limit);
+
+    return orderedResults.slice(0, limit);
   }
 
   /**
@@ -228,16 +260,18 @@ class IGDBClient {
    * every edition in `results` down to its canonical (base) game, batch
    * fetching any canonical games not already present in `results`, then
    * dedupe by canonical id (first occurrence wins, so `results`' existing
-   * order determines which edition's position each canonical game keeps)
-   * and truncate to `limit`.
+   * order determines which edition's position each canonical game keeps).
+   *
+   * Does NOT filter, sort, or truncate to a limit -- callers apply
+   * platform/year filtering and date-based ordering against the
+   * canonicalized (parent) game metadata, then truncate to the requested
+   * limit themselves, since an edition's platform list or release date can
+   * differ from its canonical parent's.
    *
    * Never throws: if fetching parent games fails, this logs and falls back
    * to the original (uncanonicalized) entries.
    */
-  private async canonicalizeVersionedGames(
-    results: IGDBGame[],
-    limit: number
-  ): Promise<IGDBGame[]> {
+  private async canonicalizeVersionedGames(results: IGDBGame[]): Promise<IGDBGame[]> {
     const resultById = new Map(results.map((game) => [game.id, game] as const));
     const parentIdsToFetch = Array.from(
       new Set(
@@ -257,7 +291,7 @@ class IGDBClient {
           { error, parentIdsToFetch },
           "failed to fetch version_parent games for canonicalization; falling back to uncanonicalized results"
         );
-        return results.slice(0, limit);
+        return results;
       }
     }
 
@@ -273,7 +307,6 @@ class IGDBClient {
       if (seenCanonicalIds.has(canonicalGame.id)) continue;
       seenCanonicalIds.add(canonicalGame.id);
       canonical.push(canonicalGame);
-      if (canonical.length >= limit) break;
     }
 
     return canonical;
@@ -514,7 +547,7 @@ class IGDBClient {
             { approach: i + 1, query: sanitizedQuery, resultCount: results.length },
             `search approach ${i + 1} found ${results.length} results`
           );
-          return this.postProcessSearchResults(results, limit, options);
+          return await this.postProcessSearchResults(results, limit, options);
         }
       } catch {
         igdbLogger.warn(
@@ -585,7 +618,20 @@ class IGDBClient {
             index === self.findIndex((g) => g.id === game.id)
         );
 
-        return this.postProcessSearchResults(uniqueResults, limit, options);
+        // This fallback path sits outside the try/catch that wraps the
+        // primary search approaches above, so guard the post-processing
+        // call explicitly -- a rejection here must not escape as an
+        // unhandled crash; fall back to the uncanonicalized/unfiltered
+        // word-search results instead.
+        try {
+          return await this.postProcessSearchResults(uniqueResults, limit, options);
+        } catch (error) {
+          igdbLogger.warn(
+            { error, query: sanitizedQuery },
+            "post-processing failed for word search fallback results; returning uncanonicalized results"
+          );
+          return uniqueResults.slice(0, limit);
+        }
       }
     }
 

--- a/server/igdb.ts
+++ b/server/igdb.ts
@@ -525,10 +525,14 @@ class IGDBClient {
     // headroom left after canonicalizeVersionedGames collapses editions down
     // to their canonical parent (which can shrink the result count even for
     // an unfiltered search) and, when platformId/releaseYear are set, after
-    // local filtering against the resolved parent's metadata. Capped at
+    // local filtering against the resolved parent's metadata. A local filter
+    // discards a much larger share of the raw rows than edition dedupe
+    // alone, so ask for more headroom when one is set. Still capped at
     // MAX_LIMIT (IGDB's own relevance ranking keeps this tractable without
-    // needing a larger multiplier).
-    const requestLimit = Math.min(limit * 2, MAX_LIMIT);
+    // needing an even larger multiplier).
+    const hasLocalFilter = options.platformId != null || options.releaseYear != null;
+    const headroomMultiplier = hasLocalFilter ? 5 : 2;
+    const requestLimit = Math.min(limit * headroomMultiplier, MAX_LIMIT);
 
     const exactNameCondition = `name ~= "${sanitizedQuery}"`;
     const partialNameCondition = `name ~ *"${sanitizedQuery}"*`;


### PR DESCRIPTION
## Description

Part of a split of #935 into smaller, independently reviewable PRs (see that PR for the full list). This is item 7: IGDB edition canonicalization/dedup.

IGDB models editions ("Gold Edition", "Deluxe Edition", ...) as separate game entities linked to their base game via `version_parent`. `searchGames()` previously returned every edition as a distinct result, cluttering a limited results window with near-duplicates of the same game.

- Adds `version_parent` (`.id` and `.name`) and `category` to the requested field list and `IGDBGame` type, and a `canonicalizeVersionedGames(results, limit)` helper: collects distinct parent ids not already present in the result set, batch-fetches them via the existing `getGamesByIds`, remaps every edition to its canonical parent, dedupes by canonical id (first occurrence wins). On any failure fetching parents it logs and falls back to the original (uncanonicalized) entries — it never throws.
- Wired in as the final step of `postProcessSearchResults`, after sort order is decided but before truncating to `limit`.
- Fixes canonicalization ordering: edition→parent canonicalization now runs *before* `platformId`/`releaseYear` filtering and date-based sorting, so those evaluate the actual canonical game being returned instead of stale edition metadata (platform list, `first_release_date`) that can differ. Also removes `platformId`/`releaseYear` from the upstream IGDB `where` clause entirely — an edition that doesn't itself match the requested platform/year was previously excluded by IGDB's own API before ever reaching canonicalization, even when its `version_parent` (the base game) would have matched. Local filtering runs post-canonicalization against 2x-limit headroom (capped) requested from IGDB, so dedupe doesn't shrink result counts below the caller's requested limit.
- `postProcessSearchResults` is now properly awaited in both the primary search-approach loop and the word-search fallback (each in its own try/catch), so a rejection doesn't escape as an unhandled promise rejection.
- Routes the canonicalization parent-fetch through the shared `queueRequest` rate-limit serializer, since `getGamesByIds` skips that queue internally and two concurrent `searchGames()` calls could otherwise race on the shared pacing state.
- Requests `version_parent.id` (not just `.name`) so canonicalization actually gets the ID it needs from real API responses.

## Validation

- `npm run check` — passes
- `npx vitest run server/__tests__/igdb.test.ts` — 32 passed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WRPBAsaPG8msACszPPv5X2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results now consolidate game editions and versions under their canonical base games.
  * Platform and release-year filters are applied using canonical game metadata for more accurate results.
  * Results remain deduplicated and sorted after canonicalization.
  * Editions whose base games match the selected filters are retained in results.

* **Bug Fixes**
  * Improved handling of missing or failed parent-game lookups, preserving usable search results when canonicalization cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->