### PR TITLE
Fix production log level hardcoded to debug; add secret redaction

### DIFF
--- a/server/__tests__/logger.test.ts
+++ b/server/__tests__/logger.test.ts
@@ -55,6 +55,53 @@ describe("Logger Module", () => {
     expect(loggerModule.logger.level).toBe("debug");
   });
 
+  it("should default to info level in production when LOG_LEVEL is not set", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.LOG_LEVEL;
+
+    const loggerModule = await import("../logger.js");
+
+    expect(loggerModule.logger.level).toBe("info");
+  });
+
+  it("should still let LOG_LEVEL override the production default", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.LOG_LEVEL = "warn";
+
+    const loggerModule = await import("../logger.js");
+
+    expect(loggerModule.logger.level).toBe("warn");
+  });
+
+  it("redacts secret-shaped fields from structured log objects before they hit the sink", async () => {
+    const loggerModule = await import("../logger.js");
+    const { logEmitter } = await import("../log-events.js");
+
+    const line: string = await new Promise((resolve) => {
+      logEmitter.once("line", (l: string) => resolve(l));
+      loggerModule.logger.info(
+        {
+          apiKey: "super-secret-value",
+          token: "abc123",
+          nested: { password: "hunter2" },
+          safe: "keep-me",
+        },
+        "redaction marker message"
+      );
+    });
+
+    expect(line).not.toContain("super-secret-value");
+    expect(line).not.toContain("hunter2");
+
+    const parsed = JSON.parse(line);
+    expect(parsed).toMatchObject({
+      apiKey: "[redacted]",
+      token: "[redacted]",
+      nested: { password: "[redacted]" },
+      safe: "keep-me",
+    });
+  });
+
   it("configures the pino-pretty stdout target outside of production", async () => {
     process.env.NODE_ENV = "development";
 

--- a/server/__tests__/security-redaction.test.ts
+++ b/server/__tests__/security-redaction.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { redactSecretText, redactSecrets } from "../security.js";
+
+describe("redactSecretText", () => {
+  it("redacts key=value style secrets", () => {
+    expect(redactSecretText("apikey=abc123&other=fine")).toBe("apikey=[redacted]&other=fine");
+    expect(redactSecretText('password: "hunter2"')).toContain("password=[redacted]");
+  });
+
+  it("redacts Bearer tokens", () => {
+    const input = "Authorization header was Bearer eyJhbGciOiJIUzI1NiJ9.abc.def";
+    expect(redactSecretText(input)).toBe("Authorization header was Bearer [redacted]");
+  });
+
+  it("redacts Discord webhook URLs", () => {
+    const input = "https://discord.com/api/webhooks/12345/abcdef-token";
+    expect(redactSecretText(input)).toBe("[redacted-discord-webhook]");
+  });
+
+  it("leaves ordinary text untouched", () => {
+    const input = "Search completed with 12 results for query 'zelda'";
+    expect(redactSecretText(input)).toBe(input);
+  });
+});
+
+describe("redactSecrets", () => {
+  it("redacts values whose key looks secret-shaped", () => {
+    const result = redactSecrets({
+      apiKey: "abc123",
+      client_secret: "xyz789",
+      password: "hunter2",
+      token: "tok_1",
+      title: "My Game",
+    });
+
+    expect(result).toEqual({
+      apiKey: "[redacted]",
+      client_secret: "[redacted]",
+      password: "[redacted]",
+      token: "[redacted]",
+      title: "My Game",
+    });
+  });
+
+  it("recurses into nested objects and arrays", () => {
+    const result = redactSecrets({
+      downloader: { name: "qbit", password: "secret-pw" },
+      indexers: [
+        { name: "idx1", apiKey: "key1" },
+        { name: "idx2", apiKey: "key2" },
+      ],
+    });
+
+    expect(result).toEqual({
+      downloader: { name: "qbit", password: "[redacted]" },
+      indexers: [
+        { name: "idx1", apiKey: "[redacted]" },
+        { name: "idx2", apiKey: "[redacted]" },
+      ],
+    });
+  });
+
+  it("redacts secret-shaped substrings inside plain string values too", () => {
+    const result = redactSecrets({ message: "used Bearer sekrettoken123 to authenticate" });
+    expect(result).toEqual({ message: "used Bearer [redacted] to authenticate" });
+  });
+
+  it("passes through primitives and non-secret objects unchanged", () => {
+    expect(redactSecrets(42)).toBe(42);
+    expect(redactSecrets(null)).toBeNull();
+    expect(redactSecrets(undefined)).toBeUndefined();
+    expect(redactSecrets({ count: 3, ok: true })).toEqual({ count: 3, ok: true });
+  });
+
+  it("summarizes Error objects instead of leaking their full shape", () => {
+    const error = new Error("token=abc123 was invalid");
+    expect(redactSecrets(error)).toEqual({
+      name: "Error",
+      message: "token=[redacted] was invalid",
+    });
+  });
+});

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -2,6 +2,7 @@ import pino from "pino";
 import { Writable } from "node:stream";
 import { consumeLogChunk, flushLogRemainder } from "./log-stream.js";
 import { logEmitter } from "./log-events.js";
+import { redactSecrets } from "./security.js";
 
 class LogBroadcaster extends Writable {
   private remainder = "";
@@ -31,6 +32,12 @@ class LogBroadcaster extends Writable {
 
 const isProduction = process.env.NODE_ENV === "production";
 const isTest = process.env.NODE_ENV === "test";
+
+// Default log verbosity by environment (LOG_LEVEL always overrides this):
+// quiet info-level logs in production, verbose debug logs everywhere else
+// (development and test), matching how the rest of the repo's env-based
+// config (see config.ts) treats NODE_ENV.
+const DEFAULT_LOG_LEVEL = isProduction ? "info" : "debug";
 
 // Tests import this module in every server test file. The full transport pipeline below
 // spawns worker threads per target (file + pino-pretty) and writes to a shared server.log,
@@ -66,9 +73,16 @@ const destination = isTest
 
 export const logger = pino(
   {
-    level: process.env.LOG_LEVEL || "debug",
+    level: process.env.LOG_LEVEL || DEFAULT_LOG_LEVEL,
     timestamp: pino.stdTimeFunctions.isoTime,
     base: undefined,
+    formatters: {
+      // Redact secret-shaped fields (api keys, tokens, passwords, Bearer
+      // headers, ...) out of every structured log object before it's
+      // serialized, so an accidental `logger.info({ config })` call can't
+      // leak credentials to the log sink.
+      log: (object) => redactSecrets(object) as Record<string, unknown>,
+    },
   },
   destination
 );

--- a/server/security.ts
+++ b/server/security.ts
@@ -10,16 +10,20 @@ const SECRET_KEY_PATTERN =
  * out of a plain string before it reaches a log sink.
  */
 export function redactSecretText(value: string): string {
-  return value
-    .replace(
-      /\b(apikey|api[_-]?key|token|password|secret)["']?\s*[:=]\s*["']?([^"',\s&]+)["']?/gi,
-      "$1=[redacted]"
-    )
-    .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
-    .replace(
-      /https:\/\/(?:discord|discordapp)\.com\/api\/webhooks\/[^\s"'<>]+/gi,
-      "[redacted-discord-webhook]"
-    );
+  return (
+    value
+      .replace(
+        /\b(apikey|api[_-]?key|token|password|secret)["']?\s*[:=]\s*["']?([^"',\s&]+)["']?/gi,
+        "$1=[redacted]"
+      )
+      // The /i flag already folds case, so an explicit A-Z range here would
+      // duplicate a-z -- SonarCloud flags that as a redundant character class.
+      .replace(/(Bearer\s+)[a-z0-9._~+/=-]+/gi, "$1[redacted]")
+      .replace(
+        /https:\/\/(?:discord|discordapp)\.com\/api\/webhooks\/[^\s"'<>]+/gi,
+        "[redacted-discord-webhook]"
+      )
+  );
 }
 
 /**

--- a/server/security.ts
+++ b/server/security.ts
@@ -1,0 +1,47 @@
+// Small, dependency-free security helpers shared across the server. Keep
+// additions here narrowly scoped -- this is not a place for a general
+// utility grab-bag.
+
+const SECRET_KEY_PATTERN =
+  /(api[_-]?key|apikey|authorization|bearer|client[_-]?secret|cookie|csrf|jwt|password|secret|token|webhook)/i;
+
+/**
+ * Redact common secret-shaped substrings (api_key=..., Bearer <token>, etc.)
+ * out of a plain string before it reaches a log sink.
+ */
+export function redactSecretText(value: string): string {
+  return value
+    .replace(
+      /\b(apikey|api[_-]?key|token|password|secret)["']?\s*[:=]\s*["']?([^"',\s&]+)["']?/gi,
+      "$1=[redacted]"
+    )
+    .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
+    .replace(
+      /https:\/\/(?:discord|discordapp)\.com\/api\/webhooks\/[^\s"'<>]+/gi,
+      "[redacted-discord-webhook]"
+    );
+}
+
+/**
+ * Recursively redact values whose key looks secret-shaped (api_key, token,
+ * password, secret, authorization, ...), and run redactSecretText over every
+ * remaining string. Used as a pino `formatters.log` hook so structured log
+ * fields never leak credentials, even if a caller accidentally logs a raw
+ * config/downloader/indexer object.
+ */
+export function redactSecrets(value: unknown, depth = 0): unknown {
+  if (depth > 8) return "[Redacted: depth limit]";
+  if (value == null) return value;
+  if (typeof value === "string") return redactSecretText(value);
+  if (typeof value !== "object") return value;
+  if (value instanceof Error) {
+    return { name: value.name, message: redactSecretText(value.message) };
+  }
+  if (Array.isArray(value)) return value.map((item) => redactSecrets(item, depth + 1));
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    redacted[key] = SECRET_KEY_PATTERN.test(key) ? "[redacted]" : redactSecrets(entry, depth + 1);
+  }
+  return redacted;
+}


### PR DESCRIPTION
## Description

Part of a split of #935 into smaller, independently reviewable PRs (see that PR for the full list). This is item 6: production log level + secret redaction.

`server/logger.ts` hardcoded the default Pino log level to `"debug"` regardless of `NODE_ENV`, unless `LOG_LEVEL` was explicitly set — meaning a default production deploy runs at debug verbosity. Defaults to `"info"` in production and `"debug"` otherwise (`LOG_LEVEL` still overrides either way), matching how the rest of the repo treats `NODE_ENV` (see `config.ts`).

Adds a new `server/security.ts` with small, dependency-free `redactSecretText`/`redactSecrets` helpers (regex-redact `api_key`/`token`/`password`/`secret`-shaped keys and values, `Bearer` headers, Discord webhook URLs) and wires `redactSecrets` into the logger as a pino `formatters.log` hook, so structured log fields can't leak credentials even from an accidental `logger.info({ config })` call.

## Validation

- `npm run check` — passes
- `npx vitest run server/__tests__/logger.test.ts server/__tests__/security-redaction.test.ts server/__tests__/security.test.ts` — 30 passed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security-relevant change — production no longer defaults to debug-level logging, and log fields are now redacted of common secret shapes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WRPBAsaPG8msACszPPv5X2)_