### PR TITLE
Add Proxmox VE LXC deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Run this **on your Proxmox VE host**, as `root`, to create an LXC container with
 and running as a `systemd` service:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-lxc.sh)"
+bash -c "$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-lxc.sh)"
 ```
 
 The script picks the next free container ID, downloads a Debian template if needed, creates an

--- a/README.md
+++ b/README.md
@@ -115,6 +115,29 @@ docker run -d -p 5000:5000 -v ./data:/app/data --name questarr ghcr.io/doezer/qu
 3. **Access the application:**
    Open your browser to `http://localhost:5000`
 
+### Proxmox VE (LXC)
+
+<details>
+<summary><b>Deploy as a Proxmox LXC container — no Docker</b></summary>
+
+Run this **on your Proxmox VE host**, as `root`, to create an LXC container with Questarr installed
+and running as a `systemd` service:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-lxc.sh)"
+```
+
+The script picks the next free container ID, downloads a Debian template if needed, creates an
+unprivileged container, builds Questarr from source, and prints the URL to open. Every prompt has a
+default, so you can accept them all and be done in a few minutes.
+
+Update later with `pct exec <ctid> -- update`.
+
+See [docs/PROXMOX.md](docs/PROXMOX.md) for non-interactive installs, sizing guidance, configuration,
+and troubleshooting.
+
+</details>
+
 ### UNRAID
 
 <details>

--- a/docs/GITHUB_DOCUMENTATION.md
+++ b/docs/GITHUB_DOCUMENTATION.md
@@ -10,6 +10,7 @@ This file is the single entry point for GitHub-facing documentation in this repo
 - Changelog: [`docs/CHANGELOG.md`](./CHANGELOG.md)
 - Migration notes: [`docs/MIGRATION.md`](./MIGRATION.md), for migration from PostgreSQL to SQLite in v1.1
 - Reverse proxy / subdirectory deployment: [`docs/REVERSE_PROXY.md`](./REVERSE_PROXY.md), for serving Questarr from a path like `/Questarr` behind nginx/Traefik/Caddy
+- Proxmox VE deployment: [`docs/PROXMOX.md`](./PROXMOX.md), for deploying Questarr into a Proxmox LXC container without Docker
 - Security model and operations:
   - [`docs/THREAT_MODEL.md`](./THREAT_MODEL.md), for the attack surface analysis and security architecture
   - [`docs/SECURITY_ASSESSMENT.md`](./SECURITY_ASSESSMENT.md), security risk assessment.

--- a/docs/PROXMOX.md
+++ b/docs/PROXMOX.md
@@ -9,7 +9,7 @@ no image layers) and makes it behave like any other service on your Proxmox node
 Run this **on the Proxmox host** (the node itself, not inside a container or VM), as `root`:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-lxc.sh)"
+bash -c "$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-lxc.sh)"
 ```
 
 The script will:
@@ -32,7 +32,7 @@ prompting:
 ```bash
 CTID=210 CT_HOSTNAME=questarr CORES=2 RAM=2048 DISK=8 \
 STORAGE=local-lvm BRIDGE=vmbr0 NET=dhcp \
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-lxc.sh)" -- --yes
+  bash -c "$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-lxc.sh)" -- --yes
 ```
 
 | Variable           | Default           | Description                                        |
@@ -103,7 +103,7 @@ development code. Pin a release with `QUESTARR_REF` if you want to avoid that.
 To move to a specific version instead:
 
 ```bash
-pct exec 210 -- env QUESTARR_REF=v1.4.3 bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-install.sh)"
+pct exec 210 -- env QUESTARR_REF=v1.4.3 bash -c "$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-install.sh)"
 ```
 
 Take a Proxmox snapshot or backup before updating if you want a quick way back:
@@ -131,7 +131,7 @@ you normally do not need to touch `.env` at all.
 this inside it as `root`:
 
 ```bash
-bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-install.sh)"
+bash -c "$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-install.sh)"
 ```
 
 It installs the same `systemd` service and `update` helper. It is safe to re-run: it replaces the

--- a/docs/PROXMOX.md
+++ b/docs/PROXMOX.md
@@ -1,0 +1,150 @@
+# Proxmox VE — LXC deployment
+
+Questarr can run directly inside a Proxmox VE LXC container, without Docker. The container runs
+Questarr from source as a `systemd` service, which keeps the footprint small (no container runtime,
+no image layers) and makes it behave like any other service on your Proxmox node.
+
+## Quick start
+
+Run this **on the Proxmox host** (the node itself, not inside a container or VM), as `root`:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-lxc.sh)"
+```
+
+The script will:
+
+1. Verify it is running on a Proxmox VE node.
+2. Prompt for the container settings (ID, hostname, cores, RAM, disk, storage, network, port), each
+   with a sensible default.
+3. Download the newest Debian LXC template if your node does not already have it.
+4. Create and start an unprivileged container.
+5. Install Node.js, build Questarr from source, and register a `questarr.service` unit.
+6. Print the URL to open.
+
+When it finishes, open `http://<container-ip>:5000`.
+
+## Non-interactive install
+
+Every prompt has an environment variable override. Pass `--yes` to accept all of them without
+prompting:
+
+```bash
+CTID=210 CT_HOSTNAME=questarr CORES=2 RAM=2048 DISK=8 \
+STORAGE=local-lvm BRIDGE=vmbr0 NET=dhcp \
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-lxc.sh)" -- --yes
+```
+
+| Variable           | Default           | Description                                        |
+| ------------------ | ----------------- | -------------------------------------------------- |
+| `CTID`             | next free ID      | Container ID                                       |
+| `CT_HOSTNAME`      | `questarr`        | Container hostname                                 |
+| `CORES`            | `2`               | CPU cores                                          |
+| `RAM`              | `2048`            | RAM in MiB                                         |
+| `SWAP`             | `512`             | Swap in MiB                                        |
+| `DISK`             | `8`               | Root disk in GiB                                   |
+| `STORAGE`          | first active      | Storage for the root filesystem                    |
+| `TEMPLATE_STORAGE` | first active      | Storage holding the LXC template                   |
+| `BRIDGE`           | `vmbr0`           | Network bridge                                     |
+| `NET`              | `dhcp`            | `dhcp`, or a static CIDR such as `192.168.1.50/24` |
+| `GATEWAY`          | —                 | Gateway, required when `NET` is a static address   |
+| `UNPRIVILEGED`     | `1`               | Create an unprivileged container                   |
+| `ONBOOT`           | `1`               | Start the container when the node boots            |
+| `CT_PASSWORD`      | —                 | Root password inside the container (optional)      |
+| `QUESTARR_PORT`    | `5000`            | HTTP port Questarr listens on                      |
+| `QUESTARR_REPO`    | `Doezer/Questarr` | Source repository                                  |
+| `QUESTARR_REF`     | latest release    | Tag or branch to install                           |
+
+### Sizing
+
+2 GiB of RAM is the practical floor: the installer builds the client with Vite and type-checks the
+server with `tsc`, and both run during installation. You can lower the container's RAM afterwards if
+you want — Questarr itself is comfortable in far less — but leave it at 2 GiB whenever you update,
+since an update rebuilds from source.
+
+The default 8 GiB disk covers the OS, Node.js, `node_modules`, and the build output with room to
+spare. Questarr's own data (a SQLite database) stays small; it does not store game files.
+
+## Managing the container
+
+```bash
+pct enter 210                          # shell inside the container
+pct exec 210 -- systemctl status questarr
+pct exec 210 -- journalctl -u questarr -f
+pct exec 210 -- systemctl restart questarr
+```
+
+Inside the container:
+
+| Path                              | Purpose                                        |
+| --------------------------------- | ---------------------------------------------- |
+| `/opt/questarr`                   | Application (replaced on every update)         |
+| `/opt/questarr/data`              | SQLite database — **this is what you back up** |
+| `/opt/questarr/.env`              | Configuration, preserved across updates        |
+| `/opt/questarr/.questarr_version` | Installed tag or branch                        |
+
+## Updating
+
+Following the Proxmox helper-script convention, the installer places an `update` command inside the
+container:
+
+```bash
+pct exec 210 -- update
+```
+
+This re-runs the installer against the latest release. The new version is downloaded and built in a
+staging directory first, and only swapped into place once the build succeeds, so a failed download or
+build leaves your running installation untouched. Your `data/` directory and `.env` are preserved.
+
+If no published release can be resolved — either the repository has none, or the unauthenticated
+GitHub API rate limit was hit — the installer says so and falls back to the `main` branch, which is
+development code. Pin a release with `QUESTARR_REF` if you want to avoid that.
+
+To move to a specific version instead:
+
+```bash
+pct exec 210 -- env QUESTARR_REF=v1.4.3 bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-install.sh)"
+```
+
+Take a Proxmox snapshot or backup before updating if you want a quick way back:
+
+```bash
+vzdump 210 --mode snapshot --compress zstd
+```
+
+## Configuration
+
+All of the options in [`.env.example`](../.env.example) apply. Edit `/opt/questarr/.env` and restart:
+
+```bash
+pct exec 210 -- sh -c 'nano /opt/questarr/.env && systemctl restart questarr'
+```
+
+IGDB credentials, indexers, and download clients are configured in the web UI under **Settings**, so
+you normally do not need to touch `.env` at all.
+
+## Installing into an existing container or VM
+
+`questarr-install.sh` is standalone. If you already have a Debian or Ubuntu LXC (or a plain VM), run
+this inside it as `root`:
+
+```bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-install.sh)"
+```
+
+It installs the same `systemd` service and `update` helper. It is safe to re-run: it replaces the
+application tree while preserving `data/` and `.env`.
+
+## Notes and troubleshooting
+
+- **The service runs unprivileged.** Questarr runs as the `questarr` system user under a hardened
+  unit (`ProtectSystem=strict`, `NoNewPrivileges`, `PrivateTmp`), with `/opt/questarr` as the only
+  writable path.
+- **The install fails at "Waiting for network".** The container could not resolve DNS. Check that the
+  bridge you chose is correct and that your static IP and gateway are valid.
+- **The install fails during `npm ci` or the build.** Almost always the container ran out of RAM or
+  disk. Raise them (`pct set 210 --memory 2048`, `pct resize 210 rootfs +4G`) and re-run `update`.
+- **The service will not start.** `pct exec 210 -- journalctl -u questarr -n 50` shows the reason. A
+  port already in use and a non-writable `data/` directory are the usual causes.
+- **Backups.** `/opt/questarr/data` holds everything that matters. A Proxmox container backup
+  (`vzdump`) covers it, as does copying that directory.

--- a/docs/PROXMOX.md
+++ b/docs/PROXMOX.md
@@ -117,8 +117,10 @@ vzdump 210 --mode snapshot --compress zstd
 All of the options in [`.env.example`](../.env.example) apply. Edit `/opt/questarr/.env` and restart:
 
 ```bash
-pct exec 210 -- sh -c 'nano /opt/questarr/.env && systemctl restart questarr'
+pct exec 210 -- sh -c 'vi /opt/questarr/.env && systemctl restart questarr'
 ```
+
+(`vi` ships with the base Debian template; install `nano` first with `apt-get install -y nano` if you prefer it.)
 
 IGDB credentials, indexers, and download clients are configured in the web UI under **Settings**, so
 you normally do not need to touch `.env` at all.

--- a/scripts/proxmox/questarr-install.sh
+++ b/scripts/proxmox/questarr-install.sh
@@ -264,7 +264,9 @@ apt-get -y -qq clean
 IP_ADDR="$(hostname -I 2>/dev/null | awk '{print $1}')"
 echo
 ok "Questarr ${REF} is installed."
-echo "   URL:      http://${IP_ADDR:-<container-ip>}:${QUESTARR_PORT}"
+# Informational only: this is the address of the user's own freshly created
+# container, matching Questarr's own HTTP-by-default listener.
+echo "   URL:      http://${IP_ADDR:-<container-ip>}:${QUESTARR_PORT}" # NOSONAR
 echo "   Config:   ${APP_DIR}/.env"
 echo "   Data:     ${DATA_DIR}"
 echo "   Logs:     journalctl -u questarr -f"

--- a/scripts/proxmox/questarr-install.sh
+++ b/scripts/proxmox/questarr-install.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+#
+# Questarr in-container installer.
+#
+# Installs Questarr from source into /opt/questarr and runs it as a systemd
+# service. Intended to be executed as root inside a freshly created Debian or
+# Ubuntu LXC container (see questarr-lxc.sh), but it works just as well on any
+# bare Debian/Ubuntu VM or host.
+#
+#   bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-install.sh)"
+#
+# Environment overrides:
+#   QUESTARR_REPO    GitHub repository            (default: Doezer/Questarr)
+#   QUESTARR_REF     Tag/branch to install        (default: latest release, else main)
+#   QUESTARR_PORT    HTTP port                    (default: 5000)
+#   QUESTARR_HOST    Bind address                 (default: 0.0.0.0)
+#   NODE_MAJOR       Node.js major version        (default: 22)
+#
+# Copyright (C) Doezer — GPL-3.0-or-later
+
+set -euo pipefail
+
+QUESTARR_REPO="${QUESTARR_REPO:-Doezer/Questarr}"
+QUESTARR_REF="${QUESTARR_REF:-}"
+QUESTARR_PORT="${QUESTARR_PORT:-5000}"
+QUESTARR_HOST="${QUESTARR_HOST:-0.0.0.0}"
+NODE_MAJOR="${NODE_MAJOR:-22}"
+
+APP_DIR="/opt/questarr"
+DATA_DIR="${APP_DIR}/data"
+APP_USER="questarr"
+VERSION_FILE="${APP_DIR}/.questarr_version"
+STAGE_DIR="/opt/.questarr-stage"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[0;33m'
+BLUE=$'\033[0;34m'
+RESET=$'\033[0m'
+
+msg() { echo "${BLUE}==>${RESET} $*"; }
+ok() { echo "${GREEN} ✔${RESET} $*"; }
+warn() { echo "${YELLOW} !${RESET} $*" >&2; }
+die() {
+  echo "${RED} ✘ $*${RESET}" >&2
+  exit 1
+}
+
+[ "$(id -u)" -eq 0 ] || die "This installer must run as root."
+
+# ──────────────────────────────────────────────────────────────
+# 1. OS packages
+# ──────────────────────────────────────────────────────────────
+# build-essential + python3 are needed because npm runs node-gyp's configure
+# step for better-sqlite3 on install, even when it ends up using a prebuilt
+# binary and never compiles anything (same reasoning as the Dockerfile).
+msg "Installing OS dependencies"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq --no-install-recommends \
+  ca-certificates curl gnupg git tar jq \
+  build-essential python3 >/dev/null
+ok "OS dependencies installed"
+
+# ──────────────────────────────────────────────────────────────
+# 2. Node.js
+# ──────────────────────────────────────────────────────────────
+install_node() {
+  msg "Installing Node.js ${NODE_MAJOR}.x from NodeSource"
+  install -d -m 0755 /etc/apt/keyrings
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key |
+    gpg --dearmor --yes -o /etc/apt/keyrings/nodesource.gpg
+  chmod 0644 /etc/apt/keyrings/nodesource.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+    >/etc/apt/sources.list.d/nodesource.list
+  apt-get update -qq
+  apt-get install -y -qq nodejs >/dev/null
+  ok "Node.js $(node -v) installed"
+}
+
+if command -v node >/dev/null 2>&1 &&
+  [ "$(node -p 'process.versions.node.split(".")[0]')" -ge "${NODE_MAJOR}" ]; then
+  ok "Node.js $(node -v) already present"
+else
+  install_node
+fi
+
+# ──────────────────────────────────────────────────────────────
+# 3. Service account
+# ──────────────────────────────────────────────────────────────
+if ! id -u "${APP_USER}" >/dev/null 2>&1; then
+  msg "Creating service account '${APP_USER}'"
+  useradd --system --create-home --home-dir "${APP_DIR}" --shell /usr/sbin/nologin "${APP_USER}"
+fi
+install -d -o "${APP_USER}" -g "${APP_USER}" -m 0750 "${APP_DIR}" "${DATA_DIR}"
+
+# ──────────────────────────────────────────────────────────────
+# 4. Fetch the source
+# ──────────────────────────────────────────────────────────────
+resolve_ref() {
+  if [ -n "${QUESTARR_REF}" ]; then
+    echo "${QUESTARR_REF}"
+    return
+  fi
+  local tag
+  tag=$(curl -fsSL "https://api.github.com/repos/${QUESTARR_REPO}/releases/latest" 2>/dev/null |
+    jq -r '.tag_name // empty' 2>/dev/null || true)
+  if [ -z "${tag}" ]; then
+    # No published release, or the unauthenticated GitHub API rate limit was hit
+    # (60 requests/hour per IP). Fall back to the default branch rather than
+    # failing, but say so — main is development code, not a release.
+    warn "Could not determine the latest release; installing from 'main' instead."
+    warn "Pin a version with QUESTARR_REF=<tag> if you want a released build."
+    echo "main"
+    return
+  fi
+  echo "${tag}"
+}
+
+REF="$(resolve_ref)"
+msg "Installing Questarr ${REF} from ${QUESTARR_REPO}"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "${TMP_DIR}" "${STAGE_DIR}"; }
+trap cleanup EXIT
+
+TARBALL="${TMP_DIR}/questarr.tar.gz"
+curl -fsSL "https://codeload.github.com/${QUESTARR_REPO}/tar.gz/${REF}" -o "${TARBALL}" ||
+  die "Could not download ${QUESTARR_REPO} at ref '${REF}'."
+# Clear any leftovers from a previous run that died before its cleanup trap.
+rm -rf "${STAGE_DIR}"
+mkdir -p "${STAGE_DIR}"
+tar -xzf "${TARBALL}" -C "${STAGE_DIR}" --strip-components=1
+
+# ──────────────────────────────────────────────────────────────
+# 5. Build (in a staging directory)
+# ──────────────────────────────────────────────────────────────
+# Everything is built before the live application tree is touched, so a failed
+# download or build on an update leaves the running installation intact.
+msg "Installing npm dependencies (this takes a few minutes)"
+cd "${STAGE_DIR}"
+# --ignore-scripts skips husky's prepare hook, which needs a git repo that the
+# release tarball is not.
+npm ci --no-audit --no-fund --ignore-scripts >/dev/null
+# better-sqlite3 ships prebuilt bindings for every supported platform inside the
+# npm package, so this is a no-op today. It stays as a safety net: if a future
+# release drops the bundled prebuild, this fetches or compiles the binding
+# instead of failing at first database access.
+npm rebuild better-sqlite3 >/dev/null
+node -e 'require("better-sqlite3")' ||
+  die "better-sqlite3 native binding is unusable — the install cannot continue."
+ok "Dependencies installed"
+
+msg "Building Questarr"
+npm run build >/dev/null
+ok "Build complete"
+
+msg "Pruning development dependencies"
+npm prune --omit=dev --ignore-scripts --no-audit --no-fund >/dev/null
+
+# ──────────────────────────────────────────────────────────────
+# 5b. Swap the freshly built tree into place
+# ──────────────────────────────────────────────────────────────
+cd /
+if systemctl is-active --quiet questarr 2>/dev/null; then
+  msg "Stopping questarr for the swap"
+  systemctl stop questarr
+fi
+
+msg "Installing to ${APP_DIR}"
+# Replace the application tree while keeping the operator's data and config.
+find "${APP_DIR}" -mindepth 1 -maxdepth 1 \
+  ! -name data ! -name .env ! -name .questarr_version -exec rm -rf {} +
+cp -a "${STAGE_DIR}/." "${APP_DIR}/"
+echo "${REF}" >"${VERSION_FILE}"
+chown -R "${APP_USER}:${APP_USER}" "${APP_DIR}"
+rm -rf "${STAGE_DIR}"
+
+# ──────────────────────────────────────────────────────────────
+# 6. Configuration
+# ──────────────────────────────────────────────────────────────
+# Written once and never overwritten, so an update keeps the operator's edits.
+if [ ! -f "${APP_DIR}/.env" ]; then
+  msg "Writing default configuration to ${APP_DIR}/.env"
+  cat >"${APP_DIR}/.env" <<EOF
+# Questarr configuration — see .env.example in the repo for every option.
+NODE_ENV=production
+PORT=${QUESTARR_PORT}
+HOST=${QUESTARR_HOST}
+SQLITE_DB_PATH=${DATA_DIR}/sqlite.db
+EOF
+fi
+chown "${APP_USER}:${APP_USER}" "${APP_DIR}/.env"
+chmod 0640 "${APP_DIR}/.env"
+
+# ──────────────────────────────────────────────────────────────
+# 7. systemd service
+# ──────────────────────────────────────────────────────────────
+msg "Installing systemd service"
+cat >/etc/systemd/system/questarr.service <<EOF
+[Unit]
+Description=Questarr — game library manager
+Documentation=https://github.com/${QUESTARR_REPO}
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${APP_USER}
+Group=${APP_USER}
+WorkingDirectory=${APP_DIR}
+EnvironmentFile=${APP_DIR}/.env
+ExecStart=/usr/bin/node ${APP_DIR}/dist/server/index.js
+Restart=on-failure
+RestartSec=10
+
+# Hardening. Questarr writes its SQLite database to data/ and a server.log to
+# its working directory, so ${APP_DIR} is the only writable path it needs.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+ReadWritePaths=${APP_DIR}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable -q questarr
+systemctl restart questarr
+ok "questarr.service enabled and started"
+
+# ──────────────────────────────────────────────────────────────
+# 8. Updater helper
+# ──────────────────────────────────────────────────────────────
+# Matches the Proxmox helper-script convention: `update` inside the container.
+cat >/usr/bin/update <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+QUESTARR_REPO="${QUESTARR_REPO}" \\
+QUESTARR_PORT="${QUESTARR_PORT}" \\
+QUESTARR_HOST="${QUESTARR_HOST}" \\
+NODE_MAJOR="${NODE_MAJOR}" \\
+  bash -c "\$(curl -fsSL https://raw.githubusercontent.com/${QUESTARR_REPO}/main/scripts/proxmox/questarr-install.sh)"
+EOF
+chmod 0755 /usr/bin/update
+
+# ──────────────────────────────────────────────────────────────
+# 9. Done
+# ──────────────────────────────────────────────────────────────
+apt-get -y -qq autoremove >/dev/null
+apt-get -y -qq clean
+
+IP_ADDR="$(hostname -I 2>/dev/null | awk '{print $1}')"
+echo
+ok "Questarr ${REF} is installed."
+echo "   URL:      http://${IP_ADDR:-<container-ip>}:${QUESTARR_PORT}"
+echo "   Config:   ${APP_DIR}/.env"
+echo "   Data:     ${DATA_DIR}"
+echo "   Logs:     journalctl -u questarr -f"
+echo "   Update:   run 'update' inside this container"
+echo
+
+if ! systemctl is-active --quiet questarr; then
+  warn "questarr.service is not active yet — check 'journalctl -u questarr -n 50'."
+fi

--- a/scripts/proxmox/questarr-install.sh
+++ b/scripts/proxmox/questarr-install.sh
@@ -32,6 +32,11 @@ APP_USER="questarr"
 VERSION_FILE="${APP_DIR}/.questarr_version"
 STAGE_DIR="/opt/.questarr-stage"
 
+# curl follows redirects (-L) for every download below, so pin both the initial
+# request and any redirect to HTTPS. Without --proto-redir a redirect could
+# downgrade to plaintext, and these downloads are piped into gpg and bash.
+CURL_OPTS=(--fail --silent --show-error --location --proto '=https' --proto-redir '=https')
+
 RED=$'\033[0;31m'
 GREEN=$'\033[0;32m'
 YELLOW=$'\033[0;33m'
@@ -68,7 +73,7 @@ ok "OS dependencies installed"
 install_node() {
   msg "Installing Node.js ${NODE_MAJOR}.x from NodeSource"
   install -d -m 0755 /etc/apt/keyrings
-  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key |
+  curl "${CURL_OPTS[@]}" https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key |
     gpg --dearmor --yes -o /etc/apt/keyrings/nodesource.gpg
   chmod 0644 /etc/apt/keyrings/nodesource.gpg
   echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
@@ -103,7 +108,7 @@ resolve_ref() {
     return
   fi
   local tag
-  tag=$(curl -fsSL "https://api.github.com/repos/${QUESTARR_REPO}/releases/latest" 2>/dev/null |
+  tag=$(curl "${CURL_OPTS[@]}" "https://api.github.com/repos/${QUESTARR_REPO}/releases/latest" 2>/dev/null |
     jq -r '.tag_name // empty' 2>/dev/null || true)
   if [ -z "${tag}" ]; then
     # No published release, or the unauthenticated GitHub API rate limit was hit
@@ -125,7 +130,7 @@ cleanup() { rm -rf "${TMP_DIR}" "${STAGE_DIR}"; }
 trap cleanup EXIT
 
 TARBALL="${TMP_DIR}/questarr.tar.gz"
-curl -fsSL "https://codeload.github.com/${QUESTARR_REPO}/tar.gz/${REF}" -o "${TARBALL}" ||
+curl "${CURL_OPTS[@]}" "https://codeload.github.com/${QUESTARR_REPO}/tar.gz/${REF}" -o "${TARBALL}" ||
   die "Could not download ${QUESTARR_REPO} at ref '${REF}'."
 # Clear any leftovers from a previous run that died before its cleanup trap.
 rm -rf "${STAGE_DIR}"
@@ -246,7 +251,7 @@ QUESTARR_REPO="${QUESTARR_REPO}" \\
 QUESTARR_PORT="${QUESTARR_PORT}" \\
 QUESTARR_HOST="${QUESTARR_HOST}" \\
 NODE_MAJOR="${NODE_MAJOR}" \\
-  bash -c "\$(curl -fsSL https://raw.githubusercontent.com/${QUESTARR_REPO}/main/scripts/proxmox/questarr-install.sh)"
+  bash -c "\$(curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' https://raw.githubusercontent.com/${QUESTARR_REPO}/main/scripts/proxmox/questarr-install.sh)"
 EOF
 chmod 0755 /usr/bin/update
 

--- a/scripts/proxmox/questarr-lxc.sh
+++ b/scripts/proxmox/questarr-lxc.sh
@@ -251,7 +251,7 @@ if [ -f "${LOCAL_INSTALLER}" ]; then
   pct push "${CTID}" "${LOCAL_INSTALLER}" /root/questarr-install.sh --perms 0755
 else
   pct exec "${CTID}" -- bash -c \
-    "apt-get update -qq && apt-get install -y -qq --no-install-recommends curl ca-certificates >/dev/null && curl -fsSL '${INSTALLER_URL}' -o /root/questarr-install.sh && chmod 0755 /root/questarr-install.sh"
+    "apt-get update -qq && apt-get install -y -qq --no-install-recommends curl ca-certificates >/dev/null && curl --fail --silent --show-error --location --proto '=https' --proto-redir '=https' '${INSTALLER_URL}' -o /root/questarr-install.sh && chmod 0755 /root/questarr-install.sh"
 fi
 
 pct exec "${CTID}" -- env \

--- a/scripts/proxmox/questarr-lxc.sh
+++ b/scripts/proxmox/questarr-lxc.sh
@@ -151,8 +151,14 @@ ask DISK "Disk (GiB)" "${DISK}"
 ask STORAGE "Storage" "${STORAGE}"
 ask BRIDGE "Network bridge" "${BRIDGE}"
 ask NET "IPv4 (dhcp or CIDR e.g. 192.168.1.50/24)" "${NET}"
-if [ "${NET}" != "dhcp" ] && [ -z "${GATEWAY}" ]; then
-  ask GATEWAY "Gateway" "${GATEWAY}"
+if [[ "${NET}" != "dhcp" ]]; then
+  if [[ -z "${GATEWAY}" ]]; then
+    ask GATEWAY "Gateway" "${GATEWAY}"
+  fi
+  # Non-interactive runs (--yes, or no /dev/tty) never prompt, so a static
+  # address without GATEWAY would otherwise reach pct create silently and
+  # leave the container with no default route.
+  [[ -n "${GATEWAY}" ]] || die "GATEWAY is required when NET is a static address (not 'dhcp')."
 fi
 ask QUESTARR_PORT "Questarr HTTP port" "${QUESTARR_PORT}"
 
@@ -267,7 +273,9 @@ CT_IP="$(pct exec "${CTID}" -- hostname -I 2>/dev/null | awk '{print $1}')"
 
 echo
 ok "${BOLD}Questarr is deployed in LXC ${CTID} (${CT_HOSTNAME}).${RESET}"
-echo "   URL:     http://${CT_IP:-<container-ip>}:${QUESTARR_PORT}"
+# Informational only: this is the address of the user's own freshly created
+# container, matching Questarr's own HTTP-by-default listener.
+echo "   URL:     http://${CT_IP:-<container-ip>}:${QUESTARR_PORT}" # NOSONAR
 echo "   Shell:   pct enter ${CTID}"
 echo "   Logs:    pct exec ${CTID} -- journalctl -u questarr -f"
 echo "   Update:  pct exec ${CTID} -- update"

--- a/scripts/proxmox/questarr-lxc.sh
+++ b/scripts/proxmox/questarr-lxc.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+#
+# Questarr — Proxmox VE LXC deployment script.
+#
+# Creates a Debian LXC container on a Proxmox VE host and installs Questarr
+# into it as a systemd service. No Docker involved.
+#
+#   bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-lxc.sh)"
+#
+# Run it on the Proxmox host (the node itself), as root.
+#
+# Non-interactive use — every prompt has an environment override:
+#   CTID=210 CT_HOSTNAME=questarr CORES=2 RAM=2048 DISK=8 BRIDGE=vmbr0 \
+#   STORAGE=local-lvm NET=dhcp UNPRIVILEGED=1 QUESTARR_PORT=5000 \
+#     bash -c "$(curl -fsSL .../questarr-lxc.sh)" -- --yes
+#
+# Copyright (C) Doezer — GPL-3.0-or-later
+
+set -Eeuo pipefail
+
+QUESTARR_REPO="${QUESTARR_REPO:-Doezer/Questarr}"
+QUESTARR_BRANCH="${QUESTARR_BRANCH:-main}"
+QUESTARR_REF="${QUESTARR_REF:-}"
+QUESTARR_PORT="${QUESTARR_PORT:-5000}"
+
+# Container defaults. Node builds the client with Vite and type-checks the
+# server with tsc during install, so 2 GiB of RAM is the practical floor.
+CTID="${CTID:-}"
+CT_HOSTNAME="${CT_HOSTNAME:-questarr}"
+CORES="${CORES:-2}"
+RAM="${RAM:-2048}"
+SWAP="${SWAP:-512}"
+DISK="${DISK:-8}"
+BRIDGE="${BRIDGE:-vmbr0}"
+STORAGE="${STORAGE:-}"
+TEMPLATE_STORAGE="${TEMPLATE_STORAGE:-}"
+NET="${NET:-dhcp}"
+GATEWAY="${GATEWAY:-}"
+UNPRIVILEGED="${UNPRIVILEGED:-1}"
+ONBOOT="${ONBOOT:-1}"
+CT_PASSWORD="${CT_PASSWORD:-}"
+
+ASSUME_YES=0
+for arg in "$@"; do
+  case "${arg}" in
+    -y | --yes) ASSUME_YES=1 ;;
+    -h | --help)
+      echo "Usage: questarr-lxc.sh [-y|--yes]"
+      echo
+      echo "Creates a Debian LXC on this Proxmox VE host and installs Questarr into it."
+      echo "Every prompt has an environment override: CTID, CT_HOSTNAME, CORES, RAM,"
+      echo "SWAP, DISK, STORAGE, TEMPLATE_STORAGE, BRIDGE, NET, GATEWAY, UNPRIVILEGED,"
+      echo "ONBOOT, CT_PASSWORD, QUESTARR_PORT, QUESTARR_REPO, QUESTARR_REF."
+      echo
+      echo "  -y, --yes   accept every default without prompting"
+      exit 0
+      ;;
+    *) ;;
+  esac
+done
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[0;33m'
+BLUE=$'\033[0;34m'
+BOLD=$'\033[1m'
+RESET=$'\033[0m'
+
+msg() { echo "${BLUE}==>${RESET} $*"; }
+ok() { echo "${GREEN} ✔${RESET} $*"; }
+warn() { echo "${YELLOW} !${RESET} $*" >&2; }
+die() {
+  echo "${RED} ✘ $*${RESET}" >&2
+  exit 1
+}
+
+CREATED_CTID=""
+on_error() {
+  local code=$?
+  echo >&2
+  echo "${RED} ✘ Deployment failed (exit ${code}).${RESET}" >&2
+  if [ -n "${CREATED_CTID}" ]; then
+    warn "Container ${CREATED_CTID} was created but is not fully configured."
+    warn "Inspect it with 'pct enter ${CREATED_CTID}', or remove it with 'pct destroy ${CREATED_CTID} --force'."
+  fi
+  exit "${code}"
+}
+trap on_error ERR
+
+banner() {
+  echo
+  echo "${BOLD}  Questarr — Proxmox VE LXC deployment${RESET}"
+  echo "  https://github.com/${QUESTARR_REPO}"
+  echo
+}
+
+# ──────────────────────────────────────────────────────────────
+# Preflight
+# ──────────────────────────────────────────────────────────────
+banner
+
+[ "$(id -u)" -eq 0 ] || die "Run this script as root on the Proxmox VE host."
+command -v pveversion >/dev/null 2>&1 ||
+  die "Proxmox VE not detected. Run this on the Proxmox host, not inside a container or VM."
+command -v pct >/dev/null 2>&1 || die "'pct' not found — is this a Proxmox VE node?"
+
+ok "Proxmox VE $(pveversion | cut -d'/' -f2) detected"
+
+# ──────────────────────────────────────────────────────────────
+# Settings
+# ──────────────────────────────────────────────────────────────
+interactive() { [ -r /dev/tty ]; }
+
+ask() {
+  # ask <variable-name> <prompt> <default>
+  local var="$1" prompt="$2" default="$3" answer
+  if [ "${ASSUME_YES}" -eq 1 ] || ! interactive; then
+    printf -v "${var}" '%s' "${default}"
+    return
+  fi
+  read -r -p "  ${prompt} [${default}]: " answer </dev/tty || answer=""
+  printf -v "${var}" '%s' "${answer:-${default}}"
+}
+
+if [ -z "${CTID}" ]; then
+  CTID="$(pvesh get /cluster/nextid)"
+fi
+
+# Pick a storage that can hold container root filesystems.
+list_storage() {
+  local content="$1"
+  pvesm status -content "${content}" 2>/dev/null | awk 'NR>1 && $3=="active" {print $1}'
+}
+
+if [ -z "${STORAGE}" ]; then
+  STORAGE="$(list_storage rootdir | head -n1)"
+  [ -n "${STORAGE}" ] || die "No active storage supports container root filesystems. Set STORAGE=<name>."
+fi
+if [ -z "${TEMPLATE_STORAGE}" ]; then
+  TEMPLATE_STORAGE="$(list_storage vztmpl | head -n1)"
+  [ -n "${TEMPLATE_STORAGE}" ] || die "No active storage accepts container templates. Set TEMPLATE_STORAGE=<name>."
+fi
+
+echo
+echo "${BOLD}Container settings${RESET} (press Enter to accept each default)"
+ask CTID "Container ID" "${CTID}"
+ask CT_HOSTNAME "Hostname" "${CT_HOSTNAME}"
+ask CORES "CPU cores" "${CORES}"
+ask RAM "RAM (MiB)" "${RAM}"
+ask DISK "Disk (GiB)" "${DISK}"
+ask STORAGE "Storage" "${STORAGE}"
+ask BRIDGE "Network bridge" "${BRIDGE}"
+ask NET "IPv4 (dhcp or CIDR e.g. 192.168.1.50/24)" "${NET}"
+if [ "${NET}" != "dhcp" ] && [ -z "${GATEWAY}" ]; then
+  ask GATEWAY "Gateway" "${GATEWAY}"
+fi
+ask QUESTARR_PORT "Questarr HTTP port" "${QUESTARR_PORT}"
+
+pct status "${CTID}" >/dev/null 2>&1 && die "Container ${CTID} already exists."
+
+echo
+echo "  ${BOLD}CTID${RESET} ${CTID}   ${BOLD}Host${RESET} ${CT_HOSTNAME}   ${BOLD}${CORES}${RESET} cores   ${BOLD}${RAM}${RESET} MiB   ${BOLD}${DISK}${RESET} GiB on ${BOLD}${STORAGE}${RESET}"
+echo "  ${BOLD}Net${RESET}  ${BRIDGE} / ${NET}${GATEWAY:+ gw ${GATEWAY}}   ${BOLD}Port${RESET} ${QUESTARR_PORT}"
+echo
+
+if [ "${ASSUME_YES}" -eq 0 ] && interactive; then
+  read -r -p "  Create this container? [Y/n]: " confirm </dev/tty || confirm=""
+  case "${confirm}" in
+    [nN] | [nN][oO]) die "Aborted." ;;
+  esac
+fi
+
+# ──────────────────────────────────────────────────────────────
+# Template
+# ──────────────────────────────────────────────────────────────
+msg "Refreshing the template catalogue"
+pveam update >/dev/null 2>&1 || warn "'pveam update' failed — using the cached catalogue."
+
+# Newest available Debian standard template, preferring the highest release.
+TEMPLATE="$(pveam available --section system |
+  awk '{print $2}' |
+  grep -E '^debian-1[0-9]+-standard' |
+  sort -V |
+  tail -n1)"
+[ -n "${TEMPLATE}" ] || die "No Debian LXC template found in the Proxmox catalogue."
+
+if ! pveam list "${TEMPLATE_STORAGE}" 2>/dev/null | awk '{print $1}' | grep -q "/${TEMPLATE}$"; then
+  msg "Downloading ${TEMPLATE} to ${TEMPLATE_STORAGE}"
+  pveam download "${TEMPLATE_STORAGE}" "${TEMPLATE}" >/dev/null
+fi
+ok "Template ready: ${TEMPLATE}"
+
+# ──────────────────────────────────────────────────────────────
+# Create the container
+# ──────────────────────────────────────────────────────────────
+if [ "${NET}" = "dhcp" ]; then
+  NET_CONFIG="name=eth0,bridge=${BRIDGE},ip=dhcp"
+else
+  NET_CONFIG="name=eth0,bridge=${BRIDGE},ip=${NET}"
+  if [ -n "${GATEWAY}" ]; then
+    NET_CONFIG="${NET_CONFIG},gw=${GATEWAY}"
+  fi
+fi
+
+msg "Creating container ${CTID}"
+PCT_ARGS=(
+  --hostname "${CT_HOSTNAME}"
+  --cores "${CORES}"
+  --memory "${RAM}"
+  --swap "${SWAP}"
+  --rootfs "${STORAGE}:${DISK}"
+  --net0 "${NET_CONFIG}"
+  --unprivileged "${UNPRIVILEGED}"
+  --onboot "${ONBOOT}"
+  --features nesting=1
+  --ostype debian
+  --tags questarr
+)
+if [ -n "${CT_PASSWORD}" ]; then
+  PCT_ARGS+=(--password "${CT_PASSWORD}")
+fi
+
+pct create "${CTID}" "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" "${PCT_ARGS[@]}" >/dev/null
+CREATED_CTID="${CTID}"
+ok "Container ${CTID} created"
+
+msg "Starting container ${CTID}"
+pct start "${CTID}" >/dev/null
+
+# Wait for the container's network to come up before the installer needs it.
+msg "Waiting for network"
+for _ in $(seq 1 60); do
+  if pct exec "${CTID}" -- getent hosts deb.debian.org >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+pct exec "${CTID}" -- getent hosts deb.debian.org >/dev/null 2>&1 ||
+  die "Container ${CTID} has no working DNS/network. Check the ${BRIDGE} bridge and your ${NET} settings."
+ok "Network is up"
+
+# ──────────────────────────────────────────────────────────────
+# Install Questarr inside the container
+# ──────────────────────────────────────────────────────────────
+INSTALLER_URL="https://raw.githubusercontent.com/${QUESTARR_REPO}/${QUESTARR_BRANCH}/scripts/proxmox/questarr-install.sh"
+LOCAL_INSTALLER="$(dirname "$(readlink -f "$0")")/questarr-install.sh"
+
+msg "Installing Questarr inside container ${CTID}"
+if [ -f "${LOCAL_INSTALLER}" ]; then
+  # Running from a checkout: use the sibling installer so both halves match.
+  pct push "${CTID}" "${LOCAL_INSTALLER}" /root/questarr-install.sh --perms 0755
+else
+  pct exec "${CTID}" -- bash -c \
+    "apt-get update -qq && apt-get install -y -qq --no-install-recommends curl ca-certificates >/dev/null && curl -fsSL '${INSTALLER_URL}' -o /root/questarr-install.sh && chmod 0755 /root/questarr-install.sh"
+fi
+
+pct exec "${CTID}" -- env \
+  QUESTARR_REPO="${QUESTARR_REPO}" \
+  QUESTARR_REF="${QUESTARR_REF}" \
+  QUESTARR_PORT="${QUESTARR_PORT}" \
+  bash /root/questarr-install.sh
+
+# ──────────────────────────────────────────────────────────────
+# Done
+# ──────────────────────────────────────────────────────────────
+CT_IP="$(pct exec "${CTID}" -- hostname -I 2>/dev/null | awk '{print $1}')"
+
+echo
+ok "${BOLD}Questarr is deployed in LXC ${CTID} (${CT_HOSTNAME}).${RESET}"
+echo "   URL:     http://${CT_IP:-<container-ip>}:${QUESTARR_PORT}"
+echo "   Shell:   pct enter ${CTID}"
+echo "   Logs:    pct exec ${CTID} -- journalctl -u questarr -f"
+echo "   Update:  pct exec ${CTID} -- update"
+echo


### PR DESCRIPTION
## Description

Adds a single-command Proxmox VE deployment path, so users can spin up Questarr in a lightweight LXC container without Docker overhead. The container runs Questarr from source as a hardened `systemd` service.

```bash
bash -c "$(curl -fsSL https://raw.githubusercontent.com/Doezer/Questarr/main/scripts/proxmox/questarr-lxc.sh)"
```

**`scripts/proxmox/questarr-lxc.sh`** — runs on the Proxmox host. Verifies it is on a PVE node, picks the next free CTID and a suitable storage, prompts for container settings (each with a default and an environment override, plus `--yes` for non-interactive use), downloads the newest Debian template if the node lacks it, creates an unprivileged container, waits for its network, then runs the installer inside it. On failure it tells the operator how to inspect or destroy the partially created container.

**`scripts/proxmox/questarr-install.sh`** — runs inside the container, and is also usable standalone on any Debian/Ubuntu LXC or VM. Installs Node.js from NodeSource, builds Questarr, writes the `systemd` unit, and installs an `update` helper following the Proxmox helper-script convention (`pct exec <ctid> -- update`).

Notable design points:

- **Updates are build-then-swap.** The new version is downloaded and built in a staging directory and only moved into place once the build succeeds, so a failed download or build leaves the running installation intact. `data/` and `.env` are preserved.
- **Hardened service.** Runs as an unprivileged `questarr` user under `ProtectSystem=strict`, `NoNewPrivileges`, `PrivateTmp`, with `/opt/questarr` as the only writable path — which covers both the SQLite database in `data/` and the `server.log` the app writes to its working directory.
- **Release resolution is explicit.** If no published release can be resolved (none exist, or the unauthenticated GitHub API rate limit was hit), the installer warns and falls back to `main` rather than silently installing development code. `QUESTARR_REF` pins a version.

No application code is touched — this is additive packaging and documentation only.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Verification

The Proxmox-host half needs a PVE node, but the parts that carry the real risk were validated directly:

- **npm pipeline**, exactly as the installer runs it: `npm ci --ignore-scripts` → `npm rebuild better-sqlite3` → `npm run build` → `npm prune --omit=dev`. Confirmed `--ignore-scripts` leaves no native binding on its own and that better-sqlite3 v13 ships bundled prebuilds that survive the prune, so the runtime binding loads correctly.
- **End-to-end boot** of the pruned production build with the same environment the `systemd` unit supplies: migrations applied automatically, server bound, `HTTP 200` on `/`. This also confirmed `dist/server/index.js` as the correct `ExecStart` and that `server.log` is written to the working directory, which is what drives the `ReadWritePaths` choice.
- **Generated artifacts**: the rendered `update` script and `systemd` unit were both checked for correct heredoc expansion and syntax (`systemd-analyze verify` reports no unit errors).
- **Source fetch**: ref resolution and tarball download/extract were run against the real repository; the extracted tree contains `package.json` and `package-lock.json`, so `npm ci` works.
- Both scripts pass `bash -n` and `shellcheck` with no warnings.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly — new docs page `docs/PROXMOX.md`, linked from the README installation section and from the canonical documentation map in `docs/GITHUB_DOCUMENTATION.md`. No API or actor changes; the deployment-hardening rationale is documented inline in the unit.
- [ ] I have added tests that prove my fix is effective or that my feature works — the repo has no shell-script test harness; validated manually as described under Verification.
- [x] New and existing unit tests pass locally with my changes — no application code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ycq3PeVXtAe7tT4kF2XqL

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ycq3PeVXtAe7tT4kF2XqL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated deployment of Questarr in a Proxmox VE LXC container without Docker.
  * Added configurable resources, networking, and non-interactive installation options.
  * Added update support and access details after deployment.

* **Documentation**
  * Added Proxmox installation, configuration, sizing, management, and troubleshooting guidance.
  * Added Proxmox deployment documentation to the documentation index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->