### PR TITLE
Fix mobile game details sheet auto-focusing notes textarea

### DIFF
--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -242,6 +242,26 @@ describe("GameDetailsModal", () => {
     });
   });
 
+  it("does not auto-focus the notes textarea when the mobile sheet opens", async () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
+
+    try {
+      renderComponent();
+
+      const notes = await screen.findByRole("textbox", { name: /personal notes for this game/i });
+      expect(notes).toBeInTheDocument();
+      // Radix would otherwise auto-focus this first focusable field and open the keyboard.
+      expect(notes).not.toHaveFocus();
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    }
+  });
+
   it("opens the screenshot lightbox as a fullscreen sheet on mobile", async () => {
     const originalInnerWidth = window.innerWidth;
     Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -249,9 +249,10 @@ describe("GameDetailsModal", () => {
     try {
       renderComponent();
 
+      const title = await screen.findByRole("heading", { name: "Test Game" });
       const notes = await screen.findByRole("textbox", { name: /personal notes for this game/i });
-      expect(notes).toBeInTheDocument();
-      // Radix would otherwise auto-focus this first focusable field and open the keyboard.
+      // Keep focus inside the sheet on the title, not the notes field (which opens the keyboard).
+      expect(title).toHaveFocus();
       expect(notes).not.toHaveFocus();
     } finally {
       Object.defineProperty(window, "innerWidth", {

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -1480,6 +1480,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
             side="fullscreen"
             className="flex flex-col overflow-hidden gap-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]"
             onClick={(e) => e.stopPropagation()}
+            onOpenAutoFocus={(e) => e.preventDefault()}
           >
             {detailsBody}
           </SheetContent>

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -351,6 +351,7 @@ function StarRatingInput({
 
 export default function GameDetailsModal({ game, open, onOpenChange }: GameDetailsModalProps) {
   const isMobile = useIsMobile();
+  const initialFocusRef = useRef<HTMLHeadingElement>(null);
   const [selectedScreenshotIndex, setSelectedScreenshotIndex] = useState<number | null>(null);
   const [downloadOpen, setDownloadOpen] = useState(false);
   const [isSummaryExpanded, setIsSummaryExpanded] = useState(false);
@@ -686,6 +687,8 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
         <div className="flex items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
             <DialogTitle
+              ref={initialFocusRef}
+              tabIndex={-1}
               className="text-2xl font-bold mb-2 leading-tight"
               data-testid={`text-game-title-${game.id}`}
             >
@@ -1480,7 +1483,10 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
             side="fullscreen"
             className="flex flex-col overflow-hidden gap-4 pb-[max(1.5rem,env(safe-area-inset-bottom))]"
             onClick={(e) => e.stopPropagation()}
-            onOpenAutoFocus={(e) => e.preventDefault()}
+            onOpenAutoFocus={(e) => {
+              e.preventDefault();
+              initialFocusRef.current?.focus();
+            }}
           >
             {detailsBody}
           </SheetContent>


### PR DESCRIPTION
## Description

On mobile, opening a game’s details Sheet auto-focused the personal notes `Textarea` because Radix Sheet/Dialog focuses the first focusable element on open. That immediately popped the on-screen keyboard.

This PR prevents that auto-focus on the **mobile game-details** `SheetContent` only. The screenshot lightbox `SheetContent` is unchanged.

Fixes #990

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Fix

- Add `onOpenAutoFocus={(e) => e.preventDefault()}` on the mobile details `SheetContent` in `client/src/components/GameDetailsModal.tsx`.
- `client/src/components/ui/sheet.tsx` already spreads props onto Radix Content, so the handler is applied as-is.
- Unit test: mobile-width path asserts the notes textarea is present and not focused.

## Checklist

- [x] Self-review
- [x] Tests added / existing tests pass (`GameDetailsModal.test.tsx` — 41 passed)

Assisted by Cursor (implementation and test wiring; human-reviewed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the personal-notes field from being automatically focused when the game details modal opens on mobile.
  - Improved the mobile modal’s initial focus behavior for a smoother opening experience.

- **Tests**
  - Added coverage verifying that the notes field remains unfocused when the mobile modal opens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->