### PR TITLE
Fix hardlink import falling back to copy for multi-file downloads

### DIFF
--- a/server/__tests__/import_strategies.test.ts
+++ b/server/__tests__/import_strategies.test.ts
@@ -105,6 +105,44 @@ describe("ImportStrategies", () => {
       expect(result.filesPlaced.some((p) => p.endsWith("data.pak"))).toBe(true);
     });
 
+    it("source is a DIRECTORY: hardlink mode links every file instead of falling back to copy", async () => {
+      // Regression test for a directory-wide hardlink attempt: fs.link()
+      // always rejects a directory with EPERM on Linux, so the multi-file
+      // (no sortExtras) path used to hand the whole source folder to
+      // fs.link() and silently fall back to a full copy every time. Each
+      // file inside the directory should now be its own hardlink, matching
+      // what `cp -al` does on the CLI.
+      const root = tempDir();
+      const sourceDir = path.join(root, "downloads", "game-folder");
+      const destination = path.join(root, "library", "PC", "game-folder");
+      await fs.ensureDir(path.join(sourceDir, "nested"));
+      await fs.writeFile(path.join(sourceDir, "game.exe"), "exe-bytes");
+      await fs.writeFile(path.join(sourceDir, "nested", "data.pak"), "pak-bytes");
+
+      const strategy = new PCImportStrategy();
+      const result = await strategy.executeImport(
+        {
+          needsReview: false,
+          originalPath: sourceDir,
+          proposedPath: destination,
+          strategy: "pc",
+        },
+        "hardlink"
+      );
+
+      expect(result.modeUsed).toBe("hardlink");
+
+      const exeSource = await fs.stat(path.join(sourceDir, "game.exe"));
+      const exeDest = await fs.stat(path.join(destination, "game.exe"));
+      expect(exeDest.ino).toBe(exeSource.ino);
+      expect(exeDest.dev).toBe(exeSource.dev);
+
+      const pakSource = await fs.stat(path.join(sourceDir, "nested", "data.pak"));
+      const pakDest = await fs.stat(path.join(destination, "nested", "data.pak"));
+      expect(pakDest.ino).toBe(pakSource.ino);
+      expect(pakDest.dev).toBe(pakSource.dev);
+    });
+
     it("sorts detected add-on files while preserving main and existing category paths", async () => {
       const root = tempDir();
       const sourceDir = path.join(root, "downloads", "game-folder");

--- a/server/services/ImportStrategies.ts
+++ b/server/services/ImportStrategies.ts
@@ -51,6 +51,25 @@ async function ensureParentDir(filePath: string): Promise<void> {
   await fs.ensureDir(path.dirname(filePath));
 }
 
+// Linux's link(2) always rejects a directory target with EPERM — hard links
+// only ever point at a single inode (a file), never a directory tree. So a
+// directory source has to be walked and linked file-by-file (mirroring what
+// `cp -al` does on the CLI), rather than handed to fs.link() as one call,
+// which would otherwise always fail for a multi-file torrent/release.
+async function hardlinkTree(source: string, destination: string): Promise<void> {
+  const stats = await fs.lstat(source);
+  if (!stats.isDirectory()) {
+    await fs.link(source, destination);
+    return;
+  }
+
+  await fs.ensureDir(destination);
+  const entries = await fs.readdir(source, { withFileTypes: true });
+  for (const entry of entries) {
+    await hardlinkTree(path.join(source, entry.name), path.join(destination, entry.name));
+  }
+}
+
 async function transferFile(
   source: string,
   destination: string,
@@ -83,7 +102,7 @@ async function transferFile(
   }
 
   try {
-    await fs.link(source, destination);
+    await hardlinkTree(source, destination);
     return "hardlink";
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
@@ -98,6 +117,9 @@ async function transferFile(
         { source, destination, code },
         "[ImportStrategies] Hardlink failed, falling back to copy"
       );
+      // Clean up any partial tree hardlinkTree() managed to create before
+      // the failure, so the copy fallback isn't merging into leftovers.
+      await fs.remove(destination).catch(() => undefined);
       await fs.copy(source, destination, { overwrite: true });
       return "copy";
     }


### PR DESCRIPTION
## Description

Fixes #976.

The reported EPERM error (`link '.../torrent/...' -> '.../workshop/...'`) happens because `fs.link()` always rejects a directory with `EPERM` on Linux — hard links can only ever point at a single inode (a file), never a directory tree.

The default import path (with `sortExtras` disabled, which is the default setting) handed the *whole download directory* to `transferFile()`, which in hardlink mode called `fs.link(source, destination)` directly on that directory. For any multi-file torrent (the common case), this always failed with `EPERM`, and silently fell back to a full `fs.copy()` — meaning hardlink mode never actually hardlinked multi-file releases, even when source and destination are on the same filesystem, exactly as the reporter observed with the manual `cp -al` test that worked outside the app.

(The per-file `sortExtras` path was unaffected — it was already calling `transferFile()` once per file, which is why the existing hardlink fallback tests only exercised single-file cases.)

## Fix

`transferFile()` now walks a directory source and hardlinks each file individually via a new `hardlinkTree()` helper, mirroring what `cp -al` does on the CLI, instead of handing the whole directory to `fs.link()`. It still falls back to a full copy (with a warning log) if an individual file's link genuinely fails (real cross-device or permission errors), cleaning up any partial hardlink tree first.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly (n/a — internal file-transfer logic only)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`npx vitest run server/__tests__/` — 1541 passed; `npm run check` clean)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nwmq83nQXsZ6MbM5bCG8RS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hardlink imports from directories on Linux.
  * Directory imports now preserve hardlink behavior for every file, including files in nested folders.
  * If hardlinking fails, incomplete output is removed before safely falling back to copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->