### PR TITLE
Redact API keys/tokens when sending logs to support

### DIFF
--- a/client/__tests__/send-logs.test.ts
+++ b/client/__tests__/send-logs.test.ts
@@ -54,8 +54,17 @@ describe("send-logs utilities", () => {
       String.raw`win=C:\Users\alice\Questarr\logs\app.log`,
     ].join(" ");
 
+    // The `token=` prefix is itself secret-shaped, so it's caught (and
+    // labeled) by the API-key/token redaction pass rather than the
+    // JWT-specific one -- either way the token value never survives.
     expect(scrubPii(input)).toBe(
-      "email=[email] ipv4=[ip] ipv6=[ip] uuid=[uuid] token=[jwt] unix=/home/[user]/questarr/logs/app.log win=C:\\Users\\[user]\\Questarr\\logs\\app.log"
+      "email=[email] ipv4=[ip] ipv6=[ip] uuid=[uuid] token=[redacted] unix=/home/[user]/questarr/logs/app.log win=C:\\Users\\[user]\\Questarr\\logs\\app.log"
+    );
+  });
+
+  it("redacts a bare JWT with no key= prefix using the JWT-specific label", () => {
+    expect(scrubPii("Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.signature")).toBe(
+      "Authorization: [jwt]"
     );
   });
 

--- a/server/__tests__/security-redaction.test.ts
+++ b/server/__tests__/security-redaction.test.ts
@@ -1,28 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { redactSecretText, redactSecrets } from "../security.js";
+import { redactSecrets } from "../security.js";
 
-describe("redactSecretText", () => {
-  it("redacts key=value style secrets", () => {
-    expect(redactSecretText("apikey=abc123&other=fine")).toBe("apikey=[redacted]&other=fine");
-    expect(redactSecretText('password: "hunter2"')).toContain("password=[redacted]");
-  });
-
-  it("redacts Bearer tokens", () => {
-    const input = "Authorization header was Bearer eyJhbGciOiJIUzI1NiJ9.abc.def";
-    expect(redactSecretText(input)).toBe("Authorization header was Bearer [redacted]");
-  });
-
-  it("redacts Discord webhook URLs", () => {
-    const input = "https://discord.com/api/webhooks/12345/abcdef-token";
-    expect(redactSecretText(input)).toBe("[redacted-discord-webhook]");
-  });
-
-  it("leaves ordinary text untouched", () => {
-    const input = "Search completed with 12 results for query 'zelda'";
-    expect(redactSecretText(input)).toBe(input);
-  });
-});
-
+// `redactSecretText` (the plain-string secret redaction `redactSecrets` is built
+// on) now lives in shared/log-scrub.ts, re-exported here for pino-formatter use
+// -- its own tests live in shared/__tests__/log-scrub.test.ts. This file covers
+// only redactSecrets' server-specific behavior: recursive object/array redaction
+// by key shape.
 describe("redactSecrets", () => {
   it("redacts values whose key looks secret-shaped", () => {
     const result = redactSecrets({

--- a/server/security.ts
+++ b/server/security.ts
@@ -2,29 +2,16 @@
 // additions here narrowly scoped -- this is not a place for a general
 // utility grab-bag.
 
+// The text-level secret redaction (`redactSecretText`) lives in
+// `shared/log-scrub.ts` so the client's manual "Send Logs" flow and the
+// server's automatic error-telemetry flow -- neither of which import from
+// `server/` -- apply the exact same redaction as this pino formatter. Re-exported
+// here so existing server-side callers/imports are unaffected.
+import { redactSecretText } from "../shared/log-scrub.js";
+export { redactSecretText } from "../shared/log-scrub.js";
+
 const SECRET_KEY_PATTERN =
   /(api[_-]?key|apikey|authorization|bearer|client[_-]?secret|cookie|csrf|jwt|password|secret|token|webhook)/i;
-
-/**
- * Redact common secret-shaped substrings (api_key=..., Bearer <token>, etc.)
- * out of a plain string before it reaches a log sink.
- */
-export function redactSecretText(value: string): string {
-  return (
-    value
-      .replace(
-        /\b(apikey|api[_-]?key|token|password|secret)["']?\s*[:=]\s*["']?([^"',\s&]+)["']?/gi,
-        "$1=[redacted]"
-      )
-      // The /i flag already folds case, so an explicit A-Z range here would
-      // duplicate a-z -- SonarCloud flags that as a redundant character class.
-      .replace(/(Bearer\s+)[a-z0-9._~+/=-]+/gi, "$1[redacted]")
-      .replace(
-        /https:\/\/(?:discord|discordapp)\.com\/api\/webhooks\/[^\s"'<>]+/gi,
-        "[redacted-discord-webhook]"
-      )
-  );
-}
 
 /**
  * Recursively redact values whose key looks secret-shaped (api_key, token,

--- a/shared/__tests__/log-scrub.test.ts
+++ b/shared/__tests__/log-scrub.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { scrubPii, scrubLogLines, redactSecretText } from "../log-scrub.js";
+
+describe("redactSecretText", () => {
+  it("redacts key=value style secrets", () => {
+    expect(redactSecretText("apikey=abc123&other=fine")).toBe("apikey=[redacted]&other=fine");
+    expect(redactSecretText('password: "hunter2"')).toContain("password=[redacted]");
+  });
+
+  it("redacts Bearer tokens", () => {
+    const input = "Authorization header was Bearer eyJhbGciOiJIUzI1NiJ9.abc.def";
+    expect(redactSecretText(input)).toBe("Authorization header was Bearer [redacted]");
+  });
+
+  it("redacts Discord webhook URLs", () => {
+    const input = "https://discord.com/api/webhooks/12345/abcdef-token";
+    expect(redactSecretText(input)).toBe("[redacted-discord-webhook]");
+  });
+});
+
+describe("scrubPii", () => {
+  it("redacts indexer/downloader API keys alongside PII", () => {
+    const input =
+      "GET https://indexer.example/api?t=search&apikey=super-secret-key&q=zelda from user@example.com";
+    const result = scrubPii(input);
+
+    expect(result).not.toContain("super-secret-key");
+    expect(result).toContain("apikey=[redacted]");
+    expect(result).toContain("[email]");
+  });
+
+  it("redacts a raw password/secret in log text", () => {
+    expect(scrubPii("secret=abcdef123456 while syncing indexer")).toBe(
+      "secret=[redacted] while syncing indexer"
+    );
+    expect(scrubPii('login failed for password: "hunter2"')).toContain("password=[redacted]");
+  });
+
+  it("scrubLogLines redacts API keys across every line", () => {
+    const lines = [
+      '{"msg":"testing indexer","url":"https://idx.example/api?apikey=abc123def"}',
+      '{"msg":"user login","email":"person@example.com"}',
+    ];
+    const result = scrubLogLines(lines);
+
+    expect(result).not.toContain("abc123def");
+    expect(result).toContain("[email]");
+  });
+});

--- a/shared/log-scrub.ts
+++ b/shared/log-scrub.ts
@@ -73,18 +73,20 @@ const WINDOWS_USERS_SEGMENT = String.raw`\Users`;
  * Each regex is applied independently so replacements don't interfere.
  */
 export function scrubPii(text: string): string {
-  return redactSecretText(scrubEmailAddresses(text))
-    .replace(JWT_RE, "[jwt]") // before email — JWTs contain dots
-    .replace(IPV6_RE, (match) => (isIpv6(match) ? "[ip]" : match))
-    .replace(IPV4_RE, (match) => (isIpv4(match) ? "[ip]" : match))
-    .replace(UUID_RE, "[uuid]")
-    .replace(HOME_PATH_RE, (_match, _username: string) => {
-      const prefix = _match.startsWith("/")
-        ? "/home"
-        : _match.substring(0, 2) + WINDOWS_USERS_SEGMENT;
-      const sep = _match.includes("\\") ? "\\" : "/";
-      return `${prefix}${sep}[user]`;
-    });
+  return redactSecretText(
+    scrubEmailAddresses(text)
+      .replace(JWT_RE, "[jwt]") // before email — JWTs contain dots
+      .replace(IPV6_RE, (match) => (isIpv6(match) ? "[ip]" : match))
+      .replace(IPV4_RE, (match) => (isIpv4(match) ? "[ip]" : match))
+      .replace(UUID_RE, "[uuid]")
+      .replace(HOME_PATH_RE, (_match, _username: string) => {
+        const prefix = _match.startsWith("/")
+          ? "/home"
+          : _match.substring(0, 2) + WINDOWS_USERS_SEGMENT;
+        const sep = _match.includes("\\") ? "\\" : "/";
+        return `${prefix}${sep}[user]`;
+      })
+  );
 }
 
 function scrubEmailAddresses(text: string): string {

--- a/shared/log-scrub.ts
+++ b/shared/log-scrub.ts
@@ -8,7 +8,42 @@
  *  - UUIDs             (e.g. socket IDs formatted as UUIDs, download hashes)
  *  - JWT tokens        (defensive — tokens should never be logged)
  *  - OS home-dir paths (e.g. /home/alice/… or C:\Users\alice\…)
+ *  - Secret-shaped text (indexer/downloader API keys, tokens, passwords, Bearer
+ *    headers, webhook URLs — see `redactSecretText` below)
+ *
+ * Server-side, structured log fields are already redacted at write time by
+ * `server/security.ts`'s pino formatter (`redactSecrets`), so `server.log`
+ * should never contain a raw secret in the first place. `redactSecretText` is
+ * defined here (rather than only in `server/security.ts`) so this module's
+ * `scrubPii`/`scrubLogLines` — used by both the client's manual "Send Logs"
+ * flow and the server's automatic error-telemetry flow — apply the exact same
+ * secret redaction as a second layer before log content ever leaves the
+ * instance, in case a secret slips into a log line some other way (e.g. a raw
+ * response body or an un-redacted string field).
  */
+
+// ── Secret-shaped text ────────────────────────────────────────────────────────
+
+/**
+ * Redact common secret-shaped substrings (api_key=..., Bearer <token>, etc.)
+ * out of a plain string before it reaches a log sink or leaves the instance.
+ */
+export function redactSecretText(value: string): string {
+  return (
+    value
+      .replace(
+        /\b(apikey|api[_-]?key|token|password|secret)["']?\s*[:=]\s*["']?([^"',\s&]+)["']?/gi,
+        "$1=[redacted]"
+      )
+      // The /i flag already folds case, so an explicit A-Z range here would
+      // duplicate a-z -- SonarCloud flags that as a redundant character class.
+      .replace(/(Bearer\s+)[a-z0-9._~+/=-]+/gi, "$1[redacted]")
+      .replace(
+        /https:\/\/(?:discord|discordapp)\.com\/api\/webhooks\/[^\s"'<>]+/gi,
+        "[redacted-discord-webhook]"
+      )
+  );
+}
 
 // ── PII patterns ──────────────────────────────────────────────────────────────
 
@@ -38,7 +73,7 @@ const WINDOWS_USERS_SEGMENT = String.raw`\Users`;
  * Each regex is applied independently so replacements don't interfere.
  */
 export function scrubPii(text: string): string {
-  return scrubEmailAddresses(text)
+  return redactSecretText(scrubEmailAddresses(text))
     .replace(JWT_RE, "[jwt]") // before email — JWTs contain dots
     .replace(IPV6_RE, (match) => (isIpv6(match) ? "[ip]" : match))
     .replace(IPV4_RE, (match) => (isIpv4(match) ? "[ip]" : match))


### PR DESCRIPTION
## Description

The client's manual "Send Logs" flow (`SendLogsDialog` → `sendLogs`) and the server's automatic error-telemetry flow both scrub log content with `shared/log-scrub.ts` before uploading it to the support Worker. That scrubber only stripped PII (emails, IPs, UUIDs, JWTs, home-dir paths) — it had no notion of secret-shaped text like `apikey=...`, `Bearer <token>`, a raw password, or a webhook URL. So an indexer or downloader API key embedded in a log line survived the scrub and went out with the uploaded bundle, even though `server/security.ts` already has this exact redaction (`redactSecretText`) for its own pino log formatter.

Fixes the reported bug: API keys weren't hidden in logs when a user clicked "Send logs".

## Changes

- Moved `redactSecretText` (api key / token / password / secret / Bearer / Discord webhook redaction) from `server/security.ts` into `shared/log-scrub.ts`, so it's usable from client code.
- Wired it into `scrubPii`, applied after the existing PII patterns so JWT-specific labeling (`[jwt]`) still wins for a bare token with no `key=` prefix.
- `server/security.ts` now imports and re-exports `redactSecretText` from `shared/log-scrub.ts` — its existing pino-formatter usage (`redactSecrets`) and all current imports are unaffected.
- Added `shared/__tests__/log-scrub.test.ts` covering API key / token / password redaction in `scrubPii`/`scrubLogLines`.
- Updated `client/__tests__/send-logs.test.ts` for the (still-secure) label change on a `token=<jwt>` line, and added a case for a bare JWT with no `key=` prefix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`npx vitest run`, `npm run lint`, `npm run check`)

---

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FS8sDBBDu5WvHxFmojYAwa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sensitive information in logs is now automatically redacted, including API keys, passwords, tokens, Bearer credentials, and webhook URLs.
  * PII scrubbing now applies consistently across client and server log flows.
  * JWTs and token-prefixed secrets are labeled appropriately when redacted.

* **Bug Fixes**
  * Improved protection against accidentally exposing credentials and personal information in logs.

* **Tests**
  * Added coverage for secret and PII redaction across single-line and multi-line logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->