### PR TITLE
Rebuild the /play level as a subterranean vault

### DIFF
--- a/client/src/game/__tests__/vault-decor.test.ts
+++ b/client/src/game/__tests__/vault-decor.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { cellKey, type GridPos } from "../grid";
+import { blockJitter, cellNoise, pillarCells, rubbleSpots } from "../vault-decor";
+
+/** A straight interior wall run along z, well clear of the perimeter. */
+function runAlongZ(x: number, from: number, to: number): GridPos[] {
+  const cells: GridPos[] = [];
+  for (let z = from; z <= to; z++) cells.push({ x, z });
+  return cells;
+}
+
+describe("cellNoise", () => {
+  it("is deterministic for a cell and seed", () => {
+    expect(cellNoise({ x: 3, z: 7 }, 11)).toBe(cellNoise({ x: 3, z: 7 }, 11));
+  });
+
+  it("does not depend on iteration order or neighbours", () => {
+    // The whole point of hashing coordinates: reading cells in a different order
+    // must not shift the values, or one new crate re-rolls the entire level.
+    const forward = [1, 2, 3, 4].map((x) => cellNoise({ x, z: 5 }, 2));
+    const backward = [4, 3, 2, 1].map((x) => cellNoise({ x, z: 5 }, 2)).reverse();
+    expect(forward).toEqual(backward);
+  });
+
+  it("distinguishes cells that a naive x+z hash would collide", () => {
+    expect(cellNoise({ x: 2, z: 6 }, 1)).not.toBe(cellNoise({ x: 6, z: 2 }, 1));
+    expect(cellNoise({ x: 1, z: 4 }, 1)).not.toBe(cellNoise({ x: 3, z: 2 }, 1));
+  });
+
+  it("stays in the unit interval and varies with the seed", () => {
+    const values = [];
+    for (let x = 0; x < 40; x++) values.push(cellNoise({ x, z: x * 3 }, 9));
+    for (const value of values) {
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+    expect(new Set(values).size).toBeGreaterThan(30);
+    expect(cellNoise({ x: 3, z: 7 }, 11)).not.toBe(cellNoise({ x: 3, z: 7 }, 12));
+  });
+});
+
+describe("blockJitter", () => {
+  it("is signed and bounded, so it can raise or drop a block", () => {
+    let sawNegative = false;
+    let sawPositive = false;
+    for (let x = 0; x < 60; x++) {
+      const jitter = blockJitter({ x, z: 1 }, 4);
+      expect(jitter).toBeGreaterThanOrEqual(-1);
+      expect(jitter).toBeLessThan(1);
+      if (jitter < 0) sawNegative = true;
+      if (jitter > 0) sawPositive = true;
+    }
+    expect(sawNegative).toBe(true);
+    expect(sawPositive).toBe(true);
+  });
+});
+
+describe("pillarCells", () => {
+  const gridSize = 21;
+
+  it("returns only cells that are themselves walls", () => {
+    const walls = [...runAlongZ(5, 3, 9), ...runAlongZ(9, 5, 5)];
+    const wallKeys = new Set(walls.map(cellKey));
+    // Anything returned is already blocked for movement and pathfinding, which
+    // is what makes decorating it safe.
+    for (const cell of pillarCells(walls, gridSize)) {
+      expect(wallKeys.has(cellKey(cell))).toBe(true);
+    }
+  });
+
+  it("skips the middle of a straight run", () => {
+    const walls = runAlongZ(5, 3, 9);
+    const middles = pillarCells(walls, gridSize).filter((c) => c.z > 3 && c.z < 9);
+    expect(middles).toEqual([]);
+  });
+
+  it("marks a corner where two runs turn", () => {
+    // An L: down x=5, then east along z=9.
+    const walls = [...runAlongZ(5, 3, 9), { x: 6, z: 9 }, { x: 7, z: 9 }];
+    const keys = pillarCells(walls, gridSize).map(cellKey);
+    expect(keys).toContain(cellKey({ x: 5, z: 9 }));
+  });
+
+  it("marks a T-junction", () => {
+    const walls = [...runAlongZ(5, 3, 9), { x: 6, z: 6 }];
+    const keys = pillarCells(walls, gridSize).map(cellKey);
+    expect(keys).toContain(cellKey({ x: 5, z: 6 }));
+  });
+
+  it("marks a run that terminates into the outer ring", () => {
+    // z = 1 is the first interior row; z = 0 is the outer ring, which is never
+    // listed in level.walls but is still stone, crossing this run at a right
+    // angle — a T-junction the wall list alone cannot show.
+    const walls = runAlongZ(5, 1, 6);
+    const keys = pillarCells(walls, gridSize).map(cellKey);
+    expect(keys).toContain(cellKey({ x: 5, z: 1 }));
+    expect(keys).not.toContain(cellKey({ x: 5, z: 4 }));
+  });
+
+  it("does not colonnade a run laid alongside the outer ring", () => {
+    // Every cell of this run touches the ring at x = 0, but runs parallel to it
+    // rather than into it, so none of them is a corner.
+    const walls = [
+      { x: 1, z: 3 },
+      { x: 1, z: 4 },
+      { x: 1, z: 5 },
+      { x: 1, z: 6 },
+    ];
+    const keys = pillarCells(walls, gridSize).map(cellKey);
+    expect(keys).not.toContain(cellKey({ x: 1, z: 4 }));
+    expect(keys).not.toContain(cellKey({ x: 1, z: 5 }));
+  });
+
+  it("handles an empty wall list", () => {
+    expect(pillarCells([], gridSize)).toEqual([]);
+  });
+});
+
+describe("rubbleSpots", () => {
+  const gridSize = 21;
+  const none = new Set<string>();
+
+  it("is deterministic for a seed", () => {
+    expect(rubbleSpots(7, gridSize, none, none)).toEqual(rubbleSpots(7, gridSize, none, none));
+    expect(rubbleSpots(7, gridSize, none, none)).not.toEqual(rubbleSpots(8, gridSize, none, none));
+  });
+
+  it("never places debris on blocked or reserved cells", () => {
+    const blocked = new Set([cellKey({ x: 4, z: 4 }), cellKey({ x: 5, z: 4 })]);
+    const reserved = new Set([cellKey({ x: 10, z: 10 })]);
+    for (const spot of rubbleSpots(3, gridSize, blocked, reserved, 1)) {
+      expect(blocked.has(cellKey(spot.cell))).toBe(false);
+      expect(reserved.has(cellKey(spot.cell))).toBe(false);
+    }
+  });
+
+  it("keeps the placements of untouched cells stable when a crate appears", () => {
+    // Rolling per cell regardless of eligibility is what buys this: adding one
+    // blocker must not re-scatter the rest of the level.
+    const before = rubbleSpots(5, gridSize, none, none);
+    const blocked = new Set([cellKey({ x: 6, z: 6 })]);
+    const after = rubbleSpots(5, gridSize, blocked, none);
+    const survivors = before.filter((spot) => cellKey(spot.cell) !== cellKey({ x: 6, z: 6 }));
+    expect(after).toEqual(survivors);
+  });
+
+  it("stays inside the walkable interior", () => {
+    for (const spot of rubbleSpots(2, gridSize, none, none, 1)) {
+      expect(spot.cell.x).toBeGreaterThanOrEqual(1);
+      expect(spot.cell.z).toBeGreaterThanOrEqual(1);
+      expect(spot.cell.x).toBeLessThanOrEqual(gridSize - 2);
+      expect(spot.cell.z).toBeLessThanOrEqual(gridSize - 2);
+    }
+  });
+
+  it("keeps each piece within its own cell and at a sane size", () => {
+    for (const spot of rubbleSpots(11, gridSize, none, none, 1)) {
+      expect(Math.abs(spot.offsetX)).toBeLessThan(0.5);
+      expect(Math.abs(spot.offsetZ)).toBeLessThan(0.5);
+      expect(spot.scale).toBeGreaterThan(0);
+      expect(spot.rotation).toBeGreaterThanOrEqual(0);
+      expect(spot.rotation).toBeLessThan(Math.PI * 2);
+    }
+  });
+
+  it("scales with density, and places nothing at zero", () => {
+    expect(rubbleSpots(4, gridSize, none, none, 0)).toEqual([]);
+    const sparse = rubbleSpots(4, gridSize, none, none, 0.05).length;
+    const dense = rubbleSpots(4, gridSize, none, none, 0.5).length;
+    expect(dense).toBeGreaterThan(sparse);
+  });
+});

--- a/client/src/game/infiltration-game.ts
+++ b/client/src/game/infiltration-game.ts
@@ -141,6 +141,36 @@ const LAMP_LIGHT_DISTANCE = Math.hypot(LAMP_RADIUS, LAMP_HEIGHT);
 const MOVEMENT_NOISE_INTERVAL = 0.4;
 /** How often the stealth HUD is refreshed; far coarser than the render loop. */
 const STEALTH_REPORT_INTERVAL = 0.1;
+/**
+ * The vault's palette, in one place.
+ *
+ * Surfaces are warm damp stone so the sodium lamps read as the only light down
+ * here. Everything that carries *meaning* — the door locks, the guard cones, the
+ * terminal, the keycard, the player — deliberately stays outside this warm range
+ * so it reads as signal against the rock rather than blending into it.
+ */
+const PALETTE = {
+  /** Fog and background: the unlit rock the vault is cut out of. */
+  void: 0x0a0705,
+  floor: 0x2b241d,
+  /** Flagstone joints, bright and dim. */
+  mortar: 0x3a3129,
+  mortarDim: 0x2f2822,
+  perimeterWall: 0x3c332a,
+  /** A shade up from the perimeter so interior walls read as separate masonry. */
+  interiorWall: 0x473c31,
+  crate: 0x5a4530,
+  /** Sodium lamp — the one warm light source, and the one detection reads. */
+  lamp: 0xffb35c,
+  /** Weak bounce off the ceiling, and off the floor beneath it. */
+  bounceSky: 0x5a4736,
+  bounceGround: 0x120d09,
+  fill: 0xffe9d0,
+  /** Rusted iron door leaf, in its stone lintel. */
+  doorPanel: 0x2b231b,
+  doorFrame: 0x4a3d30,
+} as const;
+
 const DOOR_COLORS = { locked: 0xff3b3b, unlocked: 0x35f0b0 };
 const CONE_COLORS: Record<GuardState, number> = {
   patrol: 0xffd23c,
@@ -224,8 +254,8 @@ export class InfiltrationGame {
 
     this.iso = new IsoCamera(canvas);
 
-    this.scene.fog = new THREE.Fog(0x0d121b, 78, 165);
-    this.scene.background = new THREE.Color(0x0d121b);
+    this.scene.fog = new THREE.Fog(PALETTE.void, 78, 165);
+    this.scene.background = new THREE.Color(PALETTE.void);
 
     this.buildLevel(seed);
 
@@ -334,9 +364,11 @@ export class InfiltrationGame {
     this.solidBoxes = [];
     this.staticBlockedCells = new Set([...this.level.crates, ...this.level.walls].map(cellKey));
 
-    this.scene.add(new THREE.HemisphereLight(0x9fb4ff, 0x232a3a, 1.5));
-    this.scene.add(new THREE.AmbientLight(0xffffff, 0.55));
-    const key = new THREE.DirectionalLight(0xd6e4ff, 1.15);
+    // Underground there is no sun: the hemisphere and key lights are reduced to
+    // weak bounce that keeps geometry readable, leaving the lamps to do the work.
+    this.scene.add(new THREE.HemisphereLight(PALETTE.bounceSky, PALETTE.bounceGround, 1.0));
+    this.scene.add(new THREE.AmbientLight(PALETTE.fill, 0.3));
+    const key = new THREE.DirectionalLight(PALETTE.fill, 0.5);
     key.position.set(12, 20, 8);
     this.scene.add(key);
     // A lamp per room, so rooms read as separately lit spaces rather than one
@@ -349,7 +381,7 @@ export class InfiltrationGame {
       // player as lit — see LAMP_LIGHT_DISTANCE for why that is not LAMP_RADIUS
       // itself. Decay 1 rather than physical 2 keeps the rendered falloff nearer
       // the linear model the stealth math uses across that same span.
-      const lamp = new THREE.PointLight(0x6ee7ff, LAMP_INTENSITY, LAMP_LIGHT_DISTANCE, 1);
+      const lamp = new THREE.PointLight(PALETTE.lamp, LAMP_INTENSITY, LAMP_LIGHT_DISTANCE, 1);
       lamp.position.set(centre.x, LAMP_HEIGHT, centre.z);
       this.scene.add(lamp);
     }
@@ -357,7 +389,7 @@ export class InfiltrationGame {
     const floorSize = this.level.gridSize * this.level.cellSize;
     const floor = new THREE.Mesh(
       new THREE.PlaneGeometry(floorSize, floorSize),
-      new THREE.MeshStandardMaterial({ color: 0x222b3b, roughness: 0.95 })
+      new THREE.MeshStandardMaterial({ color: PALETTE.floor, roughness: 1 })
     );
     floor.rotation.x = -Math.PI / 2;
     this.scene.add(floor);
@@ -385,7 +417,12 @@ export class InfiltrationGame {
 
   /** Faint tile lines, so click-to-move destinations are readable at a glance. */
   private buildFloorGrid(floorSize: number) {
-    const grid = new THREE.GridHelper(floorSize, this.level.gridSize, 0x3c4c68, 0x2f3c53);
+    const grid = new THREE.GridHelper(
+      floorSize,
+      this.level.gridSize,
+      PALETTE.mortar,
+      PALETTE.mortarDim
+    );
     grid.position.y = 0.01;
     this.scene.add(grid);
   }
@@ -401,7 +438,10 @@ export class InfiltrationGame {
     ];
     for (const [x, z, w, d] of specs) {
       // Each wall owns its material so fading one occluder doesn't fade all four.
-      const material = new THREE.MeshStandardMaterial({ color: 0x333c50, roughness: 0.8 });
+      const material = new THREE.MeshStandardMaterial({
+        color: PALETTE.perimeterWall,
+        roughness: 0.95,
+      });
       const wall = new THREE.Mesh(new THREE.BoxGeometry(w, WALL_HEIGHT, d), material);
       wall.position.set(x, WALL_HEIGHT / 2, z);
       this.scene.add(wall);
@@ -412,7 +452,7 @@ export class InfiltrationGame {
   /** A waist-high crate: cover from sight, and a solid box for collision. */
   private buildCrate(gridPos: GridPos) {
     const world = gridToWorld(gridPos, this.level);
-    const material = new THREE.MeshStandardMaterial({ color: 0x49536b, roughness: 0.7 });
+    const material = new THREE.MeshStandardMaterial({ color: PALETTE.crate, roughness: 0.85 });
     const crate = new THREE.Mesh(
       new THREE.BoxGeometry(CRATE_SIZE, CRATE_HEIGHT, CRATE_SIZE),
       material
@@ -430,7 +470,10 @@ export class InfiltrationGame {
   private buildInteriorWall(cell: GridPos) {
     const world = gridToWorld(cell, this.level);
     const size = this.level.cellSize;
-    const material = new THREE.MeshStandardMaterial({ color: 0x4a5570, roughness: 0.8 });
+    const material = new THREE.MeshStandardMaterial({
+      color: PALETTE.interiorWall,
+      roughness: 0.95,
+    });
     const mesh = new THREE.Mesh(new THREE.BoxGeometry(size, WALL_HEIGHT, size), material);
     mesh.position.set(world.x, WALL_HEIGHT / 2, world.z);
     this.scene.add(mesh);
@@ -445,11 +488,12 @@ export class InfiltrationGame {
     const group = new THREE.Group();
 
     const material = new THREE.MeshStandardMaterial({
-      color: 0x1b2330,
+      color: PALETTE.doorPanel,
       emissive: DOOR_COLORS.locked,
       emissiveIntensity: 0.6,
-      roughness: 0.4,
-      metalness: 0.5,
+      // Pitted iron rather than the polished panel a facility would have.
+      roughness: 0.65,
+      metalness: 0.7,
     });
     // splitRect cuts along both axes, so a door sits in a wall of either
     // orientation. Rooms side by side on X are divided by a wall at constant X,
@@ -471,7 +515,10 @@ export class InfiltrationGame {
     group.add(panel);
 
     // The frame stays put while the panel slides down inside it.
-    const frameMaterial = new THREE.MeshStandardMaterial({ color: 0x39435c, roughness: 0.7 });
+    const frameMaterial = new THREE.MeshStandardMaterial({
+      color: PALETTE.doorFrame,
+      roughness: 0.9,
+    });
     const lintel = new THREE.Mesh(
       new THREE.BoxGeometry(
         dividedOnX ? size * 0.6 : size,
@@ -658,7 +705,14 @@ export class InfiltrationGame {
     this.player = new THREE.Group();
     const body = new THREE.Mesh(
       new THREE.CapsuleGeometry(0.34, 1, 4, 10),
-      new THREE.MeshStandardMaterial({ color: 0x5eb0ff, roughness: 0.5 })
+      // Faintly self-lit: the vault is dark enough that an unlit avatar gets lost
+      // against the floor, and losing track of yourself is never good tension.
+      new THREE.MeshStandardMaterial({
+        color: 0x5eb0ff,
+        emissive: 0x14364f,
+        emissiveIntensity: 0.9,
+        roughness: 0.5,
+      })
     );
     body.position.y = 0.85;
     // A small nose cone makes the player's facing (and so their approach angle)

--- a/client/src/game/infiltration-game.ts
+++ b/client/src/game/infiltration-game.ts
@@ -2,6 +2,16 @@ import * as THREE from "three";
 import { IsoCamera } from "./iso-camera";
 import { cellKey, isInterior, type GridPos } from "./grid";
 import { findPath, nearestOpenCell } from "./pathfinding";
+import { mulberry32 } from "./rng";
+import {
+  applyTexture,
+  disposeVaultTextures,
+  ironTexture,
+  masonryTexture,
+  stoneFloorTexture,
+  timberTexture,
+} from "./textures";
+import { blockJitter, cellNoise, pillarCells, rubbleSpots } from "./vault-decor";
 import {
   generateLevel,
   gridToWorld,
@@ -138,6 +148,28 @@ const LAMP_HEIGHT = 5.5;
  */
 const LAMP_LIGHT_DISTANCE = Math.hypot(LAMP_RADIUS, LAMP_HEIGHT);
 /** Movement noise is emitted on a cadence, not per frame, so guards re-path sanely. */
+/**
+ * How far a pillar rises past the wall it stands in.
+ *
+ * Enough that a length of shaft is visible above the coping. A shorter overhang
+ * shows only the capital, which from a fixed overhead angle reads as a disc
+ * lying on the wall rather than as a column passing through it.
+ */
+const PILLAR_OVERHANG = 2.3;
+/** Depth of the capping course laid along the top of every wall run. */
+const WALL_CAP_HEIGHT = 0.22;
+/** How far the cap oversails the wall below it, giving the run a lip. */
+const WALL_CAP_OVERSAIL = 0.12;
+/** Peak variation in a masonry block's height, so no run tops out dead level. */
+const BLOCK_HEIGHT_JITTER = 0.28;
+/** Base size of a piece of floor debris, before its per-piece scale. */
+const RUBBLE_SIZE = 0.26;
+/** Motes of dust hanging in the air, which give the lamp pools some depth. */
+const DUST_COUNT = 420;
+/** How fast a mote drifts upward before it wraps back to the floor. */
+const DUST_RISE = 0.12;
+/** Height the motes fill, a little above the walls so the lamps sit inside it. */
+const DUST_CEILING = 6.5;
 const MOVEMENT_NOISE_INTERVAL = 0.4;
 /** How often the stealth HUD is refreshed; far coarser than the render loop. */
 const STEALTH_REPORT_INTERVAL = 0.1;
@@ -153,9 +185,6 @@ const PALETTE = {
   /** Fog and background: the unlit rock the vault is cut out of. */
   void: 0x0a0705,
   floor: 0x2b241d,
-  /** Flagstone joints, bright and dim. */
-  mortar: 0x3a3129,
-  mortarDim: 0x2f2822,
   perimeterWall: 0x3c332a,
   /** A shade up from the perimeter so interior walls read as separate masonry. */
   interiorWall: 0x473c31,
@@ -169,6 +198,14 @@ const PALETTE = {
   /** Rusted iron door leaf, in its stone lintel. */
   doorPanel: 0x2b231b,
   doorFrame: 0x4a3d30,
+  /** Load-bearing columns: paler than the walls, as dressed stone would be. */
+  pillar: 0x554a3d,
+  /** Fallen masonry on the floor, a touch darker than the flagstones. */
+  rubble: 0x3d342b,
+  /** The iron cage a lamp hangs in, and the chain it hangs from. */
+  lampHousing: 0x1c1712,
+  /** Motes in the air, lit warm so they only show inside a lamp pool. */
+  dust: 0xd9b98a,
 } as const;
 
 const DOOR_COLORS = { locked: 0xff3b3b, unlocked: 0x35f0b0 };
@@ -200,6 +237,10 @@ export class InfiltrationGame {
   private staticBlockedCells = new Set<string>();
   private solidBoxes: Box[] = [];
   private doors: Door[] = [];
+  /** Seed for the level's decorative jitter, so a replay of it looks the same. */
+  private decorSeed = 0;
+  /** Dust motes drifting in the air; animated, so held for the update loop. */
+  private dust: THREE.Points | null = null;
   private keycardMesh: THREE.Mesh | null = null;
   /** Tracked separately from the card so pickup hides the glow with it. */
   private keycardHalo: THREE.Mesh | null = null;
@@ -279,6 +320,7 @@ export class InfiltrationGame {
     this.doors = [];
     this.keycardMesh = null;
     this.keycardHalo = null;
+    this.dust = null;
     this.hasKeycard = false;
     this.playerPath = [];
     this.clearScene();
@@ -304,9 +346,16 @@ export class InfiltrationGame {
   /** Removes and disposes every scene child so replays don't leak GPU memory. */
   private clearScene() {
     this.scene.traverse((object) => {
-      // Meshes, lines and the floor GridHelper all carry geometry/material that
+      // Meshes, lines and the dust point cloud all carry geometry/material that
       // has to go back to the GPU, or replays leak a level's worth each time.
-      if (!(object instanceof THREE.Mesh) && !(object instanceof THREE.Line)) return;
+      // Points is neither a Mesh nor a Line, so it needs naming explicitly.
+      if (
+        !(object instanceof THREE.Mesh) &&
+        !(object instanceof THREE.Line) &&
+        !(object instanceof THREE.Points)
+      ) {
+        return;
+      }
       object.geometry.dispose();
       const materials = Array.isArray(object.material) ? object.material : [object.material];
       for (const material of materials) material.dispose();
@@ -351,6 +400,9 @@ export class InfiltrationGame {
     this.canvas.removeEventListener("wheel", this.handleWheel);
     this.resizeObserver.disconnect();
     this.clearScene();
+    // The texture cache is shared across replays and outlives every material, so
+    // it is only safe to drop once the game itself is going away.
+    disposeVaultTextures();
     this.renderer.dispose();
   }
 
@@ -359,6 +411,7 @@ export class InfiltrationGame {
   /** Generates a facility for the seed and raises every mesh and collider for it. */
   private buildLevel(seed: number) {
     this.level = generateLevel(seed);
+    this.decorSeed = seed;
     this.facilityHalfExtent = (this.level.gridSize * this.level.cellSize) / 2;
     this.iso.setBounds(this.facilityHalfExtent);
     this.solidBoxes = [];
@@ -367,7 +420,7 @@ export class InfiltrationGame {
     // Underground there is no sun: the hemisphere and key lights are reduced to
     // weak bounce that keeps geometry readable, leaving the lamps to do the work.
     this.scene.add(new THREE.HemisphereLight(PALETTE.bounceSky, PALETTE.bounceGround, 1.0));
-    this.scene.add(new THREE.AmbientLight(PALETTE.fill, 0.3));
+    this.scene.add(new THREE.AmbientLight(PALETTE.fill, 0.36));
     const key = new THREE.DirectionalLight(PALETTE.fill, 0.5);
     key.position.set(12, 20, 8);
     this.scene.add(key);
@@ -384,21 +437,25 @@ export class InfiltrationGame {
       const lamp = new THREE.PointLight(PALETTE.lamp, LAMP_INTENSITY, LAMP_LIGHT_DISTANCE, 1);
       lamp.position.set(centre.x, LAMP_HEIGHT, centre.z);
       this.scene.add(lamp);
+      this.buildLampFixture(centre);
     }
 
     const floorSize = this.level.gridSize * this.level.cellSize;
-    const floor = new THREE.Mesh(
-      new THREE.PlaneGeometry(floorSize, floorSize),
-      new THREE.MeshStandardMaterial({ color: PALETTE.floor, roughness: 1 })
-    );
+    const floorMaterial = new THREE.MeshStandardMaterial({ color: PALETTE.floor, roughness: 1 });
+    // Two flagstones to a cell: fine enough to read as stone from the isometric
+    // camera, coarse enough that the slabs are still individually visible.
+    applyTexture(floorMaterial, stoneFloorTexture(this.level.gridSize / 2));
+    const floor = new THREE.Mesh(new THREE.PlaneGeometry(floorSize, floorSize), floorMaterial);
     floor.rotation.x = -Math.PI / 2;
     this.scene.add(floor);
-    this.buildFloorGrid(floorSize);
 
     this.buildPerimeter(floorSize);
     for (const wallCell of this.level.walls) this.buildInteriorWall(wallCell);
+    for (const cell of pillarCells(this.level.walls, this.level.gridSize)) this.buildPillar(cell);
     for (const cratePos of this.level.crates) this.buildCrate(cratePos);
     for (const door of this.level.doors) this.buildDoor(door);
+    this.buildRubble();
+    this.buildDust(floorSize);
     this.buildTerminal();
     this.buildKeycard();
     this.buildGuards();
@@ -413,18 +470,6 @@ export class InfiltrationGame {
       needsKeycard: this.level.doors.some((door) => door.locked),
       hasKeycard: this.hasKeycard,
     });
-  }
-
-  /** Faint tile lines, so click-to-move destinations are readable at a glance. */
-  private buildFloorGrid(floorSize: number) {
-    const grid = new THREE.GridHelper(
-      floorSize,
-      this.level.gridSize,
-      PALETTE.mortar,
-      PALETTE.mortarDim
-    );
-    grid.position.y = 0.01;
-    this.scene.add(grid);
   }
 
   /** Raises the four perimeter walls, each an occluder in its own right. */
@@ -442,25 +487,67 @@ export class InfiltrationGame {
         color: PALETTE.perimeterWall,
         roughness: 0.95,
       });
+      // One course of masonry per cell of length, so the block scale matches the
+      // interior walls it meets rather than stretching along the whole run.
+      applyTexture(material, masonryTexture(Math.max(w, d) / this.level.cellSize));
       const wall = new THREE.Mesh(new THREE.BoxGeometry(w, WALL_HEIGHT, d), material);
       wall.position.set(x, WALL_HEIGHT / 2, z);
       this.scene.add(wall);
       this.occluders.push({ mesh: wall, material });
+      this.buildWallCap(x, z, w, d, WALL_HEIGHT);
     }
   }
 
-  /** A waist-high crate: cover from sight, and a solid box for collision. */
+  /**
+   * The oversailing course along the top of a wall.
+   *
+   * A wall that simply stops is a box; a wall that finishes with a lip that
+   * catches the lamplight along its edge reads as built. Purely decorative — it
+   * sits above head height and adds no collider.
+   */
+  private buildWallCap(x: number, z: number, w: number, d: number, top: number) {
+    const material = new THREE.MeshStandardMaterial({
+      color: PALETTE.pillar,
+      roughness: 0.9,
+    });
+    const cap = new THREE.Mesh(
+      new THREE.BoxGeometry(w + WALL_CAP_OVERSAIL * 2, WALL_CAP_HEIGHT, d + WALL_CAP_OVERSAIL * 2),
+      material
+    );
+    cap.position.set(x, top + WALL_CAP_HEIGHT / 2, z);
+    this.scene.add(cap);
+    this.occluders.push({ mesh: cap, material });
+  }
+
+  /** A waist-high timber crate: cover from sight, and a solid box for collision. */
   private buildCrate(gridPos: GridPos) {
     const world = gridToWorld(gridPos, this.level);
     const material = new THREE.MeshStandardMaterial({ color: PALETTE.crate, roughness: 0.85 });
-    const crate = new THREE.Mesh(
-      new THREE.BoxGeometry(CRATE_SIZE, CRATE_HEIGHT, CRATE_SIZE),
-      material
-    );
-    crate.position.set(world.x, CRATE_HEIGHT / 2, world.z);
+    applyTexture(material, timberTexture(1));
+    // Height varies per crate; the footprint never does. The collider below is
+    // built from CRATE_SIZE either way, so what the player can walk past stays
+    // exactly what it was — only the silhouette changes.
+    const height = CRATE_HEIGHT * (1 + blockJitter(gridPos, this.decorSeed) * 0.12);
+    const crate = new THREE.Mesh(new THREE.BoxGeometry(CRATE_SIZE, height, CRATE_SIZE), material);
+    crate.position.set(world.x, height / 2, world.z);
+    // A few degrees off square: crates were stacked by hand, not laid out on the
+    // grid. Kept small so the rotated box stays inside its own cell.
+    crate.rotation.y = blockJitter({ x: gridPos.z, z: gridPos.x }, this.decorSeed) * 0.09;
     this.scene.add(crate);
     this.occluders.push({ mesh: crate, material });
     this.solidBoxes.push(boxAround(world.x, world.z, CRATE_SIZE));
+
+    // Roughly a third of them carry a smaller box on top, which breaks up the
+    // repeated silhouette. It rides above the collider, so it changes nothing.
+    if (cellNoise(gridPos, this.decorSeed ^ 0x1d) >= 0.34) return;
+    const lidMaterial = new THREE.MeshStandardMaterial({ color: PALETTE.crate, roughness: 0.9 });
+    applyTexture(lidMaterial, timberTexture(1));
+    const lidSize = CRATE_SIZE * 0.55;
+    const lid = new THREE.Mesh(new THREE.BoxGeometry(lidSize, lidSize * 0.7, lidSize), lidMaterial);
+    lid.position.set(world.x, height + lidSize * 0.35, world.z);
+    lid.rotation.y = cellNoise(gridPos, this.decorSeed ^ 0x2e) * 0.8 - 0.4;
+    this.scene.add(lid);
+    this.occluders.push({ mesh: lid, material: lidMaterial });
   }
 
   /**
@@ -474,11 +561,64 @@ export class InfiltrationGame {
       color: PALETTE.interiorWall,
       roughness: 0.95,
     });
-    const mesh = new THREE.Mesh(new THREE.BoxGeometry(size, WALL_HEIGHT, size), material);
-    mesh.position.set(world.x, WALL_HEIGHT / 2, world.z);
+    applyTexture(material, masonryTexture(1));
+    // Each block tops out a little above or below its neighbours. The collider
+    // is unchanged and the wall never drops below head height, so this is a
+    // silhouette detail only: nothing becomes see-over or walk-through.
+    const height = WALL_HEIGHT + blockJitter(cell, this.decorSeed) * BLOCK_HEIGHT_JITTER;
+    const mesh = new THREE.Mesh(new THREE.BoxGeometry(size, height, size), material);
+    mesh.position.set(world.x, height / 2, world.z);
     this.scene.add(mesh);
     this.occluders.push({ mesh, material });
     this.solidBoxes.push(boxAround(world.x, world.z, size));
+    this.buildWallCap(world.x, world.z, size, size, height);
+  }
+
+  /**
+   * A dressed column at a corner or junction of the masonry.
+   *
+   * Every pillar cell comes from {@link pillarCells}, which only ever returns
+   * cells that are already walls — so a pillar stands inside an existing
+   * collider and cannot become an obstacle the pathfinder does not know about.
+   */
+  private buildPillar(cell: GridPos) {
+    const world = gridToWorld(cell, this.level);
+    const size = this.level.cellSize;
+    const height = WALL_HEIGHT + PILLAR_OVERHANG;
+    const material = new THREE.MeshStandardMaterial({ color: PALETTE.pillar, roughness: 0.85 });
+    applyTexture(material, masonryTexture(1));
+
+    // Octagonal rather than round: eight faces catch the lamplight in flat
+    // bands, which reads as cut stone where a smooth cylinder reads as a pipe.
+    const radius = size * 0.34;
+    const shaft = new THREE.Mesh(
+      new THREE.CylinderGeometry(radius * 0.92, radius, height, 8),
+      material
+    );
+    shaft.position.set(world.x, height / 2, world.z);
+    this.scene.add(shaft);
+    this.occluders.push({ mesh: shaft, material });
+
+    // Base and capital, each a drum a little wider than the shaft. Kept narrow:
+    // a broad capital seen from above is a disc, and the point of the capital is
+    // to terminate a column the player can see rising out of the wall.
+    for (const [y, drumHeight] of [
+      [0.18, 0.36],
+      [height - 0.22, 0.44],
+    ]) {
+      const trimMaterial = new THREE.MeshStandardMaterial({
+        color: PALETTE.pillar,
+        roughness: 0.8,
+      });
+      applyTexture(trimMaterial, masonryTexture(1));
+      const drum = new THREE.Mesh(
+        new THREE.CylinderGeometry(radius * 1.14, radius * 1.14, drumHeight, 8),
+        trimMaterial
+      );
+      drum.position.set(world.x, y, world.z);
+      this.scene.add(drum);
+      this.occluders.push({ mesh: drum, material: trimMaterial });
+    }
   }
 
   /** A door panel plus its collider, tinted by lock state and tracked for sliding. */
@@ -495,6 +635,7 @@ export class InfiltrationGame {
       roughness: 0.65,
       metalness: 0.7,
     });
+    applyTexture(material, ironTexture(1));
     // splitRect cuts along both axes, so a door sits in a wall of either
     // orientation. Rooms side by side on X are divided by a wall at constant X,
     // and a panel that always spanned X would leave gaps either side of that
@@ -519,6 +660,7 @@ export class InfiltrationGame {
       color: PALETTE.doorFrame,
       roughness: 0.9,
     });
+    applyTexture(frameMaterial, masonryTexture(1));
     const lintel = new THREE.Mesh(
       new THREE.BoxGeometry(
         dividedOnX ? size * 0.6 : size,
@@ -531,6 +673,40 @@ export class InfiltrationGame {
     this.scene.add(lintel);
     this.occluders.push({ mesh: lintel, material: frameMaterial });
 
+    // A relieving arch springing from the opening, which is what actually makes
+    // a hole in a stone wall read as a doorway rather than a missing block.
+    //
+    // One on each face rather than one in the middle: an arch inside the wall's
+    // own thickness is buried by the lintel and invisible. Standing them proud
+    // of both faces frames the opening from whichever room the camera is over.
+    const archTube = size * 0.13;
+    const archRadius = span / 2 + archTube * 0.5;
+    const archOffset = thickness / 2 + archTube;
+    for (const side of [-1, 1]) {
+      const archMaterial = new THREE.MeshStandardMaterial({
+        color: PALETTE.pillar,
+        roughness: 0.85,
+      });
+      applyTexture(archMaterial, masonryTexture(1));
+      const arch = new THREE.Mesh(
+        new THREE.TorusGeometry(archRadius, archTube, 6, 20, Math.PI),
+        archMaterial
+      );
+      // A half torus lies in its own XY plane, springing from -X to +X and
+      // arcing up through +Y: upright already, and spanning X. Rooms divided on
+      // X are separated by a wall at constant X, whose opening runs along Z, so
+      // that case is the one that needs turning a quarter turn — and its faces
+      // are then offset on X rather than Z.
+      if (dividedOnX) arch.rotation.y = Math.PI / 2;
+      arch.position.set(
+        world.x + (dividedOnX ? side * archOffset : 0),
+        DOOR_HEIGHT * 0.86,
+        world.z + (dividedOnX ? 0 : side * archOffset)
+      );
+      this.scene.add(arch);
+      this.occluders.push({ mesh: arch, material: archMaterial });
+    }
+
     group.position.set(world.x, 0, world.z);
     this.scene.add(group);
 
@@ -542,6 +718,132 @@ export class InfiltrationGame {
       box: boxAround(world.x, world.z, size),
       openness: 0,
     });
+  }
+
+  /**
+   * The iron lamp a room's light visibly hangs from.
+   *
+   * The `PointLight` alone is a glow with no cause; hanging a caged bulb at the
+   * same point gives the pool a source the player can see and read the room by.
+   * It hangs above wall height and holds no collider.
+   */
+  private buildLampFixture(centre: { x: number; z: number }) {
+    const housing = new THREE.MeshStandardMaterial({
+      color: PALETTE.lampHousing,
+      roughness: 0.6,
+      metalness: 0.8,
+    });
+    const chain = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.045, 0.045, LAMP_HEIGHT * 0.4, 5),
+      housing
+    );
+    chain.position.set(centre.x, LAMP_HEIGHT + LAMP_HEIGHT * 0.2, centre.z);
+
+    const cage = new THREE.Mesh(new THREE.TorusGeometry(0.34, 0.05, 5, 12), housing);
+    cage.rotation.x = Math.PI / 2;
+    cage.position.set(centre.x, LAMP_HEIGHT, centre.z);
+
+    // Emissive rather than lit: the bulb has to read as bright from any angle,
+    // and its own PointLight cannot illuminate the mesh it sits inside.
+    const bulb = new THREE.Mesh(
+      new THREE.SphereGeometry(0.26, 12, 8),
+      new THREE.MeshStandardMaterial({
+        color: PALETTE.lamp,
+        emissive: PALETTE.lamp,
+        emissiveIntensity: 1.4,
+      })
+    );
+    bulb.position.set(centre.x, LAMP_HEIGHT, centre.z);
+
+    this.scene.add(chain, cage, bulb);
+  }
+
+  /**
+   * Fallen masonry scattered over the floor.
+   *
+   * Placement comes from {@link rubbleSpots}, which keeps debris off the cells
+   * the player has to read and off anything solid. The pieces carry no collider
+   * and are shorter than a step, so they are walked over, not around.
+   */
+  private buildRubble() {
+    const reserved = new Set(
+      [
+        this.level.spawn,
+        this.level.terminal,
+        ...(this.level.keycard ? [this.level.keycard] : []),
+        ...this.level.doors.map((door) => door.pos),
+      ].map(cellKey)
+    );
+    const spots = rubbleSpots(
+      this.decorSeed,
+      this.level.gridSize,
+      this.staticBlockedCells,
+      reserved
+    );
+
+    // One material for the lot: debris is never an occluder, so nothing ever
+    // needs to fade a single piece independently of the rest.
+    const material = new THREE.MeshStandardMaterial({ color: PALETTE.rubble, roughness: 1 });
+    applyTexture(material, masonryTexture(1));
+
+    for (const spot of spots) {
+      const world = gridToWorld(spot.cell, this.level);
+      const size = RUBBLE_SIZE * spot.scale;
+      // A dodecahedron at detail 0 is an irregular lump for the price of a few
+      // triangles, which is exactly what a broken stone should look like.
+      const shard = new THREE.Mesh(new THREE.DodecahedronGeometry(size, 0), material);
+      shard.position.set(
+        world.x + spot.offsetX * this.level.cellSize,
+        size * 0.45,
+        world.z + spot.offsetZ * this.level.cellSize
+      );
+      shard.rotation.set(spot.rotation * 0.3, spot.rotation, spot.rotation * 0.2);
+      shard.scale.y = 0.6;
+      this.scene.add(shard);
+    }
+  }
+
+  /**
+   * Motes of dust hanging in the air.
+   *
+   * Vertex-coloured warm and additively blended, so a mote only shows where a
+   * lamp is already bright: the effect appears inside the pools and vanishes in
+   * the dark, which is the whole reason it reads as air rather than as noise.
+   */
+  private buildDust(floorSize: number) {
+    const positions = new Float32Array(DUST_COUNT * 3);
+    const random = mulberry32(this.decorSeed ^ 0xd0570);
+    for (let i = 0; i < DUST_COUNT; i++) {
+      positions[i * 3] = (random() - 0.5) * floorSize;
+      positions[i * 3 + 1] = random() * DUST_CEILING;
+      positions[i * 3 + 2] = (random() - 0.5) * floorSize;
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+    this.dust = new THREE.Points(
+      geometry,
+      new THREE.PointsMaterial({
+        color: PALETTE.dust,
+        size: 0.07,
+        transparent: true,
+        opacity: 0.5,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+      })
+    );
+    this.scene.add(this.dust);
+  }
+
+  /** Drifts the dust upward, wrapping each mote back to the floor at the top. */
+  private updateDust(dt: number) {
+    if (!this.dust) return;
+    const attribute = this.dust.geometry.getAttribute("position") as THREE.BufferAttribute;
+    const array = attribute.array as Float32Array;
+    for (let i = 1; i < array.length; i += 3) {
+      array[i] += DUST_RISE * dt;
+      if (array[i] > DUST_CEILING) array[i] -= DUST_CEILING;
+    }
+    attribute.needsUpdate = true;
   }
 
   /** The pickup that unlocks the terminal's door, if this layout has a lock. */
@@ -1063,6 +1365,9 @@ export class InfiltrationGame {
       if (this.throwCooldown > 0) this.throwCooldown -= dt;
     }
 
+    // Outside the paused/finished gate: the air keeps moving while the player
+    // reads a pause or win overlay, which stops the scene looking frozen solid.
+    this.updateDust(dt);
     this.iso.follow(this.player.position, dt);
     this.updateOcclusion();
     this.updateMarker(dt);

--- a/client/src/game/textures.ts
+++ b/client/src/game/textures.ts
@@ -1,0 +1,301 @@
+/**
+ * Procedurally drawn surface textures for the vault.
+ *
+ * Everything here is painted into a `<canvas>` at load time rather than shipped
+ * as image files: the easter egg should not add megabytes to the bundle, and a
+ * tiling 256px pattern is all a fixed isometric camera can resolve anyway.
+ *
+ * Each texture is drawn in *greyscale* around mid-luminance and tinted by the
+ * material's `color`, so one stone pattern serves the floor, the walls and the
+ * pillars at three different tints. The same canvas is reused as a `bumpMap`,
+ * where its luminance becomes relief — which is what makes the sodium lamps rake
+ * across the masonry instead of washing it flat.
+ *
+ * Like the engine itself this needs a browser to do anything, so it is not unit
+ * tested; `null` comes back wherever a 2D context is unavailable and callers
+ * fall back to an untextured material.
+ */
+
+import * as THREE from "three";
+import { mulberry32 } from "./rng";
+
+/** Edge length of every generated texture. Powers of two mip and wrap cleanly. */
+const SIZE = 256;
+
+/** A drawn texture and the bump map derived from the same pixels. */
+export interface VaultTexture {
+  map: THREE.CanvasTexture;
+  bumpMap: THREE.CanvasTexture;
+  bumpScale: number;
+}
+
+type Painter = (ctx: CanvasRenderingContext2D, random: () => number) => void;
+
+const cache = new Map<string, VaultTexture | null>();
+
+/**
+ * Paints one texture, wraps it for tiling, and scales it to `repeat` tiles.
+ *
+ * Results are cached by pattern *and* scale. A level has dozens of wall
+ * segments, and every one of them needs its own **material** so occlusion can
+ * fade a single segment — but they all want the same image on the GPU. The
+ * scale has to be part of the key because `repeat` lives on the texture rather
+ * than the material: cloning per material would give the wide floor its own
+ * scale at the cost of a fresh GPU upload per mesh, and a leak on every replay,
+ * since disposing a material does not dispose its textures.
+ */
+function build(
+  name: string,
+  seed: number,
+  paint: Painter,
+  bumpScale: number,
+  repeat: number
+): VaultTexture | null {
+  const key = `${name}@${repeat}`;
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = SIZE;
+  canvas.height = SIZE;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    cache.set(key, null);
+    return null;
+  }
+
+  paint(ctx, mulberry32(seed));
+
+  const map = new THREE.CanvasTexture(canvas);
+  map.wrapS = THREE.RepeatWrapping;
+  map.wrapT = THREE.RepeatWrapping;
+  map.repeat.set(repeat, repeat);
+  map.colorSpace = THREE.SRGBColorSpace;
+
+  // The bump map reads the same canvas as linear height rather than as colour,
+  // and a texture carries exactly one colour space, so it needs its own object.
+  const bumpMap = new THREE.CanvasTexture(canvas);
+  bumpMap.wrapS = THREE.RepeatWrapping;
+  bumpMap.wrapT = THREE.RepeatWrapping;
+  bumpMap.repeat.set(repeat, repeat);
+
+  const texture: VaultTexture = { map, bumpMap, bumpScale };
+  cache.set(key, texture);
+  return texture;
+}
+
+/** Grain that hides the flatness of a solid fill. Drawn wrapped, so it tiles. */
+function speckle(
+  ctx: CanvasRenderingContext2D,
+  random: () => number,
+  count: number,
+  alpha: number
+) {
+  for (let i = 0; i < count; i++) {
+    const x = random() * SIZE;
+    const y = random() * SIZE;
+    const r = 0.5 + random() * 2.5;
+    const shade = Math.floor(random() * 255);
+    ctx.fillStyle = `rgba(${shade}, ${shade}, ${shade}, ${alpha})`;
+    ctx.beginPath();
+    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+/**
+ * Draws a course of blocks with recessed joints, wrapping at the edges.
+ *
+ * Blocks are drawn *bright*: the pattern multiplies into the material colour, so
+ * a mid-grey pattern over a dark palette tint darkens the surface twice and the
+ * lamps end up lighting nothing. `stagger` breaks the bond between courses so
+ * the joints do not line up into a grid.
+ */
+function courses(
+  ctx: CanvasRenderingContext2D,
+  random: () => number,
+  rows: number,
+  cols: number,
+  stagger: boolean
+) {
+  const rowHeight = SIZE / rows;
+  const colWidth = SIZE / cols;
+  ctx.lineWidth = 2;
+
+  for (let row = 0; row < rows; row++) {
+    const y = row * rowHeight;
+    const offset = stagger && row % 2 === 1 ? colWidth / 2 : 0;
+    for (let col = -1; col < cols; col++) {
+      const x = col * colWidth + offset;
+      // Each block gets its own shade, so a course reads as separate stones.
+      const shade = 186 + Math.floor(random() * 55);
+      ctx.fillStyle = `rgb(${shade}, ${shade}, ${shade})`;
+      ctx.fillRect(x + 1.5, y + 1.5, colWidth - 3, rowHeight - 3);
+      // A dark joint and a light top edge: cheap, and enough for the bump map
+      // to catch a lamp along every course.
+      ctx.strokeStyle = "rgba(40, 36, 32, 0.85)";
+      ctx.strokeRect(x + 1.5, y + 1.5, colWidth - 3, rowHeight - 3);
+      ctx.fillStyle = "rgba(255, 255, 255, 0.16)";
+      ctx.fillRect(x + 1.5, y + 1.5, colWidth - 3, 2);
+    }
+  }
+}
+
+/** Damp flagstones: large slabs, worn unevenly, with grit in the joints. */
+export function stoneFloorTexture(repeat: number): VaultTexture | null {
+  return build(
+    "stone-floor",
+    0x51a6,
+    (ctx, random) => {
+      ctx.fillStyle = "rgb(186, 180, 172)";
+      ctx.fillRect(0, 0, SIZE, SIZE);
+      courses(ctx, random, 4, 4, true);
+      // Damp patches, darker than the slabs and unrelated to the joints, so the
+      // floor does not read as a tiled grid from above.
+      for (let i = 0; i < 14; i++) {
+        const x = random() * SIZE;
+        const y = random() * SIZE;
+        const r = 10 + random() * 34;
+        const patch = ctx.createRadialGradient(x, y, 0, x, y, r);
+        patch.addColorStop(0, "rgba(70, 66, 62, 0.5)");
+        patch.addColorStop(1, "rgba(70, 66, 62, 0)");
+        ctx.fillStyle = patch;
+        ctx.fillRect(x - r, y - r, r * 2, r * 2);
+      }
+      speckle(ctx, random, 900, 0.1);
+    },
+    0.35,
+    repeat
+  );
+}
+
+/** Coursed masonry for walls and pillars: smaller blocks, deeper joints. */
+export function masonryTexture(repeat: number): VaultTexture | null {
+  return build(
+    "masonry",
+    0x9c31,
+    (ctx, random) => {
+      ctx.fillStyle = "rgb(178, 170, 161)";
+      ctx.fillRect(0, 0, SIZE, SIZE);
+      courses(ctx, random, 8, 4, true);
+      speckle(ctx, random, 700, 0.12);
+    },
+    0.6,
+    repeat
+  );
+}
+
+/** Rough sawn timber: planks along one axis, with knots and end banding. */
+export function timberTexture(repeat: number): VaultTexture | null {
+  return build(
+    "timber",
+    0x2f77,
+    (ctx, random) => {
+      ctx.fillStyle = "rgb(198, 176, 146)";
+      ctx.fillRect(0, 0, SIZE, SIZE);
+
+      const planks = 5;
+      const plankWidth = SIZE / planks;
+      for (let i = 0; i < planks; i++) {
+        const shade = 182 + Math.floor(random() * 60);
+        ctx.fillStyle = `rgb(${shade}, ${Math.floor(shade * 0.92)}, ${Math.floor(shade * 0.78)})`;
+        ctx.fillRect(i * plankWidth + 1, 0, plankWidth - 2, SIZE);
+        // Grain: long, near-horizontal strokes that follow the plank.
+        for (let g = 0; g < 26; g++) {
+          ctx.strokeStyle = `rgba(90, 74, 56, ${0.1 + random() * 0.2})`;
+          ctx.lineWidth = 0.5 + random();
+          const y = random() * SIZE;
+          ctx.beginPath();
+          ctx.moveTo(i * plankWidth + 2, y);
+          ctx.bezierCurveTo(
+            i * plankWidth + plankWidth * 0.3,
+            y + (random() - 0.5) * 8,
+            i * plankWidth + plankWidth * 0.7,
+            y + (random() - 0.5) * 8,
+            i * plankWidth + plankWidth - 2,
+            y
+          );
+          ctx.stroke();
+        }
+        // A dark gap between planks, which the bump map turns into a groove.
+        ctx.fillStyle = "rgba(50, 38, 26, 0.9)";
+        ctx.fillRect(i * plankWidth, 0, 2, SIZE);
+      }
+
+      // Iron banding across the planks, top and bottom, like a shipping crate.
+      ctx.fillStyle = "rgba(70, 62, 54, 0.85)";
+      ctx.fillRect(0, 12, SIZE, 14);
+      ctx.fillRect(0, SIZE - 26, SIZE, 14);
+      speckle(ctx, random, 400, 0.08);
+    },
+    0.5,
+    repeat
+  );
+}
+
+/** Pitted, riveted iron for door leaves. */
+export function ironTexture(repeat: number): VaultTexture | null {
+  return build(
+    "iron",
+    0x71bd,
+    (ctx, random) => {
+      ctx.fillStyle = "rgb(176, 170, 164)";
+      ctx.fillRect(0, 0, SIZE, SIZE);
+      // Corrosion blooms, so the leaf is not a flat metal panel.
+      for (let i = 0; i < 40; i++) {
+        const x = random() * SIZE;
+        const y = random() * SIZE;
+        const r = 3 + random() * 18;
+        const bloom = ctx.createRadialGradient(x, y, 0, x, y, r);
+        bloom.addColorStop(0, `rgba(90, 78, 66, ${0.25 + random() * 0.35})`);
+        bloom.addColorStop(1, "rgba(90, 78, 66, 0)");
+        ctx.fillStyle = bloom;
+        ctx.fillRect(x - r, y - r, r * 2, r * 2);
+      }
+      // Rivets on a regular grid: the one thing on the door that is man-made.
+      for (let x = 24; x < SIZE; x += 52) {
+        for (let y = 24; y < SIZE; y += 52) {
+          const rivet = ctx.createRadialGradient(x - 1, y - 1, 0, x, y, 5);
+          rivet.addColorStop(0, "rgba(235, 230, 225, 0.9)");
+          rivet.addColorStop(1, "rgba(70, 64, 58, 0.9)");
+          ctx.fillStyle = rivet;
+          ctx.beginPath();
+          ctx.arc(x, y, 5, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+      speckle(ctx, random, 600, 0.12);
+    },
+    0.45,
+    repeat
+  );
+}
+
+/**
+ * Applies a drawn texture to a material.
+ *
+ * The material keeps whatever `color` it was given: the pattern multiplies into
+ * it, so the palette still decides what the surface *is* and this only decides
+ * how it is worked. A no-op when the texture could not be drawn, which leaves
+ * the material as the flat tinted surface it was before.
+ */
+export function applyTexture(material: THREE.MeshStandardMaterial, texture: VaultTexture | null) {
+  if (!texture) return;
+  material.map = texture.map;
+  material.bumpMap = texture.bumpMap;
+  material.bumpScale = texture.bumpScale;
+}
+
+/**
+ * Drops every cached texture.
+ *
+ * Materials are disposed per replay and never own these textures, so the cache
+ * outlives them; this is called only when the game itself goes away.
+ */
+export function disposeVaultTextures() {
+  for (const texture of cache.values()) {
+    texture?.map.dispose();
+    texture?.bumpMap.dispose();
+  }
+  cache.clear();
+}

--- a/client/src/game/vault-decor.ts
+++ b/client/src/game/vault-decor.ts
@@ -1,0 +1,136 @@
+/**
+ * Where the vault's decorative geometry goes.
+ *
+ * Pillars, rubble and the per-block height jitter that stops the masonry looking
+ * extruded are all *placement* decisions over the level grid, and placement is
+ * exactly the part that can go wrong: a pillar off a wall cell would be a
+ * collider-less obstacle, and rubble on the terminal would bury an objective.
+ * So the choices live here as pure functions over cells, testable without a
+ * WebGL context, and the engine only turns their output into meshes.
+ */
+
+import { CARDINAL_DIRS, cellKey, isInterior, type GridPos } from "./grid";
+import { mulberry32 } from "./rng";
+
+/**
+ * Deterministic value in [0, 1) for a cell, independent of iteration order.
+ *
+ * Seeding a single stream and pulling per cell would make every value depend on
+ * how many cells came before it, so a wall block's height would change when an
+ * unrelated block appeared. Hashing the coordinates instead pins each cell's
+ * jitter to the cell itself.
+ */
+export function cellNoise(cell: GridPos, seed: number): number {
+  // Two odd multipliers keep x and z from aliasing onto each other along the
+  // diagonal, where a naive x + z would give every anti-diagonal one value.
+  const hash = (cell.x * 73856093) ^ (cell.z * 19349663) ^ (seed * 83492791);
+  return mulberry32(hash >>> 0)();
+}
+
+/**
+ * Signed jitter for one masonry block, in [-1, 1].
+ *
+ * Scaled by the engine into a height and inset wobble so no two blocks in a run
+ * top out at exactly the same line — the single cheapest thing that separates
+ * "stone laid by hand" from "one box repeated".
+ */
+export function blockJitter(cell: GridPos, seed: number): number {
+  return cellNoise(cell, seed) * 2 - 1;
+}
+
+/**
+ * Wall cells that should carry a pillar: corners, T- and X-junctions, and the
+ * ends where an interior run meets the outer ring.
+ *
+ * Every returned cell is one of `walls`, which matters: those cells are already
+ * blocked for movement and pathfinding, so decorating them cannot change what
+ * the level plays like. A straight run gets nothing — a pillar every few metres
+ * along a flat wall reads as wallpaper rather than structure.
+ */
+export function pillarCells(walls: readonly GridPos[], gridSize: number): GridPos[] {
+  const wallSet = new Set(walls.map(cellKey));
+  // Junctions are read from the *listed* interior walls only. Folding the
+  // implicit outer ring in here would make every cell of a run laid alongside it
+  // look like a T, turning that whole run into a colonnade; the ring is handled
+  // separately below, where its direction can be taken into account.
+  const isWall = (cell: GridPos) => wallSet.has(cellKey(cell));
+  const offRing = (cell: GridPos) => !isInterior(cell, gridSize);
+
+  return walls.filter((cell) => {
+    const [east, west, south, north] = CARDINAL_DIRS.map((dir) =>
+      isWall({ x: cell.x + dir.x, z: cell.z + dir.z })
+    );
+    const count = [east, west, south, north].filter(Boolean).length;
+    // 3 or 4 is a junction. Exactly 2 is a corner only when they turn — two
+    // opposite neighbours is the middle of a straight run, which gets nothing.
+    if (count >= 3) return true;
+    if (count === 2 && !(east && west) && !(north && south)) return true;
+
+    // A run that terminates *into* the outer ring meets stone crossing it at a
+    // right angle, so it is a T-junction the wall list alone cannot show. It has
+    // to run into the ring rather than merely alongside it, which is why the
+    // run's own axis is compared against the axis the ring lies on.
+    const runsOnX = east || west;
+    const runsOnZ = north || south;
+    const meetsRingOnX =
+      offRing({ x: cell.x + 1, z: cell.z }) || offRing({ x: cell.x - 1, z: cell.z });
+    const meetsRingOnZ =
+      offRing({ x: cell.x, z: cell.z + 1 }) || offRing({ x: cell.x, z: cell.z - 1 });
+    return (runsOnX && meetsRingOnX) || (runsOnZ && meetsRingOnZ);
+  });
+}
+
+/** One piece of floor debris: which cell, and how it sits within it. */
+export interface RubbleSpot {
+  cell: GridPos;
+  /** Offset from the cell centre, in fractions of a cell, each in (-0.5, 0.5). */
+  offsetX: number;
+  offsetZ: number;
+  /** Scale multiplier on the base debris size. */
+  scale: number;
+  /** Y rotation in radians. */
+  rotation: number;
+}
+
+/** Fraction of eligible floor cells that get debris. */
+const RUBBLE_DENSITY = 0.12;
+/** How far from the cell centre a piece may sit, so it never straddles a joint. */
+const RUBBLE_SPREAD = 0.34;
+
+/**
+ * Scatters debris across open floor.
+ *
+ * Skips `blocked` (walls and crates, where it would float inside geometry) and
+ * `reserved` (spawn, terminal, keycard and doors, where it would sit under
+ * something the player has to read). The pieces are shorter than the player's
+ * step and carry no collider, so this is purely something to look at.
+ */
+export function rubbleSpots(
+  seed: number,
+  gridSize: number,
+  blocked: ReadonlySet<string>,
+  reserved: ReadonlySet<string>,
+  density: number = RUBBLE_DENSITY
+): RubbleSpot[] {
+  const random = mulberry32(seed ^ 0x5ec0de);
+  const spots: RubbleSpot[] = [];
+
+  // Iterated in a fixed order rather than over a Set, so one seed always lays
+  // the same debris down in the same places.
+  for (let z = 1; z <= gridSize - 2; z++) {
+    for (let x = 1; x <= gridSize - 2; x++) {
+      const key = cellKey({ x, z });
+      // Rolled for every cell, skipped afterwards: drawing only for eligible
+      // cells would shift the stream and re-scatter the whole level whenever a
+      // crate moved.
+      const roll = random();
+      const offsetX = (random() - 0.5) * 2 * RUBBLE_SPREAD;
+      const offsetZ = (random() - 0.5) * 2 * RUBBLE_SPREAD;
+      const scale = 0.6 + random() * 0.8;
+      const rotation = random() * Math.PI * 2;
+      if (roll >= density || blocked.has(key) || reserved.has(key)) continue;
+      spots.push({ cell: { x, z }, offsetX, offsetZ, scale, rotation });
+    }
+  }
+  return spots;
+}


### PR DESCRIPTION
## Description

A visual rebuild of the `/play` easter egg, following #967. The level read as a cool sci-fi facility — blue-grey surfaces under cyan lamps. It now reads as a **subterranean vault**.

This landed in two passes. The first (`0c8f674`) was paint only: a `PALETTE` constant, warm stone tints, sodium lamps, darker ambient. That was not enough on its own — the shapes underneath were still flat-shaded boxes, a plane floor with a grid helper over it, and a point light with no visible source, so it read as a *recoloured* facility. The second (`072ce23`) gives the vault an actual fabric.

### Surfaces are drawn, not tinted

New `client/src/game/textures.ts` paints tiling stone, masonry, timber and pitted iron into canvases at load time — no asset files, so the easter egg still costs the bundle nothing — and reuses each canvas as a `bumpMap`, which is what makes the lamps rake across the courses instead of washing them flat.

Patterns are drawn **bright and greyscale** so the palette still decides what each surface *is*; the pattern only decides how it is worked. They are cached per pattern **and scale**, because `repeat` lives on the texture rather than the material: every wall segment needs its own material for the occlusion fade, but they all want one image on the GPU, and cloning per material would mean a fresh upload per mesh plus a leak on every replay (disposing a material does not dispose its textures).

### Structure

New `client/src/game/vault-decor.ts` decides placement:

- **Pillars** — octagonal columns with base and capital, at the corners, T- and X-junctions of the masonry, and where a run terminates into the outer ring. Straight runs get nothing; a pillar every few metres along a flat wall reads as wallpaper.
- **Wall caps** — an oversailing course along the top of every run, so a wall finishes with a lip that catches the light rather than simply stopping.
- **Block jitter** — each masonry block and crate tops out a little off its neighbours, hashed per cell so it never depends on iteration order.
- **Arches** — a stone archivolt springing over each doorway, one proud of each face (an arch inside the wall's own thickness is buried by the lintel and invisible).
- **Lamp fixtures** — a caged bulb on a chain at each room's light, so the pool has a source the player can see.
- **Rubble and dust** — broken stone on the floor, and motes drifting up through the lamplight, additively blended so they only show where a lamp is already bright.

### Nothing here changes what the level plays like

- Pillars only ever go on cells that are already walls, so they stand **inside colliders the pathfinder already knows about**.
- Rubble carries no collider and is kept off the spawn, terminal, keycard and door cells.
- Height and rotation jitter never change a footprint; every collider is the box it always was.
- Guard cones are unlit `MeshBasicMaterial` and the doors, keycard and terminal are emissive, so everything load-bearing stays visible at any light level.

> **`LAMP_RADIUS` and `LAMP_LIGHT_DISTANCE` are untouched.** They are the contract that keeps "looks dark" and "reads as dark to a guard" the same thing — the mismatch fixed twice in #967. Only colour, warmth and ambient changed, never the radii.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — no user-facing docs cover the easter egg
- [x] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly — n/a, client-only, no new interface or dependency
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Tests

The placement maths lives in its own module precisely because it is the part that could go wrong, and it is unit-testable without a WebGL context (which is why the engine itself has no tests). 18 new tests in `vault-decor.test.ts` cover:

- pillars only on wall cells, never mid-run, and **not** colonnading a wall laid alongside the perimeter — the predicate initially got this wrong by folding the implicit outer ring into its junction count, and the test caught it;
- debris never on a blocked or reserved cell, and stable under an unrelated change (adding one crate must not re-scatter the level);
- per-cell noise independent of iteration order, and distinguishing cells a naive `x + z` hash would collide.

`textures.ts` is not unit tested for the same reason the engine is not — it needs a browser. It returns `null` where a 2D context is unavailable, and callers fall back to the flat tinted material.

## Verification

`npm run check`, `npm run lint`, `npx prettier --check "client/src/game/**/*.ts"` all clean. `npm run test:run` — **2304 passed, 7 skipped** (was 2286 before the 18 new tests).

Checked in a real browser on a production build, seeds 3 and 11, at default and wide zoom: masonry courses read on the walls, pillars rise out of the junctions with visible capitals, arches frame the doorways, crates read as iron-banded timber, lamps hang on chains, debris and dust are visible without being noisy, and the lock colours still read red/green. No page errors.

<details>
<summary>Note on <code>format:check</code></summary>

`npm run format:check` reports `client/src/pages/settings.tsx`. That is pre-existing on `main` — it reproduces on a clean checkout with none of these changes, and no CI workflow runs `format:check` — so it is left alone rather than widening this PR.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the infiltration game with a warm, underground color palette.
  * Added sodium-orange lighting, darker atmospheric effects, and subtle player glow for improved visibility.
  * Added masonry, timber, stone, and iron surface detailing across vault environments.
  * Introduced wall caps, pillars, rubble, lamp fixtures, and animated dust motes for a more immersive setting.
* **Bug Fixes**
  * Improved cleanup of visual effects and generated textures when leaving the game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->