### PR TITLE
Fix unauthenticated GET /api/config; add default-deny API auth boundary

### DIFF
--- a/client/src/__tests__/SetupPage.test.tsx
+++ b/client/src/__tests__/SetupPage.test.tsx
@@ -77,7 +77,7 @@ describe("SetupPage", () => {
   it("submits form successfully without IGDB fields when IGDB is already configured", async () => {
     // Mock config as configured
     mockApiRequest.mockImplementation((method, url) => {
-      if (url === "/api/config") {
+      if (url === "/api/auth/status") {
         return Promise.resolve({
           json: async () => ({ igdb: { configured: true } }),
         } as Response);
@@ -94,7 +94,7 @@ describe("SetupPage", () => {
 
     // Wait for config to load and verify IGDB fields are NOT present
     await waitFor(() => {
-      expect(mockApiRequest).toHaveBeenCalledWith("GET", "/api/config");
+      expect(mockApiRequest).toHaveBeenCalledWith("GET", "/api/auth/status");
       expect(screen.queryByLabelText(/client id/i)).not.toBeInTheDocument();
     });
 
@@ -122,7 +122,7 @@ describe("SetupPage", () => {
   it("requires IGDB fields when IGDB is NOT configured", async () => {
     // Mock config as NOT configured
     mockApiRequest.mockImplementation((method, url) => {
-      if (url === "/api/config") {
+      if (url === "/api/auth/status") {
         return Promise.resolve({
           json: async () => ({ igdb: { configured: false } }),
         } as Response);
@@ -136,7 +136,7 @@ describe("SetupPage", () => {
 
     // Wait for config to load and verify IGDB fields ARE present
     await waitFor(() => {
-      expect(mockApiRequest).toHaveBeenCalledWith("GET", "/api/config");
+      expect(mockApiRequest).toHaveBeenCalledWith("GET", "/api/auth/status");
       expect(screen.getByLabelText(/client id/i)).toBeInTheDocument();
     });
 

--- a/client/src/__tests__/SetupPage.test.tsx
+++ b/client/src/__tests__/SetupPage.test.tsx
@@ -174,4 +174,33 @@ describe("SetupPage", () => {
       });
     });
   });
+
+  it("does not crash when GET /api/auth/status returns { hasUsers: true } (no igdb field)", async () => {
+    // Once setup is complete, /api/auth/status omits the igdb field entirely
+    // (see server/routes.ts) -- a direct navigation to /setup racing ahead of
+    // AuthProvider's own redirect must not crash this page while it renders.
+    mockApiRequest.mockImplementation((method, url) => {
+      if (url === "/api/auth/status") {
+        return Promise.resolve({
+          json: async () => ({ hasUsers: true }),
+        } as Response);
+      }
+      return Promise.resolve({ json: async () => ({}) } as Response);
+    });
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(mockApiRequest).toHaveBeenCalledWith("GET", "/api/auth/status");
+      expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    });
+
+    // igdb is absent, so isIgdbConfigured is falsy and the IGDB fields
+    // render as required -- the same as the "not configured" case. The
+    // regression this guards against is a crash reading config.igdb.configured
+    // when igdb itself is undefined, not this field's required-ness.
+    await waitFor(() => {
+      expect(screen.getByLabelText(/client id/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/client/src/pages/auth/setup.tsx
+++ b/client/src/pages/auth/setup.tsx
@@ -210,7 +210,7 @@ export default function SetupPage() {
                 )}
               />
 
-              {config && !config.igdb.configured && (
+              {config && !config.igdb?.configured && (
                 <>
                   <div className="border-t my-4 pt-4">
                     <div className="flex items-center gap-2 mb-2">

--- a/client/src/pages/auth/setup.tsx
+++ b/client/src/pages/auth/setup.tsx
@@ -38,10 +38,15 @@ export default function SetupPage() {
   const { toast } = useToast();
   // const [_, setLocation] = useLocation();
 
-  const { data: config, isLoading: isLoadingConfig } = useQuery({
-    queryKey: ["config"],
-    queryFn: () => apiRequest("GET", "/api/config").then((res) => res.json()),
+  // GET /api/config requires authentication, which doesn't exist yet during
+  // setup, so the IGDB-configured status is read from the unauthenticated
+  // GET /api/auth/status endpoint instead (shares the query cache with
+  // AuthProvider's own status check).
+  const { data: statusData, isLoading: isLoadingConfig } = useQuery({
+    queryKey: ["/api/auth/status"],
+    queryFn: () => apiRequest("GET", "/api/auth/status").then((res) => res.json()),
   });
+  const config = statusData;
 
   const setupSchema = useMemo(() => {
     const isIgdbConfigured = config?.igdb?.configured;

--- a/server/__tests__/auth-boundary.test.ts
+++ b/server/__tests__/auth-boundary.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import {
+  mockConfig,
+  createStorageMock,
+  createIgdbMock,
+  createDbMock,
+  createLoggerMocks,
+  createRssMock,
+  createTorznabMock,
+  createNewznabMock,
+  createProwlarrMock,
+  createXrelMock,
+  createAppriseMock,
+  createDownloaderManagerMock,
+  createSteamRoutesMock,
+  createSearchMock,
+  createConfigLoaderMock,
+  createSocketMock,
+} from "./fixtures/common-route-mocks.js";
+
+// This suite intentionally does NOT mock ../auth.js: it exercises the real
+// authenticateToken/requireAuthenticationForApi wiring end-to-end (via the
+// real registerRoutes app) to prove the default-deny API auth boundary
+// actually works, rather than relying on the shared auth-bypassing mock the
+// rest of the route test suite uses for convenience.
+vi.mock("../storage.js", () => ({ storage: createStorageMock() }));
+vi.mock("../igdb.js", () => ({ igdbClient: createIgdbMock() }));
+vi.mock("../db.js", () => ({ db: createDbMock() }));
+vi.mock("../logger.js", () => createLoggerMocks());
+vi.mock("../rss.js", () => ({ rssService: createRssMock() }));
+vi.mock("../torznab.js", () => ({ torznabClient: createTorznabMock() }));
+vi.mock("../newznab.js", () => ({ newznabClient: createNewznabMock() }));
+vi.mock("../prowlarr.js", () => ({ prowlarrClient: createProwlarrMock() }));
+vi.mock("../xrel.js", () => createXrelMock());
+vi.mock("../apprise.js", async () => createAppriseMock());
+vi.mock("../downloaders.js", () => ({ DownloaderManager: createDownloaderManagerMock() }));
+vi.mock("../steam-routes.js", () => ({ steamRoutes: createSteamRoutesMock() }));
+vi.mock("../search.js", () => createSearchMock());
+vi.mock("../config.js", () => ({ config: mockConfig }));
+vi.mock("../config-loader.js", () => ({ configLoader: createConfigLoaderMock() }));
+vi.mock("../socket.js", () => createSocketMock());
+
+const JWT_SECRET = mockConfig.auth.jwtSecret;
+
+describe("default-deny API auth boundary", () => {
+  let app: express.Express;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    const { storage } = await import("../storage.js");
+    (storage.countUsers as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+    (storage.getSystemConfig as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    (storage.getUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "user-1",
+      username: "testuser",
+    });
+
+    const { db } = await import("../db.js");
+    (db.get as ReturnType<typeof vi.fn>).mockResolvedValue({ result: 1 });
+
+    const { igdbClient } = await import("../igdb.js");
+    (igdbClient.getPopularGames as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const { registerRoutes } = await import("../routes.js");
+    app = express();
+    app.use(express.json());
+    await registerRoutes(app);
+  });
+
+  function tokenFor(id: string) {
+    return jwt.sign({ id, username: "testuser" }, JWT_SECRET);
+  }
+
+  describe("previously-public routes still work with no token", () => {
+    it("GET /api/auth/status", async () => {
+      const res = await request(app).get("/api/auth/status");
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("hasUsers");
+    });
+
+    it("GET /api/health", async () => {
+      const res = await request(app).get("/api/health");
+      expect(res.status).toBe(200);
+    });
+
+    it("GET /api/ready", async () => {
+      const res = await request(app).get("/api/ready");
+      expect(res.status).toBe(200);
+    });
+
+    it("POST /api/auth/login (fails on bad creds, but isn't blocked by auth)", async () => {
+      const res = await request(app)
+        .post("/api/auth/login")
+        .send({ username: "nope", password: "nope" });
+      // Must not be 401 "Authentication required" from the boundary middleware;
+      // the route's own credential check returns 401 with a different body.
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Invalid username or password");
+    });
+
+    it("POST /api/auth/setup (rejected for a different reason once a user exists, not by the boundary)", async () => {
+      const res = await request(app)
+        .post("/api/auth/setup")
+        .send({ username: "admin", password: "password123" });
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe("Setup already completed");
+    });
+  });
+
+  describe("GET /api/config now requires auth", () => {
+    it("rejects with 401 when no token is provided", async () => {
+      const res = await request(app).get("/api/config");
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Authentication required");
+    });
+
+    it("succeeds with a valid token", async () => {
+      const res = await request(app)
+        .get("/api/config")
+        .set("Authorization", `Bearer ${tokenFor("user-1")}`);
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("igdb");
+    });
+  });
+
+  describe("fail-safe by default", () => {
+    it("a route NOT on the allowlist requires auth even though it has no explicit authenticateToken", async () => {
+      // /api/ready has no inline `authenticateToken` in its handler -- it is
+      // protected purely by being absent from PUBLIC_API_ROUTES combined with
+      // the default-deny boundary. Simulate "a new route was added and
+      // forgotten from the allowlist" by hitting an arbitrary unregistered
+      // /api/* path: Express falls through past the boundary middleware (which
+      // still ran and required auth) to a 404, never to an unauthenticated 200.
+      const res = await request(app).get("/api/this-route-does-not-exist-and-was-never-added");
+      expect(res.status).not.toBe(200);
+      expect([401, 404]).toContain(res.status);
+    });
+
+    it("unit: requireAuthenticationForApi requires auth for any unlisted path", async () => {
+      const { requireAuthenticationForApi, PUBLIC_API_ROUTES } = await import("../routes.js");
+
+      // Sanity: our synthetic path really isn't on the allowlist.
+      expect(PUBLIC_API_ROUTES.has("GET /brand-new-route-nobody-allowlisted")).toBe(false);
+
+      const req = {
+        method: "GET",
+        path: "/brand-new-route-nobody-allowlisted",
+        headers: {},
+      } as unknown as import("express").Request;
+      const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+      } as unknown as import("express").Response;
+      const next = vi.fn();
+
+      await requireAuthenticationForApi(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/__tests__/auth-boundary.test.ts
+++ b/server/__tests__/auth-boundary.test.ts
@@ -133,11 +133,14 @@ describe("default-deny API auth boundary", () => {
       // protected purely by being absent from PUBLIC_API_ROUTES combined with
       // the default-deny boundary. Simulate "a new route was added and
       // forgotten from the allowlist" by hitting an arbitrary unregistered
-      // /api/* path: Express falls through past the boundary middleware (which
-      // still ran and required auth) to a 404, never to an unauthenticated 200.
+      // /api/* path: the boundary middleware runs before Express's own 404
+      // fallback ever gets a chance, so an unauthenticated request must be
+      // rejected with 401 -- never fall through to an unauthenticated 200,
+      // and never a bare 404 either, since that would also pass if the
+      // boundary middleware were accidentally removed (Express's own
+      // catch-all would produce a 404 on its own in that case too).
       const res = await request(app).get("/api/this-route-does-not-exist-and-was-never-added");
-      expect(res.status).not.toBe(200);
-      expect([401, 404]).toContain(res.status);
+      expect(res.status).toBe(401);
     });
 
     it("unit: requireAuthenticationForApi requires auth for any unlisted path", async () => {

--- a/server/__tests__/security.test.ts
+++ b/server/__tests__/security.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import request from "supertest";
 import express from "express";
+import jwt from "jsonwebtoken";
 import { createApp as createServerApp } from "../app.js";
 
 // Use vi.hoisted to create the mock object before hoisting occurs
@@ -50,6 +51,7 @@ vi.mock("../storage.js", () => ({
   storage: {
     countUsers: vi.fn().mockResolvedValue(0),
     getSystemConfig: vi.fn().mockResolvedValue(null),
+    getUser: vi.fn().mockResolvedValue({ id: "user-1", username: "testuser" }),
   },
 }));
 
@@ -202,19 +204,33 @@ describe("Credential Exposure Prevention", () => {
     return app;
   };
 
-  it("should not expose IGDB clientId in the unauthenticated /api/config response", async () => {
+  const authToken = () =>
+    jwt.sign({ id: "user-1", username: "testuser" }, mockConfig.auth.jwtSecret);
+
+  it("requires authentication for GET /api/config (no unauthenticated access at all)", async () => {
     const app = await createApp();
     const response = await request(app).get("/api/config");
+
+    expect(response.status).toBe(401);
+  });
+
+  it("should not expose IGDB clientId in the authenticated /api/config response", async () => {
+    const app = await createApp();
+    const response = await request(app)
+      .get("/api/config")
+      .set("Authorization", `Bearer ${authToken()}`);
 
     expect(response.status).toBe(200);
     expect(response.body).not.toHaveProperty("igdb.clientId");
-    // The public endpoint should only return whether IGDB is configured
+    // Even authenticated, the endpoint should only return whether IGDB is configured
     expect(response.body.igdb).toHaveProperty("configured");
   });
 
-  it("should not expose IGDB clientSecret in the unauthenticated /api/config response", async () => {
+  it("should not expose IGDB clientSecret in the authenticated /api/config response", async () => {
     const app = await createApp();
-    const response = await request(app).get("/api/config");
+    const response = await request(app)
+      .get("/api/config")
+      .set("Authorization", `Bearer ${authToken()}`);
 
     expect(response.status).toBe(200);
     expect(response.body).not.toHaveProperty("igdb.clientSecret");

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -104,6 +104,62 @@ const normalizeInitialReleaseStatus = <
 // Root directory for the file system browser; restrict browsing to this tree
 const FILE_BROWSER_ROOT = fs.realpathSync(process.cwd());
 
+/**
+ * Whether IGDB credentials are configured (DB takes precedence over env vars),
+ * and which source they came from. Shared between the authenticated
+ * GET /api/config endpoint and the unauthenticated GET /api/auth/status
+ * endpoint (which needs just this boolean to drive the setup wizard, without
+ * exposing anything else config-related pre-login).
+ */
+async function getIgdbConfigStatus(): Promise<{
+  configured: boolean;
+  source: "env" | "database" | undefined;
+}> {
+  const dbClientId = await storage.getSystemConfig("igdb.clientId");
+  const dbClientSecret = await storage.getSystemConfig("igdb.clientSecret");
+
+  if (dbClientId && dbClientSecret) {
+    return { configured: true, source: "database" };
+  }
+  if (appConfig.igdb.isConfigured) {
+    return { configured: true, source: "env" };
+  }
+  return { configured: false, source: undefined };
+}
+
+// ── Default-deny API auth boundary ─────────────────────────────────────────
+// Every /api/* route requires authentication unless explicitly allowlisted
+// here. This is intentionally an allowlist (not a denylist of "routes that
+// need auth") so that a new route added without updating this list fails
+// safe -- it requires a token by default rather than accidentally becoming
+// public. Paths are relative to the "/api" mount point (no leading "/api").
+export const PUBLIC_API_ROUTES = new Set<string>([
+  "GET /auth/status", // setup-wizard / login-page bootstrap check, runs pre-login
+  "POST /auth/setup", // creates the first user; there is no user/token yet
+  "POST /auth/login", // issues the token; obviously can't require one
+  "GET /health", // liveness probe (docker/compose healthcheck, DAST workflow)
+  "GET /ready", // readiness probe (db/IGDB connectivity), no sensitive data
+]);
+
+function isPublicApiRequest(req: Request): boolean {
+  if (req.method === "OPTIONS") return true;
+  return PUBLIC_API_ROUTES.has(`${req.method.toUpperCase()} ${req.path}`);
+}
+
+/**
+ * Default-deny gate for the entire /api surface: anything not explicitly
+ * allowlisted above requires a valid token. Mounted before any /api route is
+ * registered so it always runs first, regardless of whether an individual
+ * route handler also happens to apply authenticateToken itself.
+ */
+export function requireAuthenticationForApi(req: Request, res: Response, next: NextFunction) {
+  if (isPublicApiRequest(req)) {
+    next();
+    return;
+  }
+  authenticateToken(req, res, next);
+}
+
 // Configure multer for memory storage
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -526,6 +582,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/robots.txt", (_req, res) => {
     res.type("text/plain").send("User-agent: *\nDisallow: /\n");
   });
+  // Default-deny auth boundary for the whole /api surface. Mounted before any
+  // /api route (including the routers below) is registered, so every /api/*
+  // request is required to authenticate unless explicitly allowlisted above.
+  app.use("/api", requireAuthenticationForApi);
 
   // Use Steam Routes
   app.use(steamRoutes);
@@ -566,7 +626,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/auth/status", async (_req, res) => {
     try {
       const userCount = await storage.countUsers();
-      res.json({ hasUsers: userCount > 0 });
+      // Also surface IGDB configured-status here (not just hasUsers) so the
+      // unauthenticated setup wizard can decide whether to ask for IGDB
+      // credentials without needing to call the authenticated /api/config
+      // endpoint pre-login.
+      const igdb = await getIgdbConfigStatus();
+      res.json({ hasUsers: userCount > 0, igdb });
     } catch (error) {
       routesLogger.error({ error }, "Failed to check setup status");
       res.status(500).json({ error: "Failed to check setup status" });
@@ -1052,7 +1117,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   );
 
-  // Configuration endpoint - read-only access to key settings
+  // Configuration endpoint - read-only access to key settings. Requires
+  // authentication (enforced by the default-deny API auth boundary below);
+  // the unauthenticated setup flow instead uses the `igdb` field on
+  // GET /api/auth/status, which exposes only the configured/source booleans.
   app.get("/api/config", sensitiveEndpointLimiter, async (req, res) => {
     try {
       // 🛡️ Sentinel: Harden config endpoint to prevent information disclosure.
@@ -1060,21 +1128,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // sensitive details like database URLs or partial API keys.
       // clientId is intentionally omitted here; use the authenticated
       // GET /api/settings/igdb endpoint to retrieve it.
-      let isConfigured = false;
-      let source: "env" | "database" | undefined;
-
-      // Check database first (takes precedence)
-      const dbClientId = await storage.getSystemConfig("igdb.clientId");
-      const dbClientSecret = await storage.getSystemConfig("igdb.clientSecret");
-
-      if (dbClientId && dbClientSecret) {
-        isConfigured = true;
-        source = "database";
-      } else if (appConfig.igdb.isConfigured) {
-        // Fallback to environment variables
-        isConfigured = true;
-        source = "env";
-      }
+      const { configured: isConfigured, source } = await getIgdbConfigStatus();
 
       const xrelApiBase =
         (await storage.getSystemConfig("xrel_api_base"))?.trim() ||
@@ -1095,17 +1149,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  // Protect all API routes from here
-  app.use("/api", (req, res, next) => {
-    // Skip authentication for specific public endpoints that were already defined or need to be excluded
-    // Note: Auth routes are defined before this middleware, so they are already skipped.
-    // We explicitly skip health check if it matched /api/health (it was defined before, so express handles it first? Yes.)
-
-    // Just applying authenticateToken middleware
-    authenticateToken(req, res, next);
-  });
-
-  // Mount Feature Routers (explicitly protected)
+  // Mount Feature Routers (also explicitly protected as defense-in-depth,
+  // though the default-deny boundary mounted above already covers them)
   app.use("/api/imports", authenticateToken, importRouter);
   app.use("/api/import-tasks", authenticateToken, importTasksRouter);
   app.use("/api/system", authenticateToken, systemRouter);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -104,6 +104,13 @@ const normalizeInitialReleaseStatus = <
 // Root directory for the file system browser; restrict browsing to this tree
 const FILE_BROWSER_ROOT = fs.realpathSync(process.cwd());
 
+type IgdbConfigSource = "env" | "database" | undefined;
+
+interface IgdbConfigStatus {
+  configured: boolean;
+  source: IgdbConfigSource;
+}
+
 /**
  * Whether IGDB credentials are configured (DB takes precedence over env vars),
  * and which source they came from. Shared between the authenticated
@@ -111,10 +118,7 @@ const FILE_BROWSER_ROOT = fs.realpathSync(process.cwd());
  * endpoint (which needs just this boolean to drive the setup wizard, without
  * exposing anything else config-related pre-login).
  */
-async function getIgdbConfigStatus(): Promise<{
-  configured: boolean;
-  source: "env" | "database" | undefined;
-}> {
+async function getIgdbConfigStatus(): Promise<IgdbConfigStatus> {
   const dbClientId = await storage.getSystemConfig("igdb.clientId");
   const dbClientSecret = await storage.getSystemConfig("igdb.clientSecret");
 
@@ -626,12 +630,19 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/auth/status", async (_req, res) => {
     try {
       const userCount = await storage.countUsers();
+      const hasUsers = userCount > 0;
       // Also surface IGDB configured-status here (not just hasUsers) so the
       // unauthenticated setup wizard can decide whether to ask for IGDB
       // credentials without needing to call the authenticated /api/config
-      // endpoint pre-login.
-      const igdb = await getIgdbConfigStatus();
-      res.json({ hasUsers: userCount > 0, igdb });
+      // endpoint pre-login. This route stays on the public allowlist even
+      // after setup completes (existing sessions re-check it), so once a
+      // user exists, omit the igdb field entirely rather than leaving IGDB
+      // configuration status queryable by any anonymous caller forever.
+      if (!hasUsers) {
+        const igdb = await getIgdbConfigStatus();
+        return res.json({ hasUsers, igdb });
+      }
+      res.json({ hasUsers });
     } catch (error) {
       routesLogger.error({ error }, "Failed to check setup status");
       res.status(500).json({ error: "Failed to check setup status" });


### PR DESCRIPTION
## Description

Part of a split of #935 into smaller, independently reviewable PRs (see that PR for the full list). This is item 1: the default-deny API auth boundary. **This is a prerequisite for the httpOnly-cookie/CSRF PR (item 8), which mounts CSRF protection right after this boundary — that PR should be reviewed/merged after this one.**

The global auth middleware was registered after several routes were defined, including `GET /api/config`, leaving it reachable with no authentication and leaking IGDB-configured status and the xREL API base URL.

Replaces the ad-hoc mix of individually-protected routes and the late-registered blanket middleware with an explicit `PUBLIC_API_ROUTES` allowlist plus a `requireAuthenticationForApi` gate mounted before any `/api` route is registered, so anything not explicitly allowlisted requires a token by default. The setup wizard's need to know the IGDB-configured status pre-login is now served by a small addition to the already-public `GET /api/auth/status` response instead of the full `/api/config` payload — and that field is now dropped once setup completes, so it doesn't stay queryable by any anonymous caller forever.

Adds `server/__tests__/auth-boundary.test.ts` covering: previously public routes still work with no token, `GET /api/config` now requires auth, and a synthetic never-allowlisted route defaults to requiring auth (fail-safe-by-default, asserting exactly 401).

## Validation

- `npm run check` — passes
- `npx vitest run server/__tests__/` (full server suite) — 1514 passed, 6 skipped, 0 failed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security-relevant change — closes an unauthenticated info-leak on `GET /api/config` and makes the entire `/api` surface default-deny instead of opt-in per route.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WRPBAsaPG8msACszPPv5X2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added default authentication protection for API endpoints.
- Kept health, readiness, login, setup, and authentication-status endpoints publicly accessible.
- Enabled authenticated access to configuration details.

## Bug Fixes
- Setup now checks IGDB configuration status without requiring authentication.
- Prevented IGDB client credentials from appearing in API responses.

## Tests
- Expanded coverage for authentication boundaries, public endpoints, JWT access, and credential protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->