### PR TITLE
Add indexer priority sort option to download search results

### DIFF
--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -187,9 +187,9 @@ const mockTorrents = makeSearchResult(
 );
 
 const mockEnabledIndexers = [
-  { id: 1, name: "Indexer A", enabled: true },
-  { id: 2, name: "Indexer B", enabled: true },
-  { id: 3, name: "Indexer C", enabled: true },
+  { id: 1, name: "Indexer A", enabled: true, priority: 2 },
+  { id: 2, name: "Indexer B", enabled: true, priority: 1 },
+  { id: 3, name: "Indexer C", enabled: true, priority: 3 },
 ];
 
 const mockDownloaders = [
@@ -382,6 +382,30 @@ describe("GameDownloadDialog", () => {
 
     // Should trigger a re-sort -> Ascending -> ArrowUp
     expect(screen.getAllByTestId("icon-sort-up").length).toBeGreaterThan(0);
+  });
+
+  it("sorts results by indexer priority", async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText("Priority")).toBeInTheDocument();
+    });
+
+    // Click the Priority sort header. Default order (desc) shows the
+    // highest-priority indexer (lowest configured priority number) first:
+    // Indexer B (priority 1) < Indexer A (priority 2) < Indexer C (priority 3).
+    fireEvent.click(screen.getByText("Priority"));
+
+    await waitFor(() => {
+      // Dialog content renders into a Radix portal on document.body, not inside `container`.
+      const text = document.body.textContent ?? "";
+      const posIndexerB = text.indexOf("Test Torrent 2"); // Indexer B
+      const posIndexerA = text.indexOf("Test Torrent 1"); // Indexer A
+      const posIndexerC = text.indexOf("Test Usenet NZB"); // Indexer C
+      expect(posIndexerB).toBeGreaterThan(-1);
+      expect(posIndexerA).toBeGreaterThan(posIndexerB);
+      expect(posIndexerC).toBeGreaterThan(posIndexerA);
+    });
   });
 
   it("blacklists a release when clicking 'Blacklist release'", async () => {

--- a/client/__tests__/GameDownloadDialog.test.tsx
+++ b/client/__tests__/GameDownloadDialog.test.tsx
@@ -408,6 +408,91 @@ describe("GameDownloadDialog", () => {
     });
   });
 
+  it("keeps releases from an indexer with no configured priority sorted last, in both sort directions", async () => {
+    const searchWithUnknownIndexer = makeSearchResult([
+      makeTorrentItem({
+        guid: "known-1",
+        title: "Test Torrent 1",
+        link: "http://test.com/torrent1",
+        indexerName: "Indexer A", // priority 2
+      }),
+      makeTorrentItem({
+        guid: "known-2",
+        title: "Test Torrent 2",
+        link: "http://test.com/torrent2",
+        indexerName: "Indexer B", // priority 1
+      }),
+      makeTorrentItem({
+        guid: "unknown-1",
+        title: "Test Torrent Unknown",
+        link: "http://test.com/torrent-unknown",
+        indexerName: "Indexer Removed", // not present in enabled indexers
+      }),
+    ]);
+    globalThis.fetch = createFetchMock({ search: searchWithUnknownIndexer });
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText("Priority")).toBeInTheDocument();
+    });
+
+    // Default order (desc): known indexers by priority, unknown last.
+    fireEvent.click(screen.getByText("Priority"));
+    await waitFor(() => {
+      const text = document.body.textContent ?? "";
+      const posB = text.indexOf("Test Torrent 2");
+      const posA = text.indexOf("Test Torrent 1");
+      const posUnknown = text.indexOf("Test Torrent Unknown");
+      expect(posB).toBeGreaterThan(-1);
+      expect(posA).toBeGreaterThan(posB);
+      expect(posUnknown).toBeGreaterThan(posA);
+    });
+
+    // Reversed order (asc): unknown indexer must still sort last, not first.
+    fireEvent.click(screen.getByText("Priority"));
+    await waitFor(() => {
+      const text = document.body.textContent ?? "";
+      const posB = text.indexOf("Test Torrent 2");
+      const posA = text.indexOf("Test Torrent 1");
+      const posUnknown = text.indexOf("Test Torrent Unknown");
+      expect(posA).toBeGreaterThan(-1);
+      expect(posB).toBeGreaterThan(posA);
+      expect(posUnknown).toBeGreaterThan(posB);
+    });
+  });
+
+  it("shows the Priority header and per-row priority when an unrecognized indexer is present", async () => {
+    const searchWithUnknownIndexer = makeSearchResult([
+      makeTorrentItem({
+        guid: "known-1",
+        title: "Test Torrent 1",
+        link: "http://test.com/torrent1",
+        indexerName: "Indexer A", // priority 2
+      }),
+      makeTorrentItem({
+        guid: "unknown-1",
+        title: "Test Torrent Unknown",
+        link: "http://test.com/torrent-unknown",
+        indexerName: "Indexer Removed",
+      }),
+    ]);
+    globalThis.fetch = createFetchMock({ search: searchWithUnknownIndexer });
+
+    renderComponent();
+
+    // The Priority header should render even though only one of the two
+    // result indexers is present in the enabled-indexers list.
+    await waitFor(() => {
+      expect(screen.getByText("Priority")).toBeInTheDocument();
+    });
+
+    // The unrecognized indexer's row shows an em dash instead of a number.
+    await waitFor(() => {
+      expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+    });
+  });
+
   it("blacklists a release when clicking 'Blacklist release'", async () => {
     renderComponent();
 

--- a/client/src/components/AutoDownloadRulesSettings.tsx
+++ b/client/src/components/AutoDownloadRulesSettings.tsx
@@ -63,7 +63,9 @@ export default function AutoDownloadRulesSettings({
   const queryClient = useQueryClient();
 
   const [minSeeders, setMinSeeders] = useState<number>(rules?.minSeeders ?? 0);
-  const [sortBy, setSortBy] = useState<"seeders" | "date" | "size">(rules?.sortBy ?? "seeders");
+  const [sortBy, setSortBy] = useState<"seeders" | "date" | "size" | "priority">(
+    rules?.sortBy ?? "seeders"
+  );
   const [visibleCategories, setVisibleCategories] = useState<Set<DownloadCategory>>(
     new Set(
       (rules?.visibleCategories ?? [
@@ -145,7 +147,7 @@ export default function AutoDownloadRulesSettings({
     setMinSeeders(value);
   };
 
-  const handleSortByChange = (value: "seeders" | "date" | "size") => {
+  const handleSortByChange = (value: "seeders" | "date" | "size" | "priority") => {
     setSortBy(value);
   };
 
@@ -190,7 +192,9 @@ export default function AutoDownloadRulesSettings({
             </Label>
             <Select
               value={sortBy}
-              onValueChange={(v) => handleSortByChange(v as "seeders" | "date" | "size")}
+              onValueChange={(v) =>
+                handleSortByChange(v as "seeders" | "date" | "size" | "priority")
+              }
             >
               <SelectTrigger id="sortBy">
                 <SelectValue />
@@ -199,6 +203,7 @@ export default function AutoDownloadRulesSettings({
                 <SelectItem value="seeders">Seeders (High to Low)</SelectItem>
                 <SelectItem value="date">Date (Newest First)</SelectItem>
                 <SelectItem value="size">Size (Largest First)</SelectItem>
+                <SelectItem value="priority">Indexer Priority</SelectItem>
               </SelectContent>
             </Select>
             <p className="text-xs text-muted-foreground">

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -240,7 +240,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     [minSeeders]
   );
   const [selectedIndexer, setSelectedIndexer] = useState<string>("all");
-  const [sortBy, setSortBy] = useState<"seeders" | "date" | "size">("seeders");
+  const [sortBy, setSortBy] = useState<"seeders" | "date" | "size" | "priority">("seeders");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [showFilters, setShowFilters] = useState(false);
   const [visibleCategories, setVisibleCategories] = useState<Set<DownloadCategory>>(
@@ -363,6 +363,16 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     enabled: open,
   });
 
+  // Maps indexer name -> configured priority (lower number = higher priority) so
+  // results can be sorted to match the order set on Management > Indexers.
+  const indexerPriorityMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const indexer of enabledIndexers ?? []) {
+      map.set(indexer.name, indexer.priority);
+    }
+    return map;
+  }, [enabledIndexers]);
+
   // Categorize downloads
   const categorizedDownloads = useMemo(() => {
     if (!searchResults?.items) return { main: [], update: [], dlc: [], extra: [], packs: [] };
@@ -460,6 +470,13 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
             const keyB = b.guid || b.link;
             comparison =
               (itemPubDateTimestamps.get(keyB) ?? 0) - (itemPubDateTimestamps.get(keyA) ?? 0);
+          } else if (sortBy === "priority") {
+            // Lower priority number = higher-priority indexer, so it sorts first by default.
+            const aPriority =
+              indexerPriorityMap.get(a.indexerName ?? "") ?? Number.MAX_SAFE_INTEGER;
+            const bPriority =
+              indexerPriorityMap.get(b.indexerName ?? "") ?? Number.MAX_SAFE_INTEGER;
+            comparison = aPriority - bPriority;
           } else {
             comparison = (b.size ?? 0) - (a.size ?? 0);
           }
@@ -479,6 +496,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     selectedGroups,
     selectedPlatforms,
     itemPubDateTimestamps,
+    indexerPriorityMap,
   ]);
 
   // Sorted items for display (by date)
@@ -726,7 +744,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     });
   };
 
-  const toggleSort = (field: "seeders" | "date" | "size") => {
+  const toggleSort = (field: "seeders" | "date" | "size" | "priority") => {
     if (sortBy === field) {
       setSortOrder(sortOrder === "asc" ? "desc" : "asc");
     } else {
@@ -740,7 +758,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     label,
     className = "",
   }: {
-    field: "seeders" | "date" | "size";
+    field: "seeders" | "date" | "size" | "priority";
     label: string;
     className?: string;
   }) => (
@@ -990,6 +1008,13 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                             </span>
                           </div>
                           <div className="flex items-center gap-6 md:gap-10">
+                            {availableIndexers.length > 1 && (
+                              <SortHeader
+                                field="priority"
+                                label="Priority"
+                                className="min-w-[70px] justify-end"
+                              />
+                            )}
                             <SortHeader
                               field="date"
                               label="Date"

--- a/client/src/components/GameDownloadDialog.tsx
+++ b/client/src/components/GameDownloadDialog.tsx
@@ -379,21 +379,28 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
     return groupDownloadsByCategory(searchResults.items);
   }, [searchResults?.items]);
 
-  const availableIndexers = useMemo(() => {
+  // Distinct indexer names actually present in the current results, regardless of
+  // whether they're still in the user's enabled-indexers list. Used to decide when
+  // the Priority column is meaningful (i.e. results span more than one indexer).
+  const resultIndexerNames = useMemo(() => {
     if (!searchResults?.items) return [];
     const indexers = new Set(
       searchResults.items
         .map((item) => item.indexerName)
         .filter((name): name is string => Boolean(name))
     );
+    return Array.from(indexers);
+  }, [searchResults?.items]);
+
+  const availableIndexers = useMemo(() => {
     if (enabledIndexers) {
       const enabledNames = new Set(enabledIndexers.map((i) => i.name));
-      return Array.from(indexers)
+      return resultIndexerNames
         .filter((name) => enabledNames.has(name))
         .sort((a, b) => a.localeCompare(b));
     }
-    return Array.from(indexers).sort((a, b) => a.localeCompare(b));
-  }, [searchResults?.items, enabledIndexers]);
+    return [...resultIndexerNames].sort((a, b) => a.localeCompare(b));
+  }, [resultIndexerNames, enabledIndexers]);
 
   const availableGroups = useMemo(() => {
     if (!searchResults?.items) return [];
@@ -472,10 +479,14 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
               (itemPubDateTimestamps.get(keyB) ?? 0) - (itemPubDateTimestamps.get(keyA) ?? 0);
           } else if (sortBy === "priority") {
             // Lower priority number = higher-priority indexer, so it sorts first by default.
-            const aPriority =
-              indexerPriorityMap.get(a.indexerName ?? "") ?? Number.MAX_SAFE_INTEGER;
-            const bPriority =
-              indexerPriorityMap.get(b.indexerName ?? "") ?? Number.MAX_SAFE_INTEGER;
+            // Indexers with no configured priority (e.g. since removed/disabled) always sort
+            // last, regardless of the chosen sort direction.
+            const aPriority = indexerPriorityMap.get(a.indexerName ?? "");
+            const bPriority = indexerPriorityMap.get(b.indexerName ?? "");
+            if (aPriority === undefined || bPriority === undefined) {
+              if (aPriority === undefined && bPriority === undefined) return 0;
+              return aPriority === undefined ? 1 : -1;
+            }
             comparison = aPriority - bPriority;
           } else {
             comparison = (b.size ?? 0) - (a.size ?? 0);
@@ -1008,7 +1019,7 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                             </span>
                           </div>
                           <div className="flex items-center gap-6 md:gap-10">
-                            {availableIndexers.length > 1 && (
+                            {resultIndexerNames.length > 1 && (
                               <SortHeader
                                 field="priority"
                                 label="Priority"
@@ -1329,6 +1340,12 @@ export default function GameDownloadDialog({ game, open, onOpenChange }: GameDow
                               </div>
 
                               <div className="flex items-center gap-6 md:gap-10 flex-shrink-0">
+                                {resultIndexerNames.length > 1 && (
+                                  <div className="min-w-[70px] text-right font-mono text-xs font-bold">
+                                    {indexerPriorityMap.get(download.indexerName ?? "") ?? "—"}
+                                  </div>
+                                )}
+
                                 <div className="min-w-[70px] text-right">
                                   <div className="text-xs font-medium">
                                     {formatDate(download.pubDate)}

--- a/server/__tests__/cron_autosearch.test.ts
+++ b/server/__tests__/cron_autosearch.test.ts
@@ -89,7 +89,7 @@ vi.mock("../xrel.js", () => ({
 
 // Import the function under test
 // We need to use dynamic import or require because of the hoisting of vi.mock
-const { checkAutoSearch } = await import("../cron.js");
+const { checkAutoSearch, categorizeSearchItems } = await import("../cron.js");
 
 describe("Cron - checkAutoSearch", () => {
   const userId = "user-123";
@@ -1150,6 +1150,59 @@ describe("Cron - checkAutoSearch", () => {
       // Should not throw; defaults have minSeeders=0, so the item passes
       await expect(checkAutoSearch()).resolves.not.toThrow();
       expect(mockUpdateGameSearchResultsAvailable).toHaveBeenCalledWith(game.id, true);
+    });
+
+    it("should sort by indexer priority (lower number = higher priority sorts first)", () => {
+      const itemFromLowPriorityIndexer = {
+        ...ITEM_LOW_SEEDERS,
+        title: "Test Game-LOWPRIO",
+        indexerId: "indexer-low",
+      };
+      const itemFromHighPriorityIndexer = {
+        ...ITEM_HIGH_SEEDERS,
+        title: "Test Game-HIGHPRIO",
+        indexerId: "indexer-high",
+      };
+      const indexerPriorityMap = new Map([
+        ["indexer-low", 5],
+        ["indexer-high", 1],
+      ]);
+
+      const result = categorizeSearchItems(
+        [itemFromLowPriorityIndexer, itemFromHighPriorityIndexer],
+        { minSeeders: 0, sortBy: "priority", visibleCategoriesSet: new Set(["main"]) },
+        indexerPriorityMap
+      );
+
+      expect(result.mainItems.map((item) => item.title)).toEqual([
+        "Test Game-HIGHPRIO",
+        "Test Game-LOWPRIO",
+      ]);
+    });
+
+    it("should treat unknown indexers as lowest priority when sorting by priority", () => {
+      const itemFromKnownIndexer = {
+        ...ITEM_LOW_SEEDERS,
+        title: "Test Game-KNOWN",
+        indexerId: "indexer-known",
+      };
+      const itemFromUnknownIndexer = {
+        ...ITEM_HIGH_SEEDERS,
+        title: "Test Game-UNKNOWN",
+        indexerId: "indexer-unknown",
+      };
+      const indexerPriorityMap = new Map([["indexer-known", 3]]);
+
+      const result = categorizeSearchItems(
+        [itemFromUnknownIndexer, itemFromKnownIndexer],
+        { minSeeders: 0, sortBy: "priority", visibleCategoriesSet: new Set(["main"]) },
+        indexerPriorityMap
+      );
+
+      expect(result.mainItems.map((item) => item.title)).toEqual([
+        "Test Game-KNOWN",
+        "Test Game-UNKNOWN",
+      ]);
     });
   });
 

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -49,7 +49,7 @@ const GAME_UPDATE_TITLE_TO_EVENT: Record<string, NotificationEvent> = {
   "Game Delayed": "gameDelayed",
 };
 
-type DownloadSortBy = "seeders" | "date" | "size";
+type DownloadSortBy = "seeders" | "date" | "size" | "priority";
 
 interface AutoSearchRules {
   minSeeders: number;
@@ -81,7 +81,8 @@ function getAutoSearchRules(downloadRules: string | null): AutoSearchRules {
 
 function categorizeSearchItems(
   items: SearchItem[],
-  rules: AutoSearchRules
+  rules: AutoSearchRules,
+  indexerPriorityMap?: Map<string, number>
 ): AutoSearchCategorizedItems {
   const sortedItems = items
     .filter((item) => {
@@ -94,6 +95,12 @@ function categorizeSearchItems(
       }
       if (rules.sortBy === "date") {
         return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
+      }
+      if (rules.sortBy === "priority") {
+        // Lower priority number = higher-priority indexer, so it sorts first.
+        const aPriority = indexerPriorityMap?.get(a.indexerId) ?? Infinity;
+        const bPriority = indexerPriorityMap?.get(b.indexerId) ?? Infinity;
+        return aPriority - bPriority;
       }
       return (b.size ?? 0) - (a.size ?? 0);
     });
@@ -181,7 +188,8 @@ function applyPreferredPlatformFilter(
 
 async function searchAndCategorizeItemsForGame(
   game: Pick<Game, "id" | "title">,
-  downloadRules: string | null
+  downloadRules: string | null,
+  indexerPriorityMap?: Map<string, number>
 ): Promise<AutoSearchCategorizedItems | null> {
   const { items, errors } = await searchAllIndexers({
     query: game.title,
@@ -245,7 +253,7 @@ async function searchAndCategorizeItemsForGame(
     rules = getAutoSearchRules(null);
   }
 
-  return categorizeSearchItems(nonBlacklisted, rules);
+  return categorizeSearchItems(nonBlacklisted, rules, indexerPriorityMap);
 }
 
 export function startCronJobs() {
@@ -966,7 +974,8 @@ export async function checkAutoSearch() {
 
             const searchResult = await searchAndCategorizeItemsForGame(
               game,
-              settings.downloadRules
+              settings.downloadRules,
+              indexerPriorityMap
             );
             if (!searchResult) {
               // No results at all (zero results or all blacklisted) — clear the badge
@@ -1094,7 +1103,8 @@ export async function checkAutoSearch() {
 
             const searchResult = await searchAndCategorizeItemsForGame(
               game,
-              settings.downloadRules
+              settings.downloadRules,
+              indexerPriorityMap
             );
             if (!searchResult) {
               await storage.updateGameSearchResultsAvailable(game.id, false);

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -51,13 +51,13 @@ const GAME_UPDATE_TITLE_TO_EVENT: Record<string, NotificationEvent> = {
 
 type DownloadSortBy = "seeders" | "date" | "size" | "priority";
 
-interface AutoSearchRules {
+export interface AutoSearchRules {
   minSeeders: number;
   sortBy: DownloadSortBy;
   visibleCategoriesSet: Set<string>;
 }
 
-interface AutoSearchCategorizedItems {
+export interface AutoSearchCategorizedItems {
   mainItems: SearchItem[];
   updateItems: SearchItem[];
   packsItems: SearchItem[];
@@ -79,7 +79,8 @@ function getAutoSearchRules(downloadRules: string | null): AutoSearchRules {
   return { minSeeders, sortBy, visibleCategoriesSet };
 }
 
-function categorizeSearchItems(
+// Exported for unit testing of the sort/filter/category logic in isolation.
+export function categorizeSearchItems(
   items: SearchItem[],
   rules: AutoSearchRules,
   indexerPriorityMap?: Map<string, number>

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -467,7 +467,7 @@ export const insertNotificationSchema = createInsertSchema(notifications).omit({
 // Download rules schema for auto-download filtering
 export const downloadRulesSchema = z.object({
   minSeeders: z.number().int().min(0).default(0),
-  sortBy: z.enum(["seeders", "date", "size"]).default("seeders"),
+  sortBy: z.enum(["seeders", "date", "size", "priority"]).default("seeders"),
   visibleCategories: z
     .array(z.enum(["main", "update", "dlc", "extra", "packs"]))
     .default(["main", "update", "dlc", "extra", "packs"]),


### PR DESCRIPTION
# Pull Request _Template_

## Description

Closes [#811](https://github.com/Doezer/Questarr/issues/811). Search results were only sortable by seeders, date, or size — there was no way to arrange results by indexer priority, so releases from a low-priority indexer could appear above one from a higher-priority indexer configured under Management > Indexers.

This adds a new **Priority** sort option (lower configured priority number = higher priority = sorts first) alongside the existing options:

- `shared/schema.ts`: added `"priority"` to the `downloadRulesSchema.sortBy` enum.
- `client/src/components/GameDownloadDialog.tsx`: added a "Priority" sort column header (shown when more than one indexer produced results) that sorts releases using each item's indexer priority, built from `/api/indexers/enabled`.
- `client/src/components/AutoDownloadRulesSettings.tsx`: added "Indexer Priority" to the default sort order selector used for auto-download rules.
- `server/cron.ts`: the auto-search cron job now honors `sortBy: "priority"`, reusing the indexer-priority map already built for release de-duplication; `categorizeSearchItems` is now exported for unit testing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Added:
- a client test that clicks the new Priority sort header and asserts release order matches configured indexer priority
- server unit tests covering `categorizeSearchItems` with `sortBy: "priority"`, including the unknown-indexer fallback

Full test suite: 2233 passed, 7 skipped. `npm run check` and `npm run lint` both pass. CI (build, tests, CodeQL, Semgrep, SonarCloud, Codecov) is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **Indexer Priority** as a sorting option for automatic download rules.
  - Download results can now be sorted by configured indexer priority, with lower numbers appearing first.
  - Added a Priority column to the download dialog when multiple indexers are available.
  - Items from unconfigured indexers are placed last when sorting by priority.
- **Tests**
  - Added coverage for priority-based sorting in download dialogs and automatic searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->