### PR TITLE
Collapse mobile personal notes behind an Edit button

### DIFF
--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -306,6 +306,79 @@ describe("GameDetailsModal", () => {
     }
   });
 
+  it("shows the empty-state fallback for whitespace-only mobile notes", async () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
+
+    try {
+      renderComponent();
+
+      fireEvent.click(screen.getByRole("button", { name: /edit personal notes/i }));
+      const notes = await screen.findByRole("textbox", { name: /personal notes for this game/i });
+
+      fireEvent.change(notes, { target: { value: "   " } });
+      fireEvent.blur(notes);
+
+      // Whitespace-only input is normalized to null on save, so the preview
+      // should fall back to the empty-state text rather than rendering blank.
+      await waitFor(() => {
+        expect(screen.getByText("No personal notes yet")).toBeInTheDocument();
+      });
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    }
+  });
+
+  it("keeps the mobile notes editor open with the draft when saving fails", async () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
+
+    try {
+      (global.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+        if (typeof url === "string" && url.includes("/notes")) {
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            statusText: "Internal Server Error",
+            text: vi.fn().mockResolvedValue("Server error"),
+          });
+        }
+        return makeFetchMock()(url);
+      });
+
+      renderComponent();
+
+      fireEvent.click(screen.getByRole("button", { name: /edit personal notes/i }));
+      const notes = await screen.findByRole("textbox", { name: /personal notes for this game/i });
+
+      fireEvent.change(notes, { target: { value: "Draft that fails to save" } });
+      fireEvent.blur(notes);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.stringContaining(`/api/games/${mockGame.id}/notes`),
+          expect.objectContaining({ method: "PATCH" })
+        );
+      });
+
+      // The save failed, so the editor stays open with the unsaved draft instead
+      // of collapsing back to a preview that would look like it was persisted.
+      expect(
+        await screen.findByRole("textbox", { name: /personal notes for this game/i })
+      ).toHaveValue("Draft that fails to save");
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    }
+  });
+
   it("keeps personal notes directly editable on desktop", () => {
     renderComponent();
 

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -333,6 +333,69 @@ describe("GameDetailsModal", () => {
     }
   });
 
+  it("serializes mobile note saves so an older request can't overwrite a newer draft on the server", async () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
+
+    const savedNotes: (string | null)[] = [];
+    let resolveFirstSave: () => void = () => {};
+    let resolveSecondSave: () => void = () => {};
+    const firstSave = new Promise<void>((resolve) => {
+      resolveFirstSave = resolve;
+    });
+    const secondSave = new Promise<void>((resolve) => {
+      resolveSecondSave = resolve;
+    });
+
+    try {
+      (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+        (url: string, init?: RequestInit) => {
+          if (typeof url === "string" && url.includes("/notes")) {
+            const body = init?.body
+              ? (JSON.parse(init.body as string).notes as string | null)
+              : null;
+            savedNotes.push(body);
+            const pending = savedNotes.length === 1 ? firstSave : secondSave;
+            return pending.then(() => ({ ok: true, json: vi.fn().mockResolvedValue({}) }));
+          }
+          return makeFetchMock()(url);
+        }
+      );
+
+      renderComponent();
+
+      fireEvent.click(screen.getByRole("button", { name: /edit personal notes/i }));
+      const notes = await screen.findByRole("textbox", { name: /personal notes for this game/i });
+
+      fireEvent.change(notes, { target: { value: "First draft" } });
+      fireEvent.blur(notes);
+      await waitFor(() => expect(savedNotes).toHaveLength(1));
+
+      // A second blur while the first save is still in flight must be queued
+      // behind it, not fired as an overlapping request that could resolve
+      // out of order and let the older draft win on the server.
+      fireEvent.change(notes, { target: { value: "Second, newer draft" } });
+      fireEvent.blur(notes);
+      expect(savedNotes).toHaveLength(1);
+
+      // Resolve the older, first-in-flight save before the newer one is even sent.
+      resolveFirstSave();
+      await waitFor(() => expect(savedNotes).toHaveLength(2));
+
+      resolveSecondSave();
+
+      await waitFor(() => {
+        expect(savedNotes).toEqual(["First draft", "Second, newer draft"]);
+      });
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    }
+  });
+
   it("does not discard a newer draft if the user edits again while an earlier save is still in flight", async () => {
     const originalInnerWidth = window.innerWidth;
     Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -358,6 +358,10 @@ describe("GameDetailsModal", () => {
       fireEvent.change(notes, { target: { value: "First draft" } });
       fireEvent.blur(notes);
 
+      // The field must stay enabled on mobile during the save — otherwise a
+      // real browser would block the very typing this test exercises next.
+      expect(notes).not.toBeDisabled();
+
       // The first save is still in flight; the user edits again before it resolves.
       fireEvent.change(notes, { target: { value: "Second, newer draft" } });
 
@@ -437,6 +441,37 @@ describe("GameDetailsModal", () => {
       screen.getByRole("textbox", { name: /personal notes for this game/i })
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /edit personal notes/i })).not.toBeInTheDocument();
+  });
+
+  it("disables the notes textarea while saving on desktop", async () => {
+    let resolveSave: () => void = () => {};
+    const pendingSave = new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/notes")) {
+        return pendingSave.then(() => ({ ok: true, json: vi.fn().mockResolvedValue({}) }));
+      }
+      return makeFetchMock()(url);
+    });
+
+    renderComponent();
+
+    const notes = screen.getByRole("textbox", { name: /personal notes for this game/i });
+    fireEvent.change(notes, { target: { value: "Desktop note" } });
+    fireEvent.blur(notes);
+
+    // Desktop keeps the pre-existing disable-while-saving behavior; only the
+    // mobile editor needed to stay writable for the stale-save guard.
+    await waitFor(() => {
+      expect(notes).toBeDisabled();
+    });
+
+    resolveSave();
+    await waitFor(() => {
+      expect(notes).not.toBeDisabled();
+    });
   });
 
   it("opens download dialog when download button is clicked", async () => {

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -333,6 +333,57 @@ describe("GameDetailsModal", () => {
     }
   });
 
+  it("does not discard a newer draft if the user edits again while an earlier save is still in flight", async () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
+
+    let resolveSave: () => void = () => {};
+    const pendingSave = new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    });
+
+    try {
+      (global.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+        if (typeof url === "string" && url.includes("/notes")) {
+          return pendingSave.then(() => ({ ok: true, json: vi.fn().mockResolvedValue({}) }));
+        }
+        return makeFetchMock()(url);
+      });
+
+      renderComponent();
+
+      fireEvent.click(screen.getByRole("button", { name: /edit personal notes/i }));
+      const notes = await screen.findByRole("textbox", { name: /personal notes for this game/i });
+
+      fireEvent.change(notes, { target: { value: "First draft" } });
+      fireEvent.blur(notes);
+
+      // The first save is still in flight; the user edits again before it resolves.
+      fireEvent.change(notes, { target: { value: "Second, newer draft" } });
+
+      resolveSave();
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.stringContaining(`/api/games/${mockGame.id}/notes`),
+          expect.objectContaining({ method: "PATCH" })
+        );
+      });
+
+      // The stale save's success shouldn't collapse the editor out from under
+      // the newer, still-unsaved draft.
+      expect(
+        await screen.findByRole("textbox", { name: /personal notes for this game/i })
+      ).toHaveValue("Second, newer draft");
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    }
+  });
+
   it("keeps the mobile notes editor open with the draft when saving fails", async () => {
     const originalInnerWidth = window.innerWidth;
     Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -74,6 +74,7 @@ vi.mock("lucide-react", () => ({
   ChevronRight: (props: Record<string, unknown>) => (
     <div data-testid="icon-chevron-right" {...props} />
   ),
+  Pencil: (props: Record<string, unknown>) => <div data-testid="icon-pencil" {...props} />,
 }));
 
 vi.mock("react-icons/fa", () => ({
@@ -262,6 +263,56 @@ describe("GameDetailsModal", () => {
         value: originalInnerWidth,
       });
     }
+  });
+
+  it("collapses personal notes on mobile until Edit is tapped, without stealing focus on open", async () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
+
+    try {
+      renderComponent();
+
+      await screen.findByRole("heading", { name: "Test Game" });
+
+      // No textarea should exist yet, so opening the sheet can't pop the keyboard.
+      expect(
+        screen.queryByRole("textbox", { name: /personal notes for this game/i })
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("No personal notes yet")).toBeInTheDocument();
+
+      const editButton = screen.getByRole("button", { name: /edit personal notes/i });
+      fireEvent.click(editButton);
+
+      // Tapping Edit is a deliberate gesture, so autofocus here is expected.
+      const notes = await screen.findByRole("textbox", { name: /personal notes for this game/i });
+      expect(notes).toHaveFocus();
+
+      fireEvent.change(notes, { target: { value: "Great co-op game" } });
+      fireEvent.blur(notes);
+
+      // Blurring returns to the collapsed preview showing the saved text.
+      await waitFor(() => {
+        expect(screen.getByText("Great co-op game")).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByRole("textbox", { name: /personal notes for this game/i })
+      ).not.toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    }
+  });
+
+  it("keeps personal notes directly editable on desktop", () => {
+    renderComponent();
+
+    expect(
+      screen.getByRole("textbox", { name: /personal notes for this game/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /edit personal notes/i })).not.toBeInTheDocument();
   });
 
   it("opens download dialog when download button is clicked", async () => {

--- a/client/__tests__/GameDetailsModal.test.tsx
+++ b/client/__tests__/GameDetailsModal.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import { render, screen, fireEvent, waitFor, act, within } from "@testing-library/react";
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import GameDetailsModal from "../src/components/GameDetailsModal";
 import { Toaster } from "@/components/ui/toaster";
@@ -243,11 +243,27 @@ describe("GameDetailsModal", () => {
     });
   });
 
-  it("opens the screenshot lightbox as a fullscreen sheet on mobile", async () => {
-    const originalInnerWidth = window.innerWidth;
-    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
+  describe("on mobile viewport (375px)", () => {
+    let originalInnerWidth: number;
 
-    try {
+    beforeEach(() => {
+      originalInnerWidth = window.innerWidth;
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: 375,
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    });
+
+    it("opens the screenshot lightbox as a fullscreen sheet on mobile", async () => {
       renderComponent();
 
       fireEvent.click(screen.getByTestId("screenshot-0"));
@@ -256,20 +272,9 @@ describe("GameDetailsModal", () => {
       expect(lightboxImage).toHaveAttribute("src", "http://test.com/screen1.jpg");
       // The mobile lightbox renders as a fullscreen sheet, not the centered desktop dialog.
       expect(lightboxImage.closest(".bg-black\\/95")).toBeInTheDocument();
-    } finally {
-      Object.defineProperty(window, "innerWidth", {
-        writable: true,
-        configurable: true,
-        value: originalInnerWidth,
-      });
-    }
-  });
+    });
 
-  it("collapses personal notes on mobile until Edit is tapped, without stealing focus on open", async () => {
-    const originalInnerWidth = window.innerWidth;
-    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
-
-    try {
+    it("collapses personal notes on mobile until Edit is tapped, without stealing focus on open", async () => {
       renderComponent();
 
       await screen.findByRole("heading", { name: "Test Game" });
@@ -297,20 +302,9 @@ describe("GameDetailsModal", () => {
       expect(
         screen.queryByRole("textbox", { name: /personal notes for this game/i })
       ).not.toBeInTheDocument();
-    } finally {
-      Object.defineProperty(window, "innerWidth", {
-        writable: true,
-        configurable: true,
-        value: originalInnerWidth,
-      });
-    }
-  });
+    });
 
-  it("shows the empty-state fallback for whitespace-only mobile notes", async () => {
-    const originalInnerWidth = window.innerWidth;
-    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
-
-    try {
+    it("shows the empty-state fallback for whitespace-only mobile notes", async () => {
       renderComponent();
 
       fireEvent.click(screen.getByRole("button", { name: /edit personal notes/i }));
@@ -324,30 +318,19 @@ describe("GameDetailsModal", () => {
       await waitFor(() => {
         expect(screen.getByText("No personal notes yet")).toBeInTheDocument();
       });
-    } finally {
-      Object.defineProperty(window, "innerWidth", {
-        writable: true,
-        configurable: true,
-        value: originalInnerWidth,
+    });
+
+    it("serializes mobile note saves so an older request can't overwrite a newer draft on the server", async () => {
+      const savedNotes: (string | null)[] = [];
+      let resolveFirstSave: () => void = () => {};
+      let resolveSecondSave: () => void = () => {};
+      const firstSave = new Promise<void>((resolve) => {
+        resolveFirstSave = resolve;
       });
-    }
-  });
+      const secondSave = new Promise<void>((resolve) => {
+        resolveSecondSave = resolve;
+      });
 
-  it("serializes mobile note saves so an older request can't overwrite a newer draft on the server", async () => {
-    const originalInnerWidth = window.innerWidth;
-    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
-
-    const savedNotes: (string | null)[] = [];
-    let resolveFirstSave: () => void = () => {};
-    let resolveSecondSave: () => void = () => {};
-    const firstSave = new Promise<void>((resolve) => {
-      resolveFirstSave = resolve;
-    });
-    const secondSave = new Promise<void>((resolve) => {
-      resolveSecondSave = resolve;
-    });
-
-    try {
       (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
         (url: string, init?: RequestInit) => {
           if (typeof url === "string" && url.includes("/notes")) {
@@ -387,25 +370,14 @@ describe("GameDetailsModal", () => {
       await waitFor(() => {
         expect(savedNotes).toEqual(["First draft", "Second, newer draft"]);
       });
-    } finally {
-      Object.defineProperty(window, "innerWidth", {
-        writable: true,
-        configurable: true,
-        value: originalInnerWidth,
-      });
-    }
-  });
-
-  it("does not discard a newer draft if the user edits again while an earlier save is still in flight", async () => {
-    const originalInnerWidth = window.innerWidth;
-    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
-
-    let resolveSave: () => void = () => {};
-    const pendingSave = new Promise<void>((resolve) => {
-      resolveSave = resolve;
     });
 
-    try {
+    it("does not discard a newer draft if the user edits again while an earlier save is still in flight", async () => {
+      let resolveSave: () => void = () => {};
+      const pendingSave = new Promise<void>((resolve) => {
+        resolveSave = resolve;
+      });
+
       (global.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
         if (typeof url === "string" && url.includes("/notes")) {
           return pendingSave.then(() => ({ ok: true, json: vi.fn().mockResolvedValue({}) }));
@@ -420,6 +392,12 @@ describe("GameDetailsModal", () => {
 
       fireEvent.change(notes, { target: { value: "First draft" } });
       fireEvent.blur(notes);
+
+      // Wait for the save to actually be in flight before asserting the field
+      // stays enabled through it — asserting right after blur, before React
+      // commits the pending state, would pass trivially without exercising
+      // the "during a save" case the comment below describes.
+      await screen.findByText("Saving...");
 
       // The field must stay enabled on mobile during the save — otherwise a
       // real browser would block the very typing this test exercises next.
@@ -442,20 +420,9 @@ describe("GameDetailsModal", () => {
       expect(
         await screen.findByRole("textbox", { name: /personal notes for this game/i })
       ).toHaveValue("Second, newer draft");
-    } finally {
-      Object.defineProperty(window, "innerWidth", {
-        writable: true,
-        configurable: true,
-        value: originalInnerWidth,
-      });
-    }
-  });
+    });
 
-  it("keeps the mobile notes editor open with the draft when saving fails", async () => {
-    const originalInnerWidth = window.innerWidth;
-    Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 375 });
-
-    try {
+    it("keeps the mobile notes editor open with the draft when saving fails", async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
         if (typeof url === "string" && url.includes("/notes")) {
           return Promise.resolve({
@@ -488,13 +455,102 @@ describe("GameDetailsModal", () => {
       expect(
         await screen.findByRole("textbox", { name: /personal notes for this game/i })
       ).toHaveValue("Draft that fails to save");
-    } finally {
-      Object.defineProperty(window, "innerWidth", {
-        writable: true,
-        configurable: true,
-        value: originalInnerWidth,
+    });
+
+    it("does not let a background refetch of the same game overwrite an active mobile notes draft", async () => {
+      const gameWithNotes = {
+        ...mockGame,
+        notes: "Original note",
+      } as unknown as import("@shared/schema").Game;
+
+      const { rerender } = renderComponent(gameWithNotes);
+
+      fireEvent.click(screen.getByRole("button", { name: /edit personal notes/i }));
+      const notes = await screen.findByRole("textbox", { name: /personal notes for this game/i });
+
+      fireEvent.change(notes, { target: { value: "Draft in progress" } });
+
+      // Simulate a background refetch of the same game (e.g. triggered by
+      // another save's invalidateQueries) landing while the user is mid-edit.
+      rerender(
+        <QueryClientProvider client={createQueryClient()}>
+          <GameDetailsModal
+            game={
+              {
+                ...gameWithNotes,
+                notes: "Changed elsewhere",
+              } as unknown as import("@shared/schema").Game
+            }
+            open={true}
+            onOpenChange={() => {}}
+          />
+          <Toaster />
+        </QueryClientProvider>
+      );
+
+      expect(screen.getByRole("textbox", { name: /personal notes for this game/i })).toHaveValue(
+        "Draft in progress"
+      );
+    });
+
+    it("drops a queued notes save instead of misfiring it against a different game", async () => {
+      let resolveSave: () => void = () => {};
+      const pendingSave = new Promise<void>((resolve) => {
+        resolveSave = resolve;
       });
-    }
+      const patchedGameIds: string[] = [];
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+        if (typeof url === "string" && url.includes("/notes")) {
+          const match = url.match(/\/api\/games\/([^/]+)\/notes/);
+          if (match) patchedGameIds.push(match[1]);
+          return pendingSave.then(() => ({ ok: true, json: vi.fn().mockResolvedValue({}) }));
+        }
+        return makeFetchMock()(url);
+      });
+
+      const gameA = {
+        ...mockGame,
+        id: "1",
+        notes: "A's note",
+      } as unknown as import("@shared/schema").Game;
+      const gameB = {
+        ...mockGame,
+        id: "2",
+        notes: "B's note",
+      } as unknown as import("@shared/schema").Game;
+
+      const { rerender } = renderComponent(gameA);
+
+      fireEvent.click(screen.getByRole("button", { name: /edit personal notes/i }));
+      const notes = await screen.findByRole("textbox", { name: /personal notes for this game/i });
+
+      fireEvent.change(notes, { target: { value: "A's edited note" } });
+      fireEvent.blur(notes);
+      await waitFor(() => expect(patchedGameIds).toHaveLength(1));
+
+      // A second edit while game A's save is still in flight gets queued...
+      fireEvent.change(notes, { target: { value: "A's second edit" } });
+      fireEvent.blur(notes);
+
+      // ...but before it can fire, the modal switches to a different game entirely.
+      rerender(
+        <QueryClientProvider client={createQueryClient()}>
+          <GameDetailsModal game={gameB} open={true} onOpenChange={() => {}} />
+          <Toaster />
+        </QueryClientProvider>
+      );
+
+      resolveSave();
+
+      // The switch lands on game B's collapsed preview...
+      await waitFor(() => {
+        expect(screen.getByText("B's note")).toBeInTheDocument();
+      });
+      // ...and the queued draft for game A must never be sent, let alone
+      // against game B's id.
+      expect(patchedGameIds).toEqual(["1"]);
+    });
   });
 
   it("keeps personal notes directly editable on desktop", () => {

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -833,7 +833,11 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
               className="resize-none min-h-[56px] sm:min-h-[72px] text-sm"
               maxLength={10000}
               aria-label="Personal notes for this game"
-              disabled={notesMutation.isPending}
+              // On mobile, keep the field editable through the save so the
+              // stale-save guard above is actually reachable — a disabled
+              // field would block the very typing it's meant to protect.
+              // Desktop keeps the pre-existing disable-while-saving behavior.
+              disabled={!isMobile && notesMutation.isPending}
             />
           )}
           {notesMutation.isPending && (

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -364,6 +364,13 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
   useEffect(() => {
     notesValueRef.current = notesValue;
   }, [notesValue]);
+  // Serializes mobile note saves: only one PATCH is ever in flight. A save
+  // requested while one is pending is queued (overwriting any earlier queued
+  // value — only the latest draft matters) and fired once the in-flight one
+  // settles, so two overlapping requests can never complete out of order and
+  // let an older draft silently overwrite a newer one on the server.
+  const notesSaveInFlightRef = useRef(false);
+  const queuedNotesSaveRef = useRef<{ value: string | null } | null>(null);
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
   const [removeFromClient, setRemoveFromClient] = useState(true);
   const [deleteFiles, setDeleteFiles] = useState(true);
@@ -594,6 +601,31 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
     },
   });
 
+  // Fires a notes save, or queues it if one is already in flight (see the
+  // refs above) — never lets two PATCH requests race each other.
+  const saveNotes = (trimmed: string | null) => {
+    if (notesSaveInFlightRef.current) {
+      queuedNotesSaveRef.current = { value: trimmed };
+      return;
+    }
+    notesSaveInFlightRef.current = true;
+    notesMutation.mutate(trimmed, {
+      onSuccess: () => {
+        if (isMobile && notesValueRef.current.trim() === (trimmed ?? "")) {
+          setIsEditingNotes(false);
+        }
+      },
+      onSettled: () => {
+        notesSaveInFlightRef.current = false;
+        const queued = queuedNotesSaveRef.current;
+        queuedNotesSaveRef.current = null;
+        if (queued) {
+          saveNotes(queued.value);
+        }
+      },
+    });
+  };
+
   const hiddenMutation = useHiddenMutation({
     hiddenSuccessMessage: "Game hidden from library",
     unhiddenSuccessMessage: "Game unhidden",
@@ -809,22 +841,14 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
               value={notesValue}
               onChange={(e) => setNotesValue(e.target.value)}
               onBlur={() => {
-                const valueAtBlur = notesValue;
-                const trimmed = valueAtBlur.trim() || null;
+                const trimmed = notesValue.trim() || null;
                 if (trimmed !== (game.notes ?? null)) {
-                  // On mobile, only collapse back to the preview once the save
-                  // succeeds — a failed save keeps the editor open so the draft
-                  // isn't lost or shown as if it were persisted. Also skip the
-                  // collapse if the user has kept typing since this blur (the
-                  // save is async, so a slow one shouldn't yank focus away
-                  // from — or hide — newer, still-unsaved keystrokes).
-                  notesMutation.mutate(trimmed, {
-                    onSuccess: () => {
-                      if (isMobile && notesValueRef.current === valueAtBlur) {
-                        setIsEditingNotes(false);
-                      }
-                    },
-                  });
+                  // saveNotes serializes this behind any already-in-flight
+                  // save, and its own onSuccess (above) only collapses the
+                  // mobile editor once the latest saved value matches what's
+                  // currently typed — a failed or superseded save leaves it
+                  // open instead of losing or misrepresenting the draft.
+                  saveNotes(trimmed);
                 } else if (isMobile) {
                   setIsEditingNotes(false);
                 }

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -64,6 +64,7 @@ import {
   File,
   ChevronLeft,
   ChevronRight,
+  Pencil,
 } from "lucide-react";
 import { FaSteam, FaRedditAlien, FaDiscord, FaWikipediaW, FaTwitch } from "react-icons/fa";
 import {
@@ -355,6 +356,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
   const [downloadOpen, setDownloadOpen] = useState(false);
   const [isSummaryExpanded, setIsSummaryExpanded] = useState(false);
   const [notesValue, setNotesValue] = useState<string>("");
+  const [isEditingNotes, setIsEditingNotes] = useState(false);
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
   const [removeFromClient, setRemoveFromClient] = useState(true);
   const [deleteFiles, setDeleteFiles] = useState(true);
@@ -372,12 +374,14 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
       setIsSummaryExpanded(false);
       setSelectedScreenshotIndex(null);
       setDownloadOpen(false);
+      setIsEditingNotes(false);
     }
   }, [open]);
 
   useEffect(() => {
     setIsSummaryExpanded(false);
     setNotesValue(game?.notes ?? "");
+    setIsEditingNotes(false);
   }, [game?.id, game?.notes]);
 
   useEffect(() => {
@@ -774,21 +778,45 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
 
         {/* Personal notes */}
         <div className="mt-3">
-          <Textarea
-            value={notesValue}
-            onChange={(e) => setNotesValue(e.target.value)}
-            onBlur={() => {
-              const trimmed = notesValue.trim() || null;
-              if (trimmed !== (game.notes ?? null)) {
-                notesMutation.mutate(trimmed);
-              }
-            }}
-            placeholder="Personal notes..."
-            className="resize-none min-h-[56px] sm:min-h-[72px] text-sm"
-            maxLength={10000}
-            aria-label="Personal notes for this game"
-            disabled={notesMutation.isPending}
-          />
+          {isMobile && !isEditingNotes ? (
+            // Mobile: notes start collapsed to a read-only preview so opening the sheet
+            // never lands focus on a text field and pops the on-screen keyboard.
+            // Tapping "Edit" is an explicit user gesture, so autofocus there is expected.
+            <div className="flex items-start justify-between gap-2">
+              <p className="flex-1 min-w-0 line-clamp-2 text-sm text-muted-foreground">
+                {notesValue || "No personal notes yet"}
+              </p>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 flex-shrink-0"
+                aria-label="Edit personal notes"
+                onClick={() => setIsEditingNotes(true)}
+              >
+                <Pencil className="h-4 w-4" />
+              </Button>
+            </div>
+          ) : (
+            <Textarea
+              autoFocus={isMobile}
+              value={notesValue}
+              onChange={(e) => setNotesValue(e.target.value)}
+              onBlur={() => {
+                const trimmed = notesValue.trim() || null;
+                if (trimmed !== (game.notes ?? null)) {
+                  notesMutation.mutate(trimmed);
+                }
+                if (isMobile) {
+                  setIsEditingNotes(false);
+                }
+              }}
+              placeholder="Personal notes..."
+              className="resize-none min-h-[56px] sm:min-h-[72px] text-sm"
+              maxLength={10000}
+              aria-label="Personal notes for this game"
+              disabled={notesMutation.isPending}
+            />
+          )}
           {notesMutation.isPending && (
             <p className="text-xs text-muted-foreground mt-1">Saving...</p>
           )}

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -357,6 +357,13 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
   const [isSummaryExpanded, setIsSummaryExpanded] = useState(false);
   const [notesValue, setNotesValue] = useState<string>("");
   const [isEditingNotes, setIsEditingNotes] = useState(false);
+  // Tracks the live notesValue so the async save's onSuccess (below) can tell
+  // whether the user kept typing after blur, instead of seeing the stale
+  // value it closed over.
+  const notesValueRef = useRef(notesValue);
+  useEffect(() => {
+    notesValueRef.current = notesValue;
+  }, [notesValue]);
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
   const [removeFromClient, setRemoveFromClient] = useState(true);
   const [deleteFiles, setDeleteFiles] = useState(true);
@@ -802,14 +809,20 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
               value={notesValue}
               onChange={(e) => setNotesValue(e.target.value)}
               onBlur={() => {
-                const trimmed = notesValue.trim() || null;
+                const valueAtBlur = notesValue;
+                const trimmed = valueAtBlur.trim() || null;
                 if (trimmed !== (game.notes ?? null)) {
                   // On mobile, only collapse back to the preview once the save
                   // succeeds — a failed save keeps the editor open so the draft
-                  // isn't lost or shown as if it were persisted.
+                  // isn't lost or shown as if it were persisted. Also skip the
+                  // collapse if the user has kept typing since this blur (the
+                  // save is async, so a slow one shouldn't yank focus away
+                  // from — or hide — newer, still-unsaved keystrokes).
                   notesMutation.mutate(trimmed, {
                     onSuccess: () => {
-                      if (isMobile) setIsEditingNotes(false);
+                      if (isMobile && notesValueRef.current === valueAtBlur) {
+                        setIsEditingNotes(false);
+                      }
                     },
                   });
                 } else if (isMobile) {

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -784,7 +784,7 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
             // Tapping "Edit" is an explicit user gesture, so autofocus there is expected.
             <div className="flex items-start justify-between gap-2">
               <p className="flex-1 min-w-0 line-clamp-2 text-sm text-muted-foreground">
-                {notesValue || "No personal notes yet"}
+                {notesValue.trim() || "No personal notes yet"}
               </p>
               <Button
                 variant="ghost"
@@ -804,9 +804,15 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
               onBlur={() => {
                 const trimmed = notesValue.trim() || null;
                 if (trimmed !== (game.notes ?? null)) {
-                  notesMutation.mutate(trimmed);
-                }
-                if (isMobile) {
+                  // On mobile, only collapse back to the preview once the save
+                  // succeeds — a failed save keeps the editor open so the draft
+                  // isn't lost or shown as if it were persisted.
+                  notesMutation.mutate(trimmed, {
+                    onSuccess: () => {
+                      if (isMobile) setIsEditingNotes(false);
+                    },
+                  });
+                } else if (isMobile) {
                   setIsEditingNotes(false);
                 }
               }}

--- a/client/src/components/GameDetailsModal.tsx
+++ b/client/src/components/GameDetailsModal.tsx
@@ -364,13 +364,23 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
   useEffect(() => {
     notesValueRef.current = notesValue;
   }, [notesValue]);
+  // Tracks the live isEditingNotes so the server-sync effect (below) can
+  // check it without depending on it — depending on it directly would rerun
+  // the sync (using the still-stale pre-refetch game.notes) the instant a
+  // save flips isEditingNotes back to false, flashing the old value.
+  const isEditingNotesRef = useRef(isEditingNotes);
+  useEffect(() => {
+    isEditingNotesRef.current = isEditingNotes;
+  }, [isEditingNotes]);
   // Serializes mobile note saves: only one PATCH is ever in flight. A save
   // requested while one is pending is queued (overwriting any earlier queued
   // value — only the latest draft matters) and fired once the in-flight one
   // settles, so two overlapping requests can never complete out of order and
-  // let an older draft silently overwrite a newer one on the server.
+  // let an older draft silently overwrite a newer one on the server. Each
+  // queued save also remembers which game it targets, so it's dropped
+  // instead of misfiring if the modal has since switched to another game.
   const notesSaveInFlightRef = useRef(false);
-  const queuedNotesSaveRef = useRef<{ value: string | null } | null>(null);
+  const queuedNotesSaveRef = useRef<{ value: string | null; gameId: string } | null>(null);
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
   const [removeFromClient, setRemoveFromClient] = useState(true);
   const [deleteFiles, setDeleteFiles] = useState(true);
@@ -389,14 +399,29 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
       setSelectedScreenshotIndex(null);
       setDownloadOpen(false);
       setIsEditingNotes(false);
+      queuedNotesSaveRef.current = null;
     }
   }, [open]);
 
+  // Full reset when switching to a different game — unconditional, since a
+  // new game.id means any in-progress notes draft belongs to a game we're
+  // no longer looking at.
   useEffect(() => {
     setIsSummaryExpanded(false);
     setNotesValue(game?.notes ?? "");
     setIsEditingNotes(false);
-  }, [game?.id, game?.notes]);
+    queuedNotesSaveRef.current = null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [game?.id]);
+
+  // Keep notesValue in sync with the server for the *same* game — e.g. after
+  // the notes mutation's own invalidateQueries refetch lands. Skipped while
+  // actively editing on mobile so a background refetch can't stomp a draft
+  // the user hasn't blurred away from yet.
+  useEffect(() => {
+    if (isMobile && isEditingNotesRef.current) return;
+    setNotesValue(game?.notes ?? "");
+  }, [game?.notes, isMobile]);
 
   useEffect(() => {
     setSelectedScreenshotIndex(null);
@@ -590,8 +615,8 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
   });
 
   const notesMutation = useMutation({
-    mutationFn: async (notes: string | null) => {
-      await apiRequest("PATCH", `/api/games/${game?.id}/notes`, { notes });
+    mutationFn: async ({ gameId, notes }: { gameId: string; notes: string | null }) => {
+      await apiRequest("PATCH", `/api/games/${gameId}/notes`, { notes });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/games"] });
@@ -601,29 +626,36 @@ export default function GameDetailsModal({ game, open, onOpenChange }: GameDetai
     },
   });
 
-  // Fires a notes save, or queues it if one is already in flight (see the
-  // refs above) — never lets two PATCH requests race each other.
-  const saveNotes = (trimmed: string | null) => {
+  // Fires a notes save for `gameId` (the current game by default), or queues
+  // it if one is already in flight (see the refs above) — never lets two
+  // PATCH requests race each other. The target game travels with the save
+  // itself, so a queued draft is dropped instead of misfiring against the
+  // wrong game if the modal switches games while a save is pending.
+  const saveNotes = (trimmed: string | null, gameId: string | undefined = game?.id) => {
+    if (!gameId) return;
     if (notesSaveInFlightRef.current) {
-      queuedNotesSaveRef.current = { value: trimmed };
+      queuedNotesSaveRef.current = { value: trimmed, gameId };
       return;
     }
     notesSaveInFlightRef.current = true;
-    notesMutation.mutate(trimmed, {
-      onSuccess: () => {
-        if (isMobile && notesValueRef.current.trim() === (trimmed ?? "")) {
-          setIsEditingNotes(false);
-        }
-      },
-      onSettled: () => {
-        notesSaveInFlightRef.current = false;
-        const queued = queuedNotesSaveRef.current;
-        queuedNotesSaveRef.current = null;
-        if (queued) {
-          saveNotes(queued.value);
-        }
-      },
-    });
+    notesMutation.mutate(
+      { gameId, notes: trimmed },
+      {
+        onSuccess: () => {
+          if (isMobile && game?.id === gameId && notesValueRef.current.trim() === (trimmed ?? "")) {
+            setIsEditingNotes(false);
+          }
+        },
+        onSettled: () => {
+          notesSaveInFlightRef.current = false;
+          const queued = queuedNotesSaveRef.current;
+          queuedNotesSaveRef.current = null;
+          if (queued && queued.gameId === game?.id) {
+            saveNotes(queued.value, queued.gameId);
+          }
+        },
+      }
+    );
   };
 
   const hiddenMutation = useHiddenMutation({


### PR DESCRIPTION
## Description

On mobile, opening a game's details Sheet auto-focused the personal notes `Textarea` because Radix Sheet/Dialog focuses the first focusable element on open, which immediately popped the on-screen keyboard.

This is an alternative to #992's `onOpenAutoFocus={(e) => e.preventDefault()}` redirect: instead of preventing default focus and steering it to the title, this fixes the root cause — the free-text notes field is no longer the first tabbable element when the mobile sheet opens.

## Fix

On mobile, personal notes now start as a **read-only preview** (line-clamped text + an "Edit" icon button). Tapping "Edit" is a deliberate user gesture, so autofocusing the textarea at that point is expected and safe — no more keyboard popping open on sheet mount. Desktop is unchanged: the notes textarea stays always visible and editable, since there's no virtual keyboard concern there.

- `client/src/components/GameDetailsModal.tsx`: added `isEditingNotes` state; on mobile, renders a collapsed notes preview + `Pencil` edit button until tapped, then swaps in the `Textarea` with `autoFocus`. Blurring the textarea on mobile saves (unchanged mutation logic) and collapses back to the preview. State resets when the sheet closes or the game changes.
- `client/__tests__/GameDetailsModal.test.tsx`: tests that (1) no textarea exists on mobile until "Edit" is tapped, so opening the sheet can't focus one, (2) tapping "Edit" reveals and focuses the textarea, and blurring returns to the collapsed preview with the saved text, and (3) desktop keeps the textarea directly editable with no edit button.

Fixes #990

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes (`npm run test:run` — 2316 passed)
- [x] `npm run lint` and `npm run check` pass clean

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DWT7MxU2QKre1w7wuk6Fa

---
_Generated by [Claude Code](https://claude.ai/code/session_017DWT7MxU2QKre1w7wuk6Fa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Personal notes now display as a compact preview on mobile.
  - Added an Edit button with automatic focus and save-on-blur behavior.
  - Desktop users can continue editing notes directly in the textarea.
  - Whitespace-only notes display the empty-state message.

- **Bug Fixes**
  - Failed saves keep the editor open with the unsaved draft.
  - Newer edits are protected from earlier save results.
  - The notes field is disabled during desktop saves.
  - Editing state resets when switching games or closing the modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->