### PR TITLE
Add scroll fade hints to Settings tab strip on mobile

### DIFF
--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -179,9 +179,18 @@ export default function SettingsPage() {
   }, []);
 
   useEffect(() => {
+    const el = tabsScrollRef.current;
     updateTabsScrollFade();
     window.addEventListener("resize", updateTabsScrollFade);
-    return () => window.removeEventListener("resize", updateTabsScrollFade);
+    // A ResizeObserver also catches reflows a window resize won't fire for
+    // (e.g. web font swap changing tab label widths right after load).
+    const observer =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(updateTabsScrollFade) : null;
+    if (el && observer) observer.observe(el);
+    return () => {
+      window.removeEventListener("resize", updateTabsScrollFade);
+      observer?.disconnect();
+    };
   }, [updateTabsScrollFade]);
 
   // Local state for form
@@ -899,7 +908,7 @@ export default function SettingsPage() {
             <TabsList
               ref={tabsScrollRef}
               onScroll={updateTabsScrollFade}
-              className="mb-0 flex w-full flex-nowrap overflow-x-auto scroll-smooth [&>*]:shrink-0"
+              className="mb-0 flex w-full flex-nowrap justify-start overflow-x-auto scroll-smooth [&>*]:shrink-0"
             >
               <TabsTrigger value="general">General</TabsTrigger>
               <TabsTrigger value="rules">Rules</TabsTrigger>

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -64,7 +64,7 @@ import {
   type DownloaderDebugLoggingResponse,
 } from "@shared/schema";
 import { parseJsonStringArray, CANONICAL_PLATFORMS } from "@shared/title-utils";
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import ImportSettings from "@/components/ImportSettings";
 
 interface CertInfo {
@@ -163,6 +163,26 @@ export default function SettingsPage() {
       {}
     );
   }, [blacklistEntries]);
+
+  // Mobile tab scroller: tracks whether the tab strip has more content to
+  // reveal on either side, so we can show a fade hint (tabs overflow on
+  // narrow phones and there's no visible scrollbar to signal that).
+  const tabsScrollRef = useRef<HTMLDivElement>(null);
+  const [tabsCanScrollLeft, setTabsCanScrollLeft] = useState(false);
+  const [tabsCanScrollRight, setTabsCanScrollRight] = useState(false);
+
+  const updateTabsScrollFade = useCallback(() => {
+    const el = tabsScrollRef.current;
+    if (!el) return;
+    setTabsCanScrollLeft(el.scrollLeft > 1);
+    setTabsCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    updateTabsScrollFade();
+    window.addEventListener("resize", updateTabsScrollFade);
+    return () => window.removeEventListener("resize", updateTabsScrollFade);
+  }, [updateTabsScrollFade]);
 
   // Local state for form
   const [autoSearchEnabled, setAutoSearchEnabled] = useState(true);
@@ -314,7 +334,6 @@ export default function SettingsPage() {
       toast({ title: "Failed to update downloader debug logging", variant: "destructive" });
     },
   });
-
 
   const { data: appriseSettings } = useQuery<{
     configured: boolean;
@@ -876,17 +895,37 @@ export default function SettingsPage() {
         )}
 
         <Tabs defaultValue="general" className="w-full">
-          <TabsList className="mb-4 sm:mb-8 flex w-full flex-nowrap overflow-x-auto [&>*]:shrink-0">
-            <TabsTrigger value="general">General</TabsTrigger>
-            <TabsTrigger value="rules">Rules</TabsTrigger>
-            <TabsTrigger value="notifications">Notifications</TabsTrigger>
-            <TabsTrigger value="services">Services</TabsTrigger>
-            <TabsTrigger value="import">Import</TabsTrigger>
-            <TabsTrigger value="account">Account</TabsTrigger>
-            <TabsTrigger value="security">Security</TabsTrigger>
-            <TabsTrigger value="system">System</TabsTrigger>
-            <TabsTrigger value="blacklist">Blacklist</TabsTrigger>
-          </TabsList>
+          <div className="relative mb-4 sm:mb-8">
+            <TabsList
+              ref={tabsScrollRef}
+              onScroll={updateTabsScrollFade}
+              className="mb-0 flex w-full flex-nowrap overflow-x-auto scroll-smooth [&>*]:shrink-0"
+            >
+              <TabsTrigger value="general">General</TabsTrigger>
+              <TabsTrigger value="rules">Rules</TabsTrigger>
+              <TabsTrigger value="notifications">Notifications</TabsTrigger>
+              <TabsTrigger value="services">Services</TabsTrigger>
+              <TabsTrigger value="import">Import</TabsTrigger>
+              <TabsTrigger value="account">Account</TabsTrigger>
+              <TabsTrigger value="security">Security</TabsTrigger>
+              <TabsTrigger value="system">System</TabsTrigger>
+              <TabsTrigger value="blacklist">Blacklist</TabsTrigger>
+            </TabsList>
+            {/* Edge fades hint that the tab strip scrolls further, since it has
+                no visible scrollbar on touch devices. */}
+            {tabsCanScrollLeft && (
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-y-0 left-0 w-6 rounded-l-md bg-gradient-to-r from-muted to-transparent"
+              />
+            )}
+            {tabsCanScrollRight && (
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-y-0 right-0 w-6 rounded-r-md bg-gradient-to-l from-muted to-transparent"
+              />
+            )}
+          </div>
 
           <TabsContent value="general" className="space-y-6">
             {ghostUnlocked && (

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1007,7 +1007,7 @@ export default function SettingsPage() {
             <TabsList
               ref={setTabsScrollNode}
               onScroll={updateTabsScrollFade}
-              className="mb-0 flex w-full flex-nowrap justify-start overflow-x-auto scroll-smooth"
+              className="mb-0 flex w-full flex-nowrap justify-start overflow-x-auto motion-safe:scroll-smooth motion-reduce:scroll-auto"
             >
               <div ref={setTabsInnerNode} className="flex w-max flex-nowrap [&>*]:shrink-0">
                 <TabsTrigger value="appearance">Appearance</TabsTrigger>

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -186,10 +186,21 @@ export default function SettingsPage() {
   const setTabsScrollNode = useCallback(
     (el: HTMLDivElement | null) => {
       tabsScrollRef.current = el;
+      updateTabsScrollFade();
+    },
+    [updateTabsScrollFade]
+  );
+
+  // The scroll container itself is pinned to w-full, so a ResizeObserver on
+  // it won't fire when only its (overflowing) content grows — e.g. this app
+  // ships variable web fonts, and the fallback-font layout can be narrower
+  // than the loaded-font layout, widening tab labels after the swap without
+  // changing the container's own box. Observe the intrinsic-width inner
+  // wrapper instead, whose box does reflect that.
+  const setTabsInnerNode = useCallback(
+    (el: HTMLDivElement | null) => {
       tabsResizeObserverRef.current?.disconnect();
       tabsResizeObserverRef.current = null;
-      // A ResizeObserver also catches reflows a window resize won't fire
-      // for (e.g. web font swap changing tab label widths right after load).
       if (el && typeof ResizeObserver !== "undefined") {
         const observer = new ResizeObserver(updateTabsScrollFade);
         observer.observe(el);
@@ -923,17 +934,19 @@ export default function SettingsPage() {
             <TabsList
               ref={setTabsScrollNode}
               onScroll={updateTabsScrollFade}
-              className="mb-0 flex w-full flex-nowrap justify-start overflow-x-auto scroll-smooth [&>*]:shrink-0"
+              className="mb-0 flex w-full flex-nowrap justify-start overflow-x-auto scroll-smooth"
             >
-              <TabsTrigger value="general">General</TabsTrigger>
-              <TabsTrigger value="rules">Rules</TabsTrigger>
-              <TabsTrigger value="notifications">Notifications</TabsTrigger>
-              <TabsTrigger value="services">Services</TabsTrigger>
-              <TabsTrigger value="import">Import</TabsTrigger>
-              <TabsTrigger value="account">Account</TabsTrigger>
-              <TabsTrigger value="security">Security</TabsTrigger>
-              <TabsTrigger value="system">System</TabsTrigger>
-              <TabsTrigger value="blacklist">Blacklist</TabsTrigger>
+              <div ref={setTabsInnerNode} className="flex w-max flex-nowrap [&>*]:shrink-0">
+                <TabsTrigger value="general">General</TabsTrigger>
+                <TabsTrigger value="rules">Rules</TabsTrigger>
+                <TabsTrigger value="notifications">Notifications</TabsTrigger>
+                <TabsTrigger value="services">Services</TabsTrigger>
+                <TabsTrigger value="import">Import</TabsTrigger>
+                <TabsTrigger value="account">Account</TabsTrigger>
+                <TabsTrigger value="security">Security</TabsTrigger>
+                <TabsTrigger value="system">System</TabsTrigger>
+                <TabsTrigger value="blacklist">Blacklist</TabsTrigger>
+              </div>
             </TabsList>
             {/* Edge fades hint that the tab strip scrolls further, since it has
                 no visible scrollbar on touch devices. */}

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -167,7 +167,8 @@ export default function SettingsPage() {
   // Mobile tab scroller: tracks whether the tab strip has more content to
   // reveal on either side, so we can show a fade hint (tabs overflow on
   // narrow phones and there's no visible scrollbar to signal that).
-  const tabsScrollRef = useRef<HTMLDivElement>(null);
+  const tabsScrollRef = useRef<HTMLDivElement | null>(null);
+  const tabsResizeObserverRef = useRef<ResizeObserver | null>(null);
   const [tabsCanScrollLeft, setTabsCanScrollLeft] = useState(false);
   const [tabsCanScrollRight, setTabsCanScrollRight] = useState(false);
 
@@ -178,18 +179,32 @@ export default function SettingsPage() {
     setTabsCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
   }, []);
 
+  // A callback ref (rather than measuring in an effect keyed on a stable
+  // callback) so the tab strip is measured whenever it actually mounts —
+  // including after the page's loading branch gives way to the real
+  // content, which a mount-only effect would otherwise miss entirely.
+  const setTabsScrollNode = useCallback(
+    (el: HTMLDivElement | null) => {
+      tabsScrollRef.current = el;
+      tabsResizeObserverRef.current?.disconnect();
+      tabsResizeObserverRef.current = null;
+      // A ResizeObserver also catches reflows a window resize won't fire
+      // for (e.g. web font swap changing tab label widths right after load).
+      if (el && typeof ResizeObserver !== "undefined") {
+        const observer = new ResizeObserver(updateTabsScrollFade);
+        observer.observe(el);
+        tabsResizeObserverRef.current = observer;
+      }
+      updateTabsScrollFade();
+    },
+    [updateTabsScrollFade]
+  );
+
   useEffect(() => {
-    const el = tabsScrollRef.current;
-    updateTabsScrollFade();
     window.addEventListener("resize", updateTabsScrollFade);
-    // A ResizeObserver also catches reflows a window resize won't fire for
-    // (e.g. web font swap changing tab label widths right after load).
-    const observer =
-      typeof ResizeObserver !== "undefined" ? new ResizeObserver(updateTabsScrollFade) : null;
-    if (el && observer) observer.observe(el);
     return () => {
       window.removeEventListener("resize", updateTabsScrollFade);
-      observer?.disconnect();
+      tabsResizeObserverRef.current?.disconnect();
     };
   }, [updateTabsScrollFade]);
 
@@ -906,7 +921,7 @@ export default function SettingsPage() {
         <Tabs defaultValue="general" className="w-full">
           <div className="relative mb-4 sm:mb-8">
             <TabsList
-              ref={tabsScrollRef}
+              ref={setTabsScrollNode}
               onScroll={updateTabsScrollFade}
               className="mb-0 flex w-full flex-nowrap justify-start overflow-x-auto scroll-smooth [&>*]:shrink-0"
             >

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Server,
@@ -64,7 +65,6 @@ import {
   type DownloaderDebugLoggingResponse,
 } from "@shared/schema";
 import { parseJsonStringArray, CANONICAL_PLATFORMS } from "@shared/title-utils";
-import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import ImportSettings from "@/components/ImportSettings";
 
 interface CertInfo {


### PR DESCRIPTION
## Summary

The Preferred Release Groups setting lives on the Settings page under the **Rules** tab, but on narrow phone screens (reported on a OnePlus 12) the tab strip (`General`, `Rules`, `Notifications`, ...) overflows horizontally with no visible scrollbar. There's no affordance telling the user more tabs exist off-screen, so tabs beyond what fits are easy to miss.

## Changes

- Wired up scroll-position tracking on the Settings tab strip (`client/src/pages/settings.tsx`) via a ref + scroll/resize listeners.
- Render left/right gradient fade overlays over the tab strip only when there is more content to scroll to in that direction, giving a clear visual cue that the strip is scrollable — in line with the mobile design principles in `CLAUDE.md` (thumb-first navigation, speed over ornament).
- Added `scroll-smooth` to the tab strip for a nicer scroll feel.

No functional/behavioral change to the tabs themselves — this is a mobile discoverability fix only.

## Testing

- `npm run check` (TypeScript)
- `npx eslint client/src/pages/settings.tsx`
- `npx vitest run client/__tests__/SettingsPage.test.tsx` (13 passed)

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AeDDKLztoicY1X5wbK6gDj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved mobile settings navigation with horizontally scrollable tabs.
  * Added visual fade indicators showing when additional tabs are available.
  * Tab navigation scrolls smoothly and updates as users scroll or resize the screen.
  * Settings tabs now respond more reliably to changing screen sizes and content widths.
  * Users can more easily discover and access settings sections beyond the visible area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->