### PR TITLE
Narrow SABnzbd TLS fallback to self-signed cert errors only

### DIFF
--- a/server/__tests__/downloaders_ssl_fallback.test.ts
+++ b/server/__tests__/downloaders_ssl_fallback.test.ts
@@ -112,4 +112,21 @@ describe("SABnzbdClient SSL fallback", () => {
       message: "Connected to SABnzbd v4.5.0",
     });
   });
+
+  it("does not bypass TLS verification for non-self-signed certificate errors", async () => {
+    vi.spyOn(ssrf, "safeFetch").mockRejectedValueOnce(
+      Object.assign(new Error("certificate has expired"), {
+        cause: { code: "CERT_HAS_EXPIRED" },
+      })
+    );
+
+    const httpsRequestSpy = vi.spyOn(https, "request");
+
+    const client = new SABnzbdClient(createMockDownloader());
+    const result = await client.testConnection();
+
+    expect(httpsRequestSpy).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("certificate has expired");
+  });
 });

--- a/server/downloaders/sabnzbd.ts
+++ b/server/downloaders/sabnzbd.ts
@@ -116,18 +116,20 @@ export class SABnzbdClient implements DownloaderClient {
     try {
       return await safeFetch(url, { ...options, allowPrivate: true });
     } catch (error) {
-      const isSslError =
+      // Only fall back to an insecure connection for self-signed certificate
+      // errors. Other TLS failures (expired certs, hostname mismatches,
+      // untrusted CAs, etc.) are not safe to silently bypass and must
+      // continue to surface as errors.
+      const sslErrorCode = (error as { cause?: { code?: string } })?.cause?.code;
+      const isSelfSignedCertError =
         error instanceof Error &&
-        (error.message.includes("self-signed") ||
-          error.message.includes("certificate") ||
-          (error.cause as { code: string })?.code === "DEPTH_ZERO_SELF_SIGNED_CERT" ||
-          (error.cause as { code: string })?.code === "UNABLE_TO_VERIFY_LEAF_SIGNATURE" ||
-          (error.cause as { code: string })?.code === "CERT_HAS_EXPIRED");
+        (sslErrorCode === "DEPTH_ZERO_SELF_SIGNED_CERT" ||
+          sslErrorCode === "SELF_SIGNED_CERT_IN_CHAIN");
 
-      if (isSslError) {
+      if (isSelfSignedCertError) {
         downloadersLogger.debug(
           { url },
-          "SSL verification failed, retrying with insecure connection"
+          "Self-signed certificate detected, retrying with insecure connection"
         );
         return this.fetchInsecure(url, options);
       }


### PR DESCRIPTION
# Pull Request _Template_

## Description

`SABnzbdClient.doFetchWithFallback()` retries a failed HTTPS request with `rejectUnauthorized: false` (a full TLS bypass) whenever it detects an "SSL error." That detection was too broad: it matched any `Error` whose message contained `"self-signed"` or `"certificate"`, plus the error codes `DEPTH_ZERO_SELF_SIGNED_CERT`, `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, and `CERT_HAS_EXPIRED`. In practice that meant an expired certificate, an untrusted CA, or a hostname mismatch (any error whose message happens to contain "certificate") could all silently fall through to a full TLS bypass — not just a genuinely self-signed cert, which is the only case this fallback is meant to handle (self-hosted SABnzbd instances behind self-signed certs).

This PR narrows the trigger to the two error codes that actually indicate a self-signed certificate: `DEPTH_ZERO_SELF_SIGNED_CERT` and `SELF_SIGNED_CERT_IN_CHAIN`. Every other TLS failure now propagates as a normal error instead of being bypassed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly — not needed here: existing, already-tested fallback behavior is narrowed, not a new integration
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_017PCkKmGHbyQMY5CFks6pum)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SABnzbd connection security by limiting insecure HTTPS fallback to recognized self-signed certificate errors.
  * TLS failures such as expired certificates, hostname mismatches, and untrusted certificate authorities now correctly report the original error instead of being bypassed.
  * Added coverage to verify unsafe fallback does not occur for unrelated certificate errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->