### PR TITLE
Fix clipboard copy buttons on non-secure (HTTP) contexts

### DIFF
--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -944,6 +944,28 @@ describe("GameDownloadDialog", () => {
     });
   });
 
+  it("shows a destructive toast when copying a link fails on non-secure contexts", async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error("denied")),
+      },
+    });
+    Object.assign(document, { execCommand: vi.fn().mockReturnValue(false) });
+
+    renderComponent();
+
+    expect(await screen.findAllByText("Copy Torrent Link")).not.toHaveLength(0);
+
+    fireEvent.click(screen.getAllByText("Copy Torrent Link")[0]);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith({
+        description: "Copy failed",
+        variant: "destructive",
+      });
+    });
+  });
+
   it("lets mobile users select bundle updates and download only the main game", async () => {
     mockIsMobile = true;
     globalThis.fetch = createFetchMock({

--- a/client/__tests__/SendLogsDialog.test.tsx
+++ b/client/__tests__/SendLogsDialog.test.tsx
@@ -180,12 +180,14 @@ describe("SendLogsDialog", () => {
     });
   });
 
-  it("shows a fallback toast when the Clipboard API is unavailable", async () => {
+  it("falls back to the legacy copy method when the Clipboard API is unavailable", async () => {
     sendLogsMock.mockResolvedValue({ ok: true, code: "QWER", issueNumber: 321 });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: undefined,
     });
+    const execCommandMock = vi.fn().mockReturnValue(true);
+    Object.assign(document, { execCommand: execCommandMock });
 
     render(<SendLogsDialog open={true} onOpenChange={vi.fn()} logLines={["line 1"]} />);
 
@@ -194,10 +196,37 @@ describe("SendLogsDialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Copy support code" }));
 
-    expect(toastMock).toHaveBeenCalledWith({
-      title: "Copy failed",
-      description: "Clipboard API not supported in this browser",
-      variant: "destructive",
+    await waitFor(() => {
+      expect(execCommandMock).toHaveBeenCalledWith("copy");
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "Copied",
+        description: "Code QWER copied to clipboard",
+      });
+    });
+  });
+
+  it("shows a fallback toast when neither the Clipboard API nor the legacy copy method are available", async () => {
+    sendLogsMock.mockResolvedValue({ ok: true, code: "QWER", issueNumber: 321 });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    const execCommandMock = vi.fn().mockReturnValue(false);
+    Object.assign(document, { execCommand: execCommandMock });
+
+    render(<SendLogsDialog open={true} onOpenChange={vi.fn()} logLines={["line 1"]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Send logs" }));
+    expect(await screen.findByText("Logs uploaded")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy support code" }));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "Copy failed",
+        description: "Clipboard access denied",
+        variant: "destructive",
+      });
     });
   });
 

--- a/client/__tests__/utils.test.ts
+++ b/client/__tests__/utils.test.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   asZodType,
   compareEnabledPriorityName,
+  copyToClipboard,
   formatBytes,
   isDiscoveryId,
   mapGameToInsertGame,
@@ -155,5 +156,64 @@ describe("parseReleaseDate", () => {
       year: "2024",
       fullDate: "03/02/2024",
     });
+  });
+});
+
+describe("copyToClipboard", () => {
+  const originalClipboard = navigator.clipboard;
+  const originalExecCommand = document.execCommand;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: originalClipboard,
+    });
+    document.execCommand = originalExecCommand;
+  });
+
+  it("uses the async Clipboard API when available and resolves true", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to document.execCommand when navigator.clipboard is unavailable (e.g. plain HTTP)", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand;
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("falls back to document.execCommand when the async Clipboard API throws", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand;
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("resolves false when every copy method fails", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    document.execCommand = vi.fn().mockReturnValue(false);
+
+    await expect(copyToClipboard("hello")).resolves.toBe(false);
   });
 });

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -67,7 +67,7 @@ import {
 } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
-import { cn, safeUrl } from "@/lib/utils";
+import { cn, copyToClipboard, safeUrl } from "@/lib/utils";
 import {
   type Game,
   type Indexer,
@@ -1050,8 +1050,14 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                             <DropdownMenuContent align="end">
                               <DropdownMenuItem
                                 onClick={() => {
-                                  navigator.clipboard.writeText(download.link);
-                                  toast({ description: "Link copied to clipboard" });
+                                  copyToClipboard(download.link).then((succeeded) => {
+                                    toast({
+                                      description: succeeded
+                                        ? "Link copied to clipboard"
+                                        : "Copy failed",
+                                      variant: succeeded ? undefined : "destructive",
+                                    });
+                                  });
                                 }}
                               >
                                 <Copy className="h-4 w-4 mr-2" />

--- a/client/src/components/SendErrorReportDialog.tsx
+++ b/client/src/components/SendErrorReportDialog.tsx
@@ -13,6 +13,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest, ApiError } from "@/lib/queryClient";
 import { buildGitHubIssueUrl } from "@/lib/send-logs";
+import { copyToClipboard } from "@/lib/utils";
 
 interface SendErrorReportDialogProps {
   open: boolean;
@@ -104,27 +105,17 @@ export default function SendErrorReportDialog({
 
   const handleCopyCode = useCallback(() => {
     if (!result) return;
-    const clipboard = navigator.clipboard;
-    if (!clipboard) {
-      toast({
-        title: "Copy failed",
-        description: "Clipboard API not supported in this browser",
-        variant: "destructive",
-      });
-      return;
-    }
-    clipboard
-      .writeText(result.code)
-      .then(() => {
+    copyToClipboard(result.code).then((succeeded) => {
+      if (succeeded) {
         toast({ title: "Copied", description: `Code ${result.code} copied to clipboard` });
-      })
-      .catch(() => {
+      } else {
         toast({
           title: "Copy failed",
           description: "Clipboard access denied",
           variant: "destructive",
         });
-      });
+      }
+    });
   }, [result, toast]);
 
   const issueUrl =

--- a/client/src/components/SendLogsDialog.tsx
+++ b/client/src/components/SendLogsDialog.tsx
@@ -17,6 +17,7 @@ import {
   sendLogs,
   type SendLogsResult,
 } from "@/lib/send-logs";
+import { copyToClipboard } from "@/lib/utils";
 
 interface SendLogsDialogProps {
   open: boolean;
@@ -75,28 +76,17 @@ export default function SendLogsDialog({
 
   const handleCopyCode = useCallback(() => {
     if (!result?.ok) return;
-    const clipboard = navigator.clipboard;
-    if (!clipboard) {
-      toast({
-        title: "Copy failed",
-        description: "Clipboard API not supported in this browser",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    clipboard
-      .writeText(result.code)
-      .then(() => {
+    copyToClipboard(result.code).then((succeeded) => {
+      if (succeeded) {
         toast({ title: "Copied", description: `Code ${result.code} copied to clipboard` });
-      })
-      .catch(() => {
+      } else {
         toast({
           title: "Copy failed",
           description: "Clipboard access denied",
           variant: "destructive",
         });
-      });
+      }
+    });
   }, [result, toast]);
 
   const issueUrl = result?.ok

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -124,6 +124,47 @@ export function safeUrl(url: string, fallback = "#"): string {
 }
 
 /**
+ * Copies text to the clipboard, falling back to the legacy `document.execCommand("copy")`
+ * approach when the async Clipboard API is unavailable (e.g. non-secure/plain-HTTP contexts,
+ * where `navigator.clipboard` is `undefined`).
+ *
+ * Resolves `true` on success, `false` if every copy method failed or is unsupported.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the legacy fallback below.
+    }
+  }
+
+  if (typeof document === "undefined") return false;
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  // Keep the textarea out of view and out of the tab/scroll flow.
+  textarea.style.position = "fixed";
+  textarea.style.top = "-9999px";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  let succeeded = false;
+  try {
+    succeeded = document.execCommand("copy");
+  } catch {
+    succeeded = false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+
+  return succeeded;
+}
+
+/**
  * Parses an ISO release date string into a display year and an optional full date.
  * IGDB represents year-only known dates as YYYY-12-31; fullDate is null in that case.
  * fullDate is formatted as dd/mm/yyyy using UTC to avoid timezone shifts.

--- a/client/src/pages/logs.tsx
+++ b/client/src/pages/logs.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/sheet";
 import { useToast } from "@/hooks/use-toast";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { copyToClipboard } from "@/lib/utils";
 
 interface LogField {
   key: string;
@@ -593,21 +594,20 @@ export default function LogsPage() {
 
   const copyText = useCallback(
     (text: string, description: string) => {
-      navigator.clipboard
-        .writeText(text)
-        .then(() => {
+      copyToClipboard(text).then((succeeded) => {
+        if (succeeded) {
           toast({
             title: "Copied",
             description,
           });
-        })
-        .catch(() => {
+        } else {
           toast({
             title: "Copy failed",
             description: "Clipboard access denied",
             variant: "destructive",
           });
-        });
+        }
+      });
     },
     [toast]
   );


### PR DESCRIPTION
## Summary

`navigator.clipboard` is only available in secure contexts (HTTPS or `localhost`). Over plain HTTP — a common self-hosted setup — it's `undefined`, so calling `navigator.clipboard.writeText(...)` directly threw a `TypeError` (or, where already guarded, just showed a "not supported" toast) instead of copying.

This affected:
- `client/src/components/GameDownloadDialog.tsx` — Copy Torrent/NZB Link (unguarded, threw silently)
- `client/src/pages/logs.tsx` — logs viewer Copy button (unguarded, threw silently)
- `client/src/components/SendLogsDialog.tsx` — Copy support code (guarded, but no fallback)
- `client/src/components/SendErrorReportDialog.tsx` — Copy support code (guarded, but no fallback)

## Fix

Added a shared `copyToClipboard(text): Promise<boolean>` helper in `client/src/lib/utils.ts` that:
1. Uses the async Clipboard API when `navigator.clipboard.writeText` is available.
2. Falls back to the legacy `document.execCommand("copy")` approach (via a temporary offscreen `<textarea>`) when the Clipboard API is unavailable or throws.
3. Resolves `false` only if both methods fail, so callers can show an accurate success/failure toast.

Replaced the four ad-hoc `navigator.clipboard.writeText(...)` call sites with this helper.

## Testing

- `npm run check` — passes
- `npx eslint` on changed files — clean
- `npx prettier --check` on changed files — clean
- `npx vitest run` on `utils.test.ts`, `SendLogsDialog.test.tsx`, `GameDownloadDialog.test.tsx`, `LogsPage.test.tsx`, `LogsPage.remaining.test.tsx` — all passing
- Added unit tests for `copyToClipboard` covering the async-API-success, async-API-throws-falls-back, no-Clipboard-API-falls-back, and both-fail cases
- Updated the existing `SendLogsDialog` test that previously asserted the (buggy) "not supported" toast to instead assert the new legacy-fallback success path, plus a new test for the both-methods-fail case

Fixes #914


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fim6ToMohACPVepwgMfVKa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copying of torrent links, support codes, and log content across secure and non-secure browser contexts.
  * Added a fallback method when standard clipboard access is unavailable.
  * Copy failures now consistently display clear failure notifications, while successful copies show confirmation feedback.
* **Tests**
  * Added coverage for successful fallback copying, unavailable clipboard access, and copy failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->