### PR TITLE
Start the /play run outside, behind a single vault gate

### DIFF
--- a/client/src/game/__tests__/level.test.ts
+++ b/client/src/game/__tests__/level.test.ts
@@ -24,6 +24,22 @@ function containsCell(rect: { x: number; z: number; w: number; h: number }, cell
   );
 }
 
+/** Cells of the facility's perimeter ring that are not walled: the way in. */
+function perimeterHoles(level: GeneratedLevel): string[] {
+  const walls = new Set(level.walls.map(cellKey));
+  const { facility } = level;
+  const interior = {
+    x: facility.x + 1,
+    z: facility.z + 1,
+    w: facility.w - 2,
+    h: facility.h - 2,
+  };
+  return rectCells(facility)
+    .filter((cell) => !containsCell(interior, cell))
+    .map(cellKey)
+    .filter((key) => !walls.has(key));
+}
+
 function rectCells(rect: { x: number; z: number; w: number; h: number }): GridPos[] {
   const cells: GridPos[] = [];
   for (let x = rect.x; x < rect.x + rect.w; x++) {
@@ -86,22 +102,29 @@ describe("generateLevel", () => {
     }
   });
 
-  it("leaves no interior cell that is neither floor, wall nor door", () => {
-    // A later perpendicular split can strand an earlier door so it joins fewer
-    // than two rooms. Its cell is already cut from its wall line, so if it is
-    // not sealed it becomes a hole the engine builds no collider for.
+  it("leaves no interior cell that is neither floor, wall, door nor open ground", () => {
+    // Every cell of the grid has to be *something* the engine builds: room floor
+    // and the apron are walked on, walls and the shut gate are collided with. A
+    // cell that is none of them is a hole with no collider and nothing drawn.
     for (const seed of SEEDS) {
       const level = generateLevel(seed);
       const floor = new Set(level.rooms.flatMap(rectCells).map(cellKey));
       const walls = new Set(level.walls.map(cellKey));
       const doors = new Set(level.doors.map((door) => cellKey(door.pos)));
+      const apron = new Set(rectCells(level.apron).map(cellKey));
 
       for (let x = 1; x <= level.gridSize - 2; x++) {
         for (let z = 1; z <= level.gridSize - 2; z++) {
           const cell = { x, z };
           if (!isInterior(cell, level.gridSize)) continue;
           const key = cellKey(cell);
-          expect(floor.has(key) || walls.has(key) || doors.has(key)).toBe(true);
+          const accounted =
+            floor.has(key) ||
+            walls.has(key) ||
+            doors.has(key) ||
+            apron.has(key) ||
+            key === cellKey(level.gate.pos);
+          expect(accounted).toBe(true);
         }
       }
     }
@@ -197,8 +220,96 @@ describe("generateLevel", () => {
     const level = generateLevel(1, { gridSize: 7 });
     expect(level.rooms).toHaveLength(1);
     expect(level.doors).toHaveLength(0);
-    expect(level.walls).toHaveLength(0);
     expect(level.keycard).toBeNull();
+    // The facility always has its own perimeter, however small it gets, so the
+    // one thing that can never be empty here is the wall list.
+    expect(level.walls.length).toBeGreaterThan(0);
+    expect(perimeterHoles(level)).toEqual([cellKey(level.gate.pos)]);
+  });
+});
+
+describe("the gate", () => {
+  it("starts the player outside, on the apron", () => {
+    for (const seed of SEEDS) {
+      const level = generateLevel(seed);
+      expect(containsCell(level.apron, level.spawn)).toBe(true);
+      expect(containsCell(level.facility, level.spawn)).toBe(false);
+      // Nothing is placed on the approach, so the opening walk is never blocked.
+      const blocked = structuralBlocked(level);
+      for (const cell of rectCells(level.apron)) {
+        expect(blocked.has(cellKey(cell))).toBe(false);
+      }
+    }
+  });
+
+  it("is the only opening in the facility's perimeter", () => {
+    // This is what makes the approach mean anything: with any second hole the
+    // player could walk around the gate and the whole entrance is decoration.
+    for (const seed of SEEDS) {
+      const level = generateLevel(seed);
+      expect(perimeterHoles(level)).toEqual([cellKey(level.gate.pos)]);
+    }
+  });
+
+  it("opens from the apron into the room it names", () => {
+    for (const seed of SEEDS) {
+      const level = generateLevel(seed);
+      const { gate } = level;
+      const blocked = structuralBlocked(level);
+      expect(blocked.has(cellKey(gate.pos))).toBe(false);
+
+      // The cell outside is apron, and the cell opposite it is the room floor
+      // the gate leads onto — so the gate is genuinely a threshold, not a slot
+      // punched into a corner or against the end of an interior partition.
+      expect(containsCell(level.apron, gate.outside)).toBe(true);
+      const inner = {
+        x: gate.pos.x * 2 - gate.outside.x,
+        z: gate.pos.z * 2 - gate.outside.z,
+      };
+      expect(containsCell(level.rooms[gate.room], inner)).toBe(true);
+      expect(blocked.has(cellKey(inner))).toBe(false);
+
+      // `spansX` says which way the leaf faces; the player always crosses the
+      // gate on the other axis.
+      expect(gate.spansX).toBe(gate.outside.x === gate.pos.x);
+    }
+  });
+
+  it("is the only route in, so sealing it strands the terminal", () => {
+    for (const seed of SEEDS) {
+      const level = generateLevel(seed);
+      const sealed = structuralBlocked(level);
+      sealed.add(cellKey(level.gate.pos));
+      expect(findPath(level.spawn, level.terminal, level.gridSize, sealed)).toEqual([]);
+      // And with it open the run is walkable end to end, keycard included.
+      expect(
+        findPath(level.spawn, level.terminal, level.gridSize, structuralBlocked(level)).length
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps the apron and the facility from overlapping", () => {
+    for (const seed of SEEDS) {
+      const level = generateLevel(seed);
+      for (const cell of rectCells(level.apron)) {
+        expect(containsCell(level.facility, cell)).toBe(false);
+        expect(isInterior(cell, level.gridSize)).toBe(true);
+      }
+      for (const cell of rectCells(level.facility)) {
+        expect(isInterior(cell, level.gridSize)).toBe(true);
+      }
+    }
+  });
+
+  it("puts no patrol out on the approach", () => {
+    for (const seed of SEEDS) {
+      const level = generateLevel(seed);
+      for (const guard of level.guards) {
+        for (const waypoint of guard.waypoints) {
+          expect(containsCell(level.apron, waypoint)).toBe(false);
+        }
+      }
+    }
   });
 });
 

--- a/client/src/game/__tests__/level.test.ts
+++ b/client/src/game/__tests__/level.test.ts
@@ -281,7 +281,10 @@ describe("the gate", () => {
       const sealed = structuralBlocked(level);
       sealed.add(cellKey(level.gate.pos));
       expect(findPath(level.spawn, level.terminal, level.gridSize, sealed)).toEqual([]);
-      // And with it open the run is walkable end to end, keycard included.
+      // And with it open the run is walkable end to end. `structuralBlocked`
+      // leaves the locked door open, so this is the run as a player who already
+      // holds the keycard walks it; the leg before the keycard is covered by
+      // "locks exactly one door, on the route to the terminal" above.
       expect(
         findPath(level.spawn, level.terminal, level.gridSize, structuralBlocked(level)).length
       ).toBeGreaterThan(0);

--- a/client/src/game/infiltration-game.ts
+++ b/client/src/game/infiltration-game.ts
@@ -56,6 +56,8 @@ export interface StealthState {
 }
 
 export interface ObjectiveState {
+  /** False while the player is still out on the approach, short of the gate. */
+  inside: boolean;
   /** True when a locked door stands between the player and the terminal. */
   needsKeycard: boolean;
   hasKeycard: boolean;
@@ -97,6 +99,11 @@ interface Door {
   box: Box;
   /** 0 fully closed, 1 fully open. */
   openness: number;
+  /**
+   * The gate's cog leaf, which turns about the passage axis as it retracts.
+   * Null for the interior doors, which simply drop into the floor.
+   */
+  wheel: THREE.Object3D | null;
 }
 
 /** A thrown distraction in flight, or resting on the floor until it expires. */
@@ -121,6 +128,10 @@ const CRATE_SIZE = 2.2;
 const CRATE_HEIGHT = 1.8;
 const WALL_HEIGHT = 4;
 const DOOR_HEIGHT = 2.8;
+/** How far the gate's portal stands above the perimeter it is set into. */
+const GATE_PORTAL_RISE = 1.6;
+/** Half-turns the cog leaf makes as it retracts, so it reads as disengaging. */
+const GATE_SPIN = Math.PI * 1.2;
 const VISION_RANGE = 9;
 const VISION_HALF_FOV = THREE.MathUtils.degToRad(32);
 const VISION_CHECK_INTERVAL = 0.15;
@@ -206,6 +217,11 @@ const PALETTE = {
   lampHousing: 0x1c1712,
   /** Motes in the air, lit warm so they only show inside a lamp pool. */
   dust: 0xd9b98a,
+  /** The approach outside the gate: bare grit, colder than the vault's floor. */
+  apron: 0x241f1c,
+  /** The gate's cog leaf, and the dressed stone portal it sits in. */
+  gateLeaf: 0x6f6152,
+  gatePortal: 0x574a3c,
 } as const;
 
 const DOOR_COLORS = { locked: 0xff3b3b, unlocked: 0x35f0b0 };
@@ -245,6 +261,8 @@ export class InfiltrationGame {
   /** Tracked separately from the card so pickup hides the glow with it. */
   private keycardHalo: THREE.Mesh | null = null;
   private hasKeycard = false;
+  /** Latches once the player is through the gate: the HUD's first milestone. */
+  private inside = false;
   private occluders: Occluder[] = [];
   private facilityHalfExtent = 0;
   private terminalWorld = new THREE.Vector3();
@@ -322,6 +340,7 @@ export class InfiltrationGame {
     this.keycardHalo = null;
     this.dust = null;
     this.hasKeycard = false;
+    this.inside = false;
     this.playerPath = [];
     this.clearScene();
     this.hackProgress = 0;
@@ -428,7 +447,14 @@ export class InfiltrationGame {
     // hall with a hotspot in the middle.
     // One source of truth for where light is: the meshes and the detection math
     // read the same list, so a shadow that looks safe on screen actually is.
-    this.lamps = lampPositions(this.level.rooms, (cell) => gridToWorld(cell, this.level));
+    // The gate carries a lamp of its own, on the approach side. It goes in the
+    // same list as the room lamps rather than being drawn separately, because
+    // detection reads this list: standing at the gate has to *be* as exposed as
+    // it looks, or the one place the player must cross would be a free hide.
+    this.lamps = [
+      ...lampPositions(this.level.rooms, (cell) => gridToWorld(cell, this.level)),
+      ...this.approachLampCells().map((cell) => gridToWorld(cell, this.level)),
+    ];
     for (const centre of this.lamps) {
       // The lit pool on screen ends exactly where detection stops counting the
       // player as lit — see LAMP_LIGHT_DISTANCE for why that is not LAMP_RADIUS
@@ -450,10 +476,19 @@ export class InfiltrationGame {
     this.scene.add(floor);
 
     this.buildPerimeter(floorSize);
-    for (const wallCell of this.level.walls) this.buildInteriorWall(wallCell);
+    this.buildApron();
+    // The facility's own perimeter is in the same wall list as its partitions,
+    // so it is raised the same way — one box per cell, so occlusion still fades
+    // only the segment covering the player. It is only tinted apart, as the
+    // outer shell of the building rather than a division inside it.
+    const shell = new Set(this.facilityShellCells().map(cellKey));
+    for (const wallCell of this.level.walls) {
+      this.buildInteriorWall(wallCell, shell.has(cellKey(wallCell)));
+    }
     for (const cell of pillarCells(this.level.walls, this.level.gridSize)) this.buildPillar(cell);
     for (const cratePos of this.level.crates) this.buildCrate(cratePos);
     for (const door of this.level.doors) this.buildDoor(door);
+    this.buildGate();
     this.buildRubble();
     this.buildDust(floorSize);
     this.buildTerminal();
@@ -467,6 +502,7 @@ export class InfiltrationGame {
   /** Pushes the current objective to the HUD, which owns no per-frame state itself. */
   private reportObjective() {
     this.callbacks.onObjectiveChange?.({
+      inside: this.inside,
       needsKeycard: this.level.doors.some((door) => door.locked),
       hasKeycard: this.hasKeycard,
     });
@@ -519,6 +555,279 @@ export class InfiltrationGame {
     this.occluders.push({ mesh: cap, material });
   }
 
+  /**
+   * Lamp cells strung down the approach, from the gate back towards the spawn.
+   *
+   * The apron is outside every room, so the per-room lamps leave it pitch dark
+   * and the opening walk is made across a floor the player cannot read. Lighting
+   * it also puts the crossing on the record the stealth math reads: the way in
+   * is lit, so it costs something.
+   */
+  private approachLampCells(): GridPos[] {
+    const { gate, spawn } = this.level;
+    const step = { x: Math.sign(spawn.x - gate.outside.x), z: Math.sign(spawn.z - gate.outside.z) };
+    const depth = Math.abs(spawn.x - gate.outside.x) + Math.abs(spawn.z - gate.outside.z);
+    const cells: GridPos[] = [gate.outside];
+    // Every third cell, so the pools overlap into a lit run rather than a line
+    // of separate spots with dark gaps between them.
+    for (let i = 3; i <= depth; i += 3) {
+      cells.push({ x: gate.outside.x + step.x * i, z: gate.outside.z + step.z * i });
+    }
+    return cells;
+  }
+
+  /** The cells of the facility's outer shell, as opposed to its partitions. */
+  private facilityShellCells(): GridPos[] {
+    const { facility } = this.level;
+    const cells: GridPos[] = [];
+    for (let x = facility.x; x < facility.x + facility.w; x++) {
+      for (let z = facility.z; z < facility.z + facility.h; z++) {
+        const onEdge =
+          x === facility.x ||
+          z === facility.z ||
+          x === facility.x + facility.w - 1 ||
+          z === facility.z + facility.h - 1;
+        if (onEdge) cells.push({ x, z });
+      }
+    }
+    return cells;
+  }
+
+  /**
+   * The open approach outside the gate.
+   *
+   * Laid as one square tile per cell rather than a single stretched plane: the
+   * apron is a long thin band, and a plane that shape would smear the flagstone
+   * pattern along its length while the floor inside kept its proper scale. The
+   * tiles share one geometry and one material, so this costs a draw call each
+   * and nothing else.
+   */
+  private buildApron() {
+    const size = this.level.cellSize;
+    const geometry = new THREE.PlaneGeometry(size, size);
+    const material = new THREE.MeshStandardMaterial({ color: PALETTE.apron, roughness: 1 });
+    applyTexture(material, stoneFloorTexture(1));
+
+    const { apron } = this.level;
+    for (let x = apron.x; x < apron.x + apron.w; x++) {
+      for (let z = apron.z; z < apron.z + apron.h; z++) {
+        const world = gridToWorld({ x, z }, this.level);
+        const tile = new THREE.Mesh(geometry, material);
+        tile.rotation.x = -Math.PI / 2;
+        // A hair above the vault floor beneath it, so the two never z-fight.
+        tile.position.set(world.x, 0.02, world.z);
+        this.scene.add(tile);
+      }
+    }
+  }
+
+  /**
+   * The one way in: a cog leaf in a dressed stone portal, set into the facility's
+   * outer wall where the approach meets it.
+   *
+   * It joins {@link doors} rather than being driven separately, so the sliding,
+   * the collider and the proximity trigger are the machinery the interior doors
+   * already use and there is one implementation of "a door is shut" for the
+   * pathfinder, the collision test and the sight lines to agree on. What is its
+   * own is the geometry and the turn it makes on the way down.
+   */
+  private buildGate() {
+    const { gate } = this.level;
+    const size = this.level.cellSize;
+    const world = gridToWorld(gate.pos, this.level);
+    const outside = gridToWorld(gate.outside, this.level);
+
+    // Taken from the cells rather than from `spansX` directly, so the portal is
+    // built from the same two points the level says the player passes between.
+    const through = new THREE.Vector3(outside.x - world.x, 0, outside.z - world.z).normalize();
+    const across = new THREE.Vector3(-through.z, 0, through.x);
+
+    const group = new THREE.Group();
+    group.position.set(world.x, 0, world.z);
+
+    // Plain iron, with no emissive of its own. The interior doors tint their
+    // whole panel by lock state, which works at that size; flooding a leaf this
+    // big with one colour drowns the ribs and the hub and leaves a flat disc.
+    // The status light is a ring on the hub instead — see `statusMaterial`.
+    // Low metalness on purpose. There is no environment map down here, so a
+    // near-metal surface has almost nothing to reflect and renders black however
+    // hard the gate lamp is driven — which is what a cast leaf this size did on
+    // the first pass. Dialled back, the ribs catch the lamp and read as relief.
+    const material = new THREE.MeshStandardMaterial({
+      color: PALETTE.gateLeaf,
+      roughness: 0.62,
+      metalness: 0.25,
+    });
+    applyTexture(material, ironTexture(1));
+
+    // The leaf and everything bolted to it turn together, so the spin lives on a
+    // group inside the one holding the orientation: setting a rotation on the
+    // oriented group directly would fight the quaternion aiming it down the
+    // passage.
+    const wheel = new THREE.Group();
+    wheel.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), through);
+    const spinner = new THREE.Group();
+    wheel.add(spinner);
+
+    // Sized to clear the jambs below rather than to fill the cell: a leaf wider
+    // than the opening is clipped down both sides, and a circle with its sides
+    // shaved off stops reading as a wheel and starts reading as a slot.
+    const radius = size * 0.42;
+    const thickness = size * 0.3;
+    const disc = new THREE.Mesh(
+      new THREE.CylinderGeometry(radius, radius, thickness, 24),
+      material
+    );
+    spinner.add(disc);
+
+    // Ribs and a hub on the disc's face. Local Y is the passage axis here, so a
+    // rib is laid flat across the face and stands a little proud of both sides.
+    for (let i = 0; i < 6; i++) {
+      const rib = new THREE.Mesh(
+        new THREE.BoxGeometry(radius * 1.7, thickness * 1.18, size * 0.07),
+        material
+      );
+      rib.rotation.y = (i * Math.PI) / 6;
+      spinner.add(rib);
+    }
+    const ring = new THREE.Mesh(
+      new THREE.TorusGeometry(radius * 0.66, size * 0.045, 6, 20),
+      material
+    );
+    ring.rotation.x = Math.PI / 2;
+    spinner.add(ring);
+    const hub = new THREE.Mesh(
+      new THREE.CylinderGeometry(radius * 0.26, radius * 0.26, thickness * 1.5, 12),
+      material
+    );
+    spinner.add(hub);
+
+    // The status light: the one lit thing on the leaf, so lock state still reads
+    // at a glance without the whole gate turning green. It is what `updateDoors`
+    // tints, which is why the Door record below carries it as its material.
+    const statusMaterial = new THREE.MeshStandardMaterial({
+      color: PALETTE.gateLeaf,
+      emissive: DOOR_COLORS.unlocked,
+      emissiveIntensity: 1.2,
+      roughness: 0.4,
+      metalness: 0.2,
+    });
+    for (const face of [-1, 1]) {
+      const status = new THREE.Mesh(
+        new THREE.TorusGeometry(radius * 0.3, size * 0.035, 6, 16),
+        statusMaterial
+      );
+      status.rotation.x = Math.PI / 2;
+      status.position.y = face * thickness * 0.78;
+      spinner.add(status);
+    }
+
+    // Sat just clear of the floor, and low enough that a DOOR_HEIGHT retraction
+    // takes the whole leaf out of the opening. Pushed out towards the approach
+    // face too, so it is hung in the opening where it can be seen rather than
+    // buried in the middle of the wall's thickness.
+    wheel.position.y = radius + 0.08;
+    wheel.position.x = through.x * size * 0.16;
+    wheel.position.z = through.z * size * 0.16;
+    group.add(wheel);
+    this.scene.add(group);
+
+    const portalMaterial = new THREE.MeshStandardMaterial({
+      color: PALETTE.gatePortal,
+      roughness: 0.88,
+    });
+    applyTexture(portalMaterial, masonryTexture(1));
+    const portalHeight = WALL_HEIGHT + GATE_PORTAL_RISE;
+
+    // Jambs either side and a lintel over the top: the stone the leaf is hung
+    // in, and what fills the wall between the top of the disc and the parapet.
+    // All of it sits inside the gate cell the collider already covers, so none
+    // of it is an obstacle the pathfinder does not know about.
+    //
+    // Both vectors are axis-aligned and one of them is zero on each axis, so a
+    // box is sized by saying how wide it is across the opening and how deep it
+    // is along the passage, and letting the orientation sort out which is which.
+    const boxFor = (widthAcross: number, depthThrough: number) =>
+      new THREE.BoxGeometry(
+        Math.abs(across.x) * widthAcross + Math.abs(through.x) * depthThrough,
+        portalHeight,
+        Math.abs(across.z) * widthAcross + Math.abs(through.z) * depthThrough
+      );
+
+    // Deliberately slim. Jambs at any real thickness close over the edges of the
+    // leaf from an isometric angle, and what is left of it between them is a
+    // slit; these read as a dressed edge to the opening and leave the wheel
+    // whole.
+    const jambInset = size * 0.46;
+    const jambWidth = size * 0.07;
+    // Shallow on purpose. Jambs with real depth make a tunnel, and from a fixed
+    // isometric angle the near one cuts across the opening diagonally: the wheel
+    // behind it is reduced to a tall slot however wide the gap between them is.
+    const depth = size * 0.34;
+    for (const side of [-1, 1]) {
+      const jamb = new THREE.Mesh(boxFor(jambWidth, depth), portalMaterial);
+      jamb.position.set(
+        world.x + across.x * side * jambInset,
+        portalHeight / 2,
+        world.z + across.z * side * jambInset
+      );
+      this.scene.add(jamb);
+      this.occluders.push({ mesh: jamb, material: portalMaterial });
+    }
+
+    // The lintel spans the full opening, from just above the leaf to the top of
+    // the portal. Scaled rather than rebuilt, since it differs only in height.
+    const lintelBase = radius * 2 + 0.16;
+    const lintel = new THREE.Mesh(boxFor(size, depth), portalMaterial);
+    lintel.scale.y = (portalHeight - lintelBase) / portalHeight;
+    lintel.position.set(world.x, (portalHeight + lintelBase) / 2, world.z);
+    this.scene.add(lintel);
+    this.occluders.push({ mesh: lintel, material: portalMaterial });
+    this.buildWallCap(world.x, world.z, size, size, portalHeight);
+
+    // A lamp bracketed to the portal, over the leaf.
+    //
+    // The approach lamp hanging over `gate.outside` lights the ground the player
+    // crosses, but the leaf stands in its own recess between the jambs and under
+    // the lintel, and from a cell away and five metres up almost nothing reaches
+    // it — the cog came out a black hole with a status light floating in it. This
+    // sits inside that lamp's pool rather than beside it, so it changes how the
+    // gate *looks* without putting light anywhere the detection math is unaware
+    // of.
+    const bracketPos = new THREE.Vector3(
+      world.x + through.x * size * 0.62,
+      DOOR_HEIGHT * 0.92,
+      world.z + through.z * size * 0.62
+    );
+    const bracket = new THREE.PointLight(PALETTE.lamp, LAMP_INTENSITY * 0.7, size * 2.1, 1);
+    bracket.position.copy(bracketPos);
+    this.scene.add(bracket);
+    const bulb = new THREE.Mesh(
+      new THREE.SphereGeometry(size * 0.07, 10, 8),
+      new THREE.MeshStandardMaterial({
+        color: PALETTE.lamp,
+        emissive: PALETTE.lamp,
+        emissiveIntensity: 1.4,
+      })
+    );
+    bulb.position.copy(bracketPos);
+    this.scene.add(bulb);
+
+    this.doors.push({
+      // The gate is not a division between two rooms — one side of it is the
+      // approach — so it carries the room it opens onto twice. Nothing reads
+      // these indices except the interior doors' own panel orientation, which
+      // this geometry does not use.
+      def: { pos: gate.pos, locked: false, rooms: [gate.room, gate.room] },
+      group,
+      material: statusMaterial,
+      world: new THREE.Vector3(world.x, 0, world.z),
+      box: boxAround(world.x, world.z, size),
+      openness: 0,
+      wheel: spinner,
+    });
+  }
+
   /** A waist-high timber crate: cover from sight, and a solid box for collision. */
   private buildCrate(gridPos: GridPos) {
     const world = gridToWorld(gridPos, this.level);
@@ -554,11 +863,11 @@ export class InfiltrationGame {
    * One box per interior wall cell rather than per wall run: the occlusion fade
    * then dissolves just the segment covering the player instead of a whole wall.
    */
-  private buildInteriorWall(cell: GridPos) {
+  private buildInteriorWall(cell: GridPos, isShell = false) {
     const world = gridToWorld(cell, this.level);
     const size = this.level.cellSize;
     const material = new THREE.MeshStandardMaterial({
-      color: PALETTE.interiorWall,
+      color: isShell ? PALETTE.perimeterWall : PALETTE.interiorWall,
       roughness: 0.95,
     });
     applyTexture(material, masonryTexture(1));
@@ -717,6 +1026,7 @@ export class InfiltrationGame {
       world: new THREE.Vector3(world.x, 0, world.z),
       box: boxAround(world.x, world.z, size),
       openness: 0,
+      wheel: null,
     });
   }
 
@@ -1357,6 +1667,7 @@ export class InfiltrationGame {
       this.updateGuards(dt);
       this.updateDoors(dt);
       this.updateKeycard();
+      this.updateEntry();
       this.updateHack(dt);
       // Both cooldowns are game time, so they stop with the simulation: ticking
       // them while paused would let a player tap Esc to refresh their throw, or
@@ -1556,6 +1867,8 @@ export class InfiltrationGame {
       );
       // The panel retracts into the floor; the frame above it stays put.
       door.group.position.y = -door.openness * DOOR_HEIGHT;
+      // The gate turns as it goes, so it disengages rather than simply dropping.
+      if (door.wheel) door.wheel.rotation.y = door.openness * GATE_SPIN;
 
       const passable = !door.def.locked || this.hasKeycard;
       door.material.emissive.setHex(passable ? DOOR_COLORS.unlocked : DOOR_COLORS.locked);
@@ -1571,6 +1884,27 @@ export class InfiltrationGame {
     return this.guards.some(
       (guard) => guard.group.position.distanceTo(door.world) <= DOOR_TRIGGER_RANGE
     );
+  }
+
+  /**
+   * Notices the first time the player is through the gate.
+   *
+   * It latches rather than tracking where the player is: the approach is behind
+   * them from then on, and a HUD line that flickered back to "cross the
+   * approach" every time they stepped near the gate would be noise.
+   */
+  private updateEntry() {
+    if (this.inside) return;
+    const cell = worldToGrid(this.player.position.x, this.player.position.z, this.level);
+    const { facility } = this.level;
+    const within =
+      cell.x > facility.x &&
+      cell.z > facility.z &&
+      cell.x < facility.x + facility.w - 1 &&
+      cell.z < facility.z + facility.h - 1;
+    if (!within) return;
+    this.inside = true;
+    this.reportObjective();
   }
 
   /** Picks the keycard up on contact, which unlocks every locked door. */

--- a/client/src/game/infiltration-game.ts
+++ b/client/src/game/infiltration-game.ts
@@ -599,8 +599,10 @@ export class InfiltrationGame {
    * Laid as one square tile per cell rather than a single stretched plane: the
    * apron is a long thin band, and a plane that shape would smear the flagstone
    * pattern along its length while the floor inside kept its proper scale. The
-   * tiles share one geometry and one material, so this costs a draw call each
-   * and nothing else.
+   * tiles share one geometry and one material, so the apron adds nothing to the
+   * GPU beyond one draw call per cell — sharing does not merge meshes into a
+   * single call. At an apron's size that is a few dozen quads, which is not
+   * worth the `InstancedMesh` it would take to draw them in one.
    */
   private buildApron() {
     const size = this.level.cellSize;
@@ -732,11 +734,22 @@ export class InfiltrationGame {
     group.add(wheel);
     this.scene.add(group);
 
-    const portalMaterial = new THREE.MeshStandardMaterial({
-      color: PALETTE.gatePortal,
-      roughness: 0.88,
-    });
-    applyTexture(portalMaterial, masonryTexture(1));
+    // A fresh material per piece, not one shared across the three.
+    //
+    // `updateOcclusion` walks the occluder list and writes `material.opacity`
+    // for every entry, so three entries pointing at one material fight over it
+    // within a single frame: the two that are not covering the player pull it
+    // back to 1 while the one that is pulls it down, and the fade never settles
+    // where it should. `buildPerimeter` keeps a material per wall for exactly
+    // this reason, and the gate is on the one route every run must take.
+    const portalMaterialFor = () => {
+      const material = new THREE.MeshStandardMaterial({
+        color: PALETTE.gatePortal,
+        roughness: 0.88,
+      });
+      applyTexture(material, masonryTexture(1));
+      return material;
+    };
     const portalHeight = WALL_HEIGHT + GATE_PORTAL_RISE;
 
     // Jambs either side and a lintel over the top: the stone the leaf is hung
@@ -765,24 +778,26 @@ export class InfiltrationGame {
     // behind it is reduced to a tall slot however wide the gap between them is.
     const depth = size * 0.34;
     for (const side of [-1, 1]) {
-      const jamb = new THREE.Mesh(boxFor(jambWidth, depth), portalMaterial);
+      const jambMaterial = portalMaterialFor();
+      const jamb = new THREE.Mesh(boxFor(jambWidth, depth), jambMaterial);
       jamb.position.set(
         world.x + across.x * side * jambInset,
         portalHeight / 2,
         world.z + across.z * side * jambInset
       );
       this.scene.add(jamb);
-      this.occluders.push({ mesh: jamb, material: portalMaterial });
+      this.occluders.push({ mesh: jamb, material: jambMaterial });
     }
 
     // The lintel spans the full opening, from just above the leaf to the top of
     // the portal. Scaled rather than rebuilt, since it differs only in height.
     const lintelBase = radius * 2 + 0.16;
-    const lintel = new THREE.Mesh(boxFor(size, depth), portalMaterial);
+    const lintelMaterial = portalMaterialFor();
+    const lintel = new THREE.Mesh(boxFor(size, depth), lintelMaterial);
     lintel.scale.y = (portalHeight - lintelBase) / portalHeight;
     lintel.position.set(world.x, (portalHeight + lintelBase) / 2, world.z);
     this.scene.add(lintel);
-    this.occluders.push({ mesh: lintel, material: portalMaterial });
+    this.occluders.push({ mesh: lintel, material: lintelMaterial });
     this.buildWallCap(world.x, world.z, size, size, portalHeight);
 
     // A lamp bracketed to the portal, over the leaf.

--- a/client/src/game/level.ts
+++ b/client/src/game/level.ts
@@ -19,6 +19,29 @@ export interface DoorDef {
   rooms: [number, number];
 }
 
+/**
+ * Which grid edge the open approach sits against, and so which face of the
+ * facility carries the gate.
+ */
+export type ApronSide = "north" | "south" | "east" | "west";
+
+/** The one way in through the facility's perimeter wall. */
+export interface GateDef {
+  /** The gate cell itself, punched out of the perimeter wall. */
+  pos: GridPos;
+  /**
+   * True when the wall this gate sits in runs along x, so the gate panel spans
+   * x and the player passes through it along z. The engine needs this to orient
+   * the leaf, and it cannot be derived from rooms the way interior doors are:
+   * one side of a gate is not a room at all.
+   */
+  spansX: boolean;
+  /** The apron cell immediately outside, where the approach ends. */
+  outside: GridPos;
+  /** Index into {@link GeneratedLevel.rooms} of the room it opens into. */
+  room: number;
+}
+
 /** Knobs the generator reads; {@link DEFAULT_LEVEL_CONFIG} supplies every default. */
 export interface LevelConfig {
   gridSize: number;
@@ -27,6 +50,8 @@ export interface LevelConfig {
   crateDensity: number;
   guardCount: number;
   waypointsPerGuard: number;
+  /** Depth of the open approach outside the facility, in cells. */
+  apronDepth: number;
 }
 
 /** One fully generated facility: its geometry, its objectives and its patrols. */
@@ -34,10 +59,21 @@ export interface GeneratedLevel {
   gridSize: number;
   cellSize: number;
   rooms: Rect[];
-  /** Interior wall cells. The outer ring is implicit and not listed here. */
+  /**
+   * Every wall cell: the facility's own perimeter ring as well as the interior
+   * partitions. Only the grid's outer ring is implicit and unlisted — that is
+   * the rock the whole map is cut out of, not part of the building.
+   */
   walls: GridPos[];
   doors: DoorDef[];
+  /** The facility's footprint, perimeter wall included. */
+  facility: Rect;
+  /** The approach outside the facility: open ground, no roof, no patrols. */
+  apron: Rect;
+  apronSide: ApronSide;
+  gate: GateDef;
   crates: GridPos[];
+  /** Where the run starts — out on the apron, facing the gate. */
   spawn: GridPos;
   terminal: GridPos;
   /** Null when the layout has no locked door, so no keycard is needed. */
@@ -46,23 +82,30 @@ export interface GeneratedLevel {
 }
 
 export const DEFAULT_LEVEL_CONFIG: LevelConfig = {
-  gridSize: 21,
+  // Wider than the facility needs: the extra rows are the apron the player
+  // crosses before the gate, so the building keeps the size it always had.
+  gridSize: 26,
   cellSize: 3,
   roomCount: 5,
   crateDensity: 0.1,
   guardCount: 3,
   waypointsPerGuard: 3,
+  apronDepth: 4,
 };
+
+/** The four approach sides, in a fixed order so a seed always picks the same one. */
+const APRON_SIDES: readonly ApronSide[] = ["north", "south", "east", "west"];
+/** Keeps the gate off the corners of the face it sits in. */
+const GATE_EDGE_MARGIN = 2;
 
 /** Smallest floor span a room may have on either axis. */
 const MIN_ROOM_SPAN = 4;
 /** Doors are kept off a wall's ends so they never open into a corner. */
 const DOOR_EDGE_MARGIN = 1;
 
-/** One BSP cut: the wall line it lays down, its single door, and the halves either side. */
+/** One BSP cut: the wall line it lays down and the halves either side of it. */
 interface Split {
   wall: GridPos[];
-  door: GridPos;
   a: Rect;
   b: Rect;
 }
@@ -90,8 +133,9 @@ function rectCells(rect: Rect): GridPos[] {
 
 /**
  * Cuts a rectangle in two along its longer axis, reserving one cell line for the
- * dividing wall and punching a single door through it. Returns null when neither
- * axis has room for two rooms plus that wall.
+ * dividing wall. Returns null when neither axis has room for two rooms plus that
+ * wall. The door through the wall is punched later, by {@link pickDoorInWall},
+ * once every cut is known.
  */
 function splitRect(rect: Rect, rand: () => number): Split | null {
   const canSplitZ = rect.h >= MIN_ROOM_SPAN * 2 + 1;
@@ -112,11 +156,6 @@ function splitRect(rect: Rect, rand: () => number): Split | null {
     wall.push(splitAlongZ ? { x: c, z: wallLine } : { x: wallLine, z: c });
   }
 
-  // Keep the door off the wall's ends so there is floor either side of it.
-  const doorRange = Math.max(1, crossSpan - DOOR_EDGE_MARGIN * 2);
-  const doorOffset = Math.min(crossSpan - 1, DOOR_EDGE_MARGIN + Math.floor(rand() * doorRange));
-  const door = wall[doorOffset];
-
   const a: Rect = splitAlongZ
     ? { x: rect.x, z: rect.z, w: rect.w, h: wallLine - rect.z }
     : { x: rect.x, z: rect.z, w: wallLine - rect.x, h: rect.h };
@@ -124,7 +163,7 @@ function splitRect(rect: Rect, rand: () => number): Split | null {
     ? { x: rect.x, z: wallLine + 1, w: rect.w, h: rect.z + rect.h - wallLine - 1 }
     : { x: wallLine + 1, z: rect.z, w: rect.x + rect.w - wallLine - 1, h: rect.h };
 
-  return { wall, door, a, b };
+  return { wall, a, b };
 }
 
 /** The two room indices a door connects, found from the cells either side of it. */
@@ -144,7 +183,38 @@ function roomsBesideDoor(rooms: Rect[], door: GridPos): [number, number] | null 
 }
 
 /**
- * Binary-space partitions the interior into rooms. Each split contributes one
+ * Chooses the one cell of a wall line to leave open as a door.
+ *
+ * Only cells with a room on either side qualify: a later perpendicular cut can
+ * lay wall against this line, and a door there would open into stone. Picking
+ * the door *after* every cut is known is what keeps the room graph a tree —
+ * choosing it during the split and sealing it later when a cut spoiled it used
+ * to drop that split's edge, and a level whose graph had fallen apart has no
+ * route to lock and so no keycard to find.
+ */
+function pickDoorInWall(
+  wall: readonly GridPos[],
+  rooms: Rect[],
+  rand: () => number
+): DoorDef | null {
+  const candidates: { pos: GridPos; rooms: [number, number]; edge: number }[] = [];
+  for (let i = 0; i < wall.length; i++) {
+    const joined = roomsBesideDoor(rooms, wall[i]);
+    if (!joined) continue;
+    candidates.push({ pos: wall[i], rooms: joined, edge: Math.min(i, wall.length - 1 - i) });
+  }
+  if (candidates.length === 0) return null;
+
+  // Prefer a door clear of the wall's ends so there is floor either side of it,
+  // but never at the cost of having no door at all on a short or crowded line.
+  const reach = Math.min(DOOR_EDGE_MARGIN, Math.max(...candidates.map((c) => c.edge)));
+  const preferred = candidates.filter((c) => c.edge >= reach);
+  const pick = preferred[Math.floor(rand() * preferred.length)];
+  return { pos: pick.pos, locked: false, rooms: pick.rooms };
+}
+
+/**
+ * Binary-space partitions the interior into rooms. Each cut contributes one
  * wall and exactly one door, so the room graph comes out a tree: always
  * connected, and with every door a bridge between the halves it joins.
  */
@@ -170,25 +240,17 @@ function partitionRooms(interior: Rect, roomCount: number, rand: () => number) {
   }
 
   const doors: DoorDef[] = [];
-  const orphans: GridPos[] = [];
+  const openings = new Set<string>();
   for (const split of splits) {
-    const joined = roomsBesideDoor(rooms, split.door);
-    if (joined) doors.push({ pos: split.door, locked: false, rooms: joined });
-    // A later perpendicular split can wall off the cell beside an earlier door,
-    // leaving that door joining fewer than two rooms. Its cell was already
-    // removed from its own wall line, so without sealing it here it becomes a
-    // gap that is neither floor, wall nor door — and so gets no collider at all.
-    else orphans.push(split.door);
+    const door = pickDoorInWall(split.wall, rooms, rand);
+    if (!door) continue;
+    doors.push(door);
+    openings.add(cellKey(door.pos));
   }
 
-  const cut = splits.flatMap((split) => split.wall.filter((cell) => !sameCell(cell, split.door)));
-  const seen = new Set<string>();
-  const walls = [...cut, ...orphans].filter((cell) => {
-    const key = cellKey(cell);
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
+  const walls = splits.flatMap((split) =>
+    split.wall.filter((cell) => !openings.has(cellKey(cell)))
+  );
 
   return { rooms, walls, doors };
 }
@@ -388,6 +450,154 @@ function assignGuardWaypoints(
   return guards;
 }
 
+/** The ring of cells enclosing a rectangle's floor area. */
+function ringCells(outer: Rect, inner: Rect): GridPos[] {
+  return rectCells(outer).filter((cell) => !rectContains(inner, cell));
+}
+
+/** How the grid divides into an approach and the walled facility beyond it. */
+interface Compound {
+  /** The facility footprint, perimeter wall included. */
+  facility: Rect;
+  /** The BSP area inside that wall. */
+  interior: Rect;
+  /** The open ground outside the gate. */
+  apron: Rect;
+  apronSide: ApronSide;
+  /** True when the gate's wall runs along x, so the player enters along z. */
+  spansX: boolean;
+  /** The facility face the apron looks at, as a constant on the gate's axis. */
+  gateLine: number;
+  /** Step from the gate towards the apron: -1 or +1 on the entry axis. */
+  outward: number;
+}
+
+/**
+ * Splits the grid interior into an apron and a walled facility.
+ *
+ * The apron is a band against one seeded edge; the facility takes the rest, and
+ * the face between them is where the gate will go. The gate itself is not
+ * chosen here — see {@link pickGate}, which needs the rooms first.
+ */
+function layOutCompound(gridSize: number, apronDepth: number, rand: () => number): Compound {
+  const side = APRON_SIDES[Math.floor(rand() * APRON_SIDES.length)];
+  const low = 1;
+  const span = Math.max(1, gridSize - 2);
+  const alongZ = side === "north" || side === "south";
+  // "north"/"west" put the apron at the low end of their axis; the other two
+  // put it at the high end, and the facility takes whatever is left.
+  const apronAtLow = side === "north" || side === "west";
+  // The apron is carved *out of* the span rather than added to it, so the two
+  // always tile the grid exactly. A facility needs three cells on this axis to
+  // have an interior at all, and on a grid too small to afford the configured
+  // approach the apron gives way rather than running off the edge and stranding
+  // the spawn outside the world.
+  const depth = Math.max(1, Math.min(apronDepth, span - 3));
+  const facilitySpan = span - depth;
+
+  const apronStart = apronAtLow ? low : low + facilitySpan;
+  const facilityStart = apronAtLow ? low + depth : low;
+
+  const facility: Rect = alongZ
+    ? { x: low, z: facilityStart, w: span, h: facilitySpan }
+    : { x: facilityStart, z: low, w: facilitySpan, h: span };
+  const apron: Rect = alongZ
+    ? { x: low, z: apronStart, w: span, h: depth }
+    : { x: apronStart, z: low, w: depth, h: span };
+  const interior: Rect = {
+    x: facility.x + 1,
+    z: facility.z + 1,
+    w: Math.max(1, facility.w - 2),
+    h: Math.max(1, facility.h - 2),
+  };
+
+  const gateLine = alongZ
+    ? apronAtLow
+      ? facility.z
+      : facility.z + facility.h - 1
+    : apronAtLow
+      ? facility.x
+      : facility.x + facility.w - 1;
+
+  return {
+    facility,
+    interior,
+    apron,
+    apronSide: side,
+    spansX: alongZ,
+    gateLine,
+    outward: apronAtLow ? -1 : 1,
+  };
+}
+
+/** A gate and the two cells either side of it. */
+interface GateChoice {
+  gate: GateDef;
+  inner: GridPos;
+  spawn: GridPos;
+}
+
+/**
+ * Punches the gate through the facility face the apron looks at.
+ *
+ * Candidates are limited to positions whose *inner* neighbour is open room
+ * floor: a BSP partition can meet the perimeter anywhere along that face, and a
+ * gate opening onto the end of one would lead into solid wall. Corners are
+ * excluded too, so the gate always has building either side of it.
+ */
+function pickGate(
+  compound: Compound,
+  rooms: Rect[],
+  doors: DoorDef[],
+  partitionWalls: ReadonlySet<string>,
+  rand: () => number
+): GateChoice | null {
+  const { interior, apron, spansX, gateLine, outward } = compound;
+  const crossStart = spansX ? interior.x : interior.z;
+  const crossSpan = spansX ? interior.w : interior.h;
+  // Corners are excluded so the gate always has building either side of it —
+  // except on a face too short to afford that, where any position beats none.
+  const margin = Math.min(GATE_EDGE_MARGIN, Math.floor((crossSpan - 1) / 2));
+
+  const candidates: GateChoice[] = [];
+  for (let i = margin; i < crossSpan - margin; i++) {
+    const cross = crossStart + i;
+    const pos: GridPos = spansX ? { x: cross, z: gateLine } : { x: gateLine, z: cross };
+    const inner: GridPos = spansX
+      ? { x: cross, z: gateLine - outward }
+      : { x: gateLine - outward, z: cross };
+    if (partitionWalls.has(cellKey(inner))) continue;
+    const room = rooms.findIndex((rect) => rectContains(rect, inner));
+    if (room < 0) continue;
+
+    const outside: GridPos = spansX
+      ? { x: cross, z: gateLine + outward }
+      : { x: gateLine + outward, z: cross };
+    // The far edge of the apron, straight out from the gate, so the run opens
+    // with the whole approach and the way in already lined up.
+    const spawnLine = outward < 0 ? apron.z : apron.z + apron.h - 1;
+    const spawnCol = outward < 0 ? apron.x : apron.x + apron.w - 1;
+    const spawn: GridPos = spansX ? { x: cross, z: spawnLine } : { x: spawnCol, z: cross };
+
+    candidates.push({ gate: { pos, spansX, outside, room }, inner, spawn });
+  }
+
+  if (candidates.length === 0) return null;
+
+  // Sealing an orphaned door can split the room graph, and a gate opening into
+  // a stranded room would leave the terminal and the keycard on the far side of
+  // a wall with no door. Entering through the best-connected room avoids that:
+  // the deepest room from there is then a real destination, so the lock and the
+  // keycard detour both have somewhere to go.
+  const reach = candidates.map(
+    (candidate) =>
+      roomHops(rooms, doors, candidate.gate.room).hops.filter((hop) => hop !== Infinity).length
+  );
+  const best = Math.max(...reach);
+  const bestCandidates = candidates.filter((_, index) => reach[index] === best);
+  return bestCandidates[Math.floor(rand() * bestCandidates.length)];
+}
+
 /**
  * Generates a facility from a numeric seed: BSP rooms joined by doors, the door
  * into the terminal's room locked, a keycard on the near side of that lock,
@@ -396,42 +606,57 @@ function assignGuardWaypoints(
 export function generateLevel(seed: number, overrides: Partial<LevelConfig> = {}): GeneratedLevel {
   const config = { ...DEFAULT_LEVEL_CONFIG, ...overrides };
   const rand = mulberry32(seed);
-  const interior: Rect = {
-    x: 1,
-    z: 1,
-    w: Math.max(1, config.gridSize - 2),
-    h: Math.max(1, config.gridSize - 2),
-  };
+  const compound = layOutCompound(config.gridSize, config.apronDepth, rand);
+  const { interior, facility, apron } = compound;
 
-  const { rooms, walls, doors } = partitionRooms(interior, config.roomCount, rand);
+  const partition = partitionRooms(interior, config.roomCount, rand);
+  const { rooms, doors } = partition;
+  const partitionWalls = new Set(partition.walls.map(cellKey));
+
+  // Every position along the face is a candidate, so this only comes back null
+  // for a facility too small to have a face at all — not for any real config.
+  const choice = pickGate(compound, rooms, doors, partitionWalls, rand);
+  if (!choice) throw new Error(`seed ${seed}: no gate position on the facility face`);
+  const { gate, spawn } = choice;
+
+  // The facility's own perimeter is real, listed wall — the gate is simply the
+  // one cell missing from it, so nothing else has to know a gate exists to
+  // treat the rest of that ring as solid.
+  const perimeter = ringCells(facility, interior).filter((cell) => !sameCell(cell, gate.pos));
+  const walls = [...partition.walls, ...perimeter];
   const structural = new Set(walls.map(cellKey));
 
-  // Enter from the room nearest the grid origin, so the way in is always a corner.
-  const spawnRoom = rooms.reduce(
-    (best, room, index) => (room.x + room.z < rooms[best].x + rooms[best].z ? index : best),
-    0
-  );
-  const spawn: GridPos = { x: rooms[spawnRoom].x, z: rooms[spawnRoom].z };
+  // The run starts outside, so the room the layout is measured from is the one
+  // behind the gate: the first thing the player reaches indoors.
+  const entryRoom = gate.room;
 
-  const { hops, via } = roomHops(rooms, doors, spawnRoom);
+  const { hops, via } = roomHops(rooms, doors, entryRoom);
   const terminalRoom = hops.reduce(
     (best, value, index) => (value !== Infinity && value > hops[best] ? index : best),
-    spawnRoom
+    entryRoom
   );
-  const terminal = farthestCellIn(rooms[terminalRoom], spawn, structural);
+  const terminal = farthestCellIn(rooms[terminalRoom], gate.pos, structural);
 
   // The door into the terminal's room is the one worth locking: it is the last
   // bridge on the route, so the keycard detour can never be skipped.
-  const route = doorsOnRoute(via, spawnRoom, terminalRoom);
+  const route = doorsOnRoute(via, entryRoom, terminalRoom);
   const lockedDoor = route.length > 0 ? route[0] : null;
   if (lockedDoor) lockedDoor.locked = true;
 
   const keycard = lockedDoor
-    ? pickKeycardCell(rooms, doors, lockedDoor, spawnRoom, spawn, structural)
+    ? pickKeycardCell(rooms, doors, lockedDoor, entryRoom, gate.pos, structural)
     : null;
 
   const reserved = new Set(
-    [spawn, terminal, ...(keycard ? [keycard] : []), ...doorApproaches(doors)].map(cellKey)
+    [
+      spawn,
+      terminal,
+      gate.pos,
+      gate.outside,
+      choice.inner,
+      ...(keycard ? [keycard] : []),
+      ...doorApproaches(doors),
+    ].map(cellKey)
   );
   const crates = placeCrates(
     rooms,
@@ -444,10 +669,10 @@ export function generateLevel(seed: number, overrides: Partial<LevelConfig> = {}
   );
 
   const blockedForGuards = new Set([...structural, ...crates.map(cellKey)]);
-  const patrolRooms = rooms.map((_, index) => index).filter((index) => index !== spawnRoom);
+  const patrolRooms = rooms.map((_, index) => index).filter((index) => index !== entryRoom);
   const guards = assignGuardWaypoints(
     rooms,
-    patrolRooms.length > 0 ? patrolRooms : [spawnRoom],
+    patrolRooms.length > 0 ? patrolRooms : [entryRoom],
     config,
     blockedForGuards,
     rand
@@ -459,6 +684,10 @@ export function generateLevel(seed: number, overrides: Partial<LevelConfig> = {}
     rooms,
     walls,
     doors,
+    facility,
+    apron,
+    apronSide: compound.apronSide,
+    gate,
     crates,
     spawn,
     terminal,

--- a/client/src/game/level.ts
+++ b/client/src/game/level.ts
@@ -511,13 +511,12 @@ function layOutCompound(gridSize: number, apronDepth: number, rand: () => number
     h: Math.max(1, facility.h - 2),
   };
 
-  const gateLine = alongZ
-    ? apronAtLow
-      ? facility.z
-      : facility.z + facility.h - 1
-    : apronAtLow
-      ? facility.x
-      : facility.x + facility.w - 1;
+  // The facility's extent on the entry axis, then whichever end of it the apron
+  // is on. Split in two rather than nested: the axis choice and the end choice
+  // are independent, and folding them together reads as one four-way decision.
+  const faceStart = alongZ ? facility.z : facility.x;
+  const faceSpan = alongZ ? facility.h : facility.w;
+  const gateLine = apronAtLow ? faceStart : faceStart + faceSpan - 1;
 
   return {
     facility,
@@ -538,6 +537,35 @@ interface GateChoice {
 }
 
 /**
+ * Works out the gate one position along the face would make, or null when that
+ * position is unusable because the cell inside it is not open room floor.
+ *
+ * Split out of {@link pickGate} so that function is left with the two decisions
+ * that matter — which positions to try, and which of them to take — rather than
+ * the axis arithmetic for every cell either side of the opening.
+ */
+function gateCandidateAt(compound: Compound, cross: number, rooms: Rect[]): GateChoice | null {
+  const { apron, spansX, gateLine, outward } = compound;
+  const inner: GridPos = spansX
+    ? { x: cross, z: gateLine - outward }
+    : { x: gateLine - outward, z: cross };
+  const room = rooms.findIndex((rect) => rectContains(rect, inner));
+  if (room < 0) return null;
+
+  const pos: GridPos = spansX ? { x: cross, z: gateLine } : { x: gateLine, z: cross };
+  const outside: GridPos = spansX
+    ? { x: cross, z: gateLine + outward }
+    : { x: gateLine + outward, z: cross };
+  // The far edge of the apron, straight out from the gate, so the run opens
+  // with the whole approach and the way in already lined up.
+  const spawnLine = outward < 0 ? apron.z : apron.z + apron.h - 1;
+  const spawnCol = outward < 0 ? apron.x : apron.x + apron.w - 1;
+  const spawn: GridPos = spansX ? { x: cross, z: spawnLine } : { x: spawnCol, z: cross };
+
+  return { gate: { pos, spansX, outside, room }, inner, spawn };
+}
+
+/**
  * Punches the gate through the facility face the apron looks at.
  *
  * Candidates are limited to positions whose *inner* neighbour is open room
@@ -552,7 +580,7 @@ function pickGate(
   partitionWalls: ReadonlySet<string>,
   rand: () => number
 ): GateChoice | null {
-  const { interior, apron, spansX, gateLine, outward } = compound;
+  const { interior, spansX } = compound;
   const crossStart = spansX ? interior.x : interior.z;
   const crossSpan = spansX ? interior.w : interior.h;
   // Corners are excluded so the gate always has building either side of it —
@@ -561,25 +589,9 @@ function pickGate(
 
   const candidates: GateChoice[] = [];
   for (let i = margin; i < crossSpan - margin; i++) {
-    const cross = crossStart + i;
-    const pos: GridPos = spansX ? { x: cross, z: gateLine } : { x: gateLine, z: cross };
-    const inner: GridPos = spansX
-      ? { x: cross, z: gateLine - outward }
-      : { x: gateLine - outward, z: cross };
-    if (partitionWalls.has(cellKey(inner))) continue;
-    const room = rooms.findIndex((rect) => rectContains(rect, inner));
-    if (room < 0) continue;
-
-    const outside: GridPos = spansX
-      ? { x: cross, z: gateLine + outward }
-      : { x: gateLine + outward, z: cross };
-    // The far edge of the apron, straight out from the gate, so the run opens
-    // with the whole approach and the way in already lined up.
-    const spawnLine = outward < 0 ? apron.z : apron.z + apron.h - 1;
-    const spawnCol = outward < 0 ? apron.x : apron.x + apron.w - 1;
-    const spawn: GridPos = spansX ? { x: cross, z: spawnLine } : { x: spawnCol, z: cross };
-
-    candidates.push({ gate: { pos, spansX, outside, room }, inner, spawn });
+    const candidate = gateCandidateAt(compound, crossStart + i, rooms);
+    if (!candidate || partitionWalls.has(cellKey(candidate.inner))) continue;
+    candidates.push(candidate);
   }
 
   if (candidates.length === 0) return null;

--- a/client/src/pages/play.tsx
+++ b/client/src/pages/play.tsx
@@ -41,7 +41,8 @@ function detectionColor(awareness: number): string {
 }
 
 /** The single next step, so the HUD never asks the player to hold two goals. */
-function objectiveText({ needsKeycard, hasKeycard }: ObjectiveState): string {
+function objectiveText({ inside, needsKeycard, hasKeycard }: ObjectiveState): string {
+  if (!inside) return "cross the approach and get through the gate";
   if (needsKeycard && !hasKeycard) return "find the keycard, then reach the console";
   return "reach the console and hack it unseen";
 }
@@ -65,6 +66,7 @@ export default function PlayPage() {
   const [paused, setPaused] = useState(true);
   const [won, setWon] = useState(false);
   const [objective, setObjective] = useState<ObjectiveState>({
+    inside: false,
     needsKeycard: false,
     hasKeycard: false,
   });
@@ -263,9 +265,11 @@ export default function PlayPage() {
               Ghost the Terminal
             </h1>
             <p className="text-sm text-white/70">
-              A procedurally generated facility of connected rooms, patrolling guards, and one
-              console worth hacking. The door to it is locked, so find the keycard first. Stay out
-              of the vision cones &mdash; walls and crates break line of sight.
+              You start outside, on the approach. One gate is cut through the facility&rsquo;s wall
+              and it is the only way in &mdash; cross the open ground and it rolls back for you.
+              Inside are connected rooms, patrolling guards, and one console worth hacking. The door
+              to it is locked, so find the keycard first. Stay out of the vision cones &mdash; walls
+              and crates break line of sight.
             </p>
             <dl className="mx-auto grid max-w-xs grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-left text-sm text-white/70">
               {CONTROLS.map(({ keys, action }) => (


### PR DESCRIPTION
## Description

The `/play` easter egg's facility had no walls of its own — the map's outer ring did that job, so a run began already indoors, with nothing to enter through. This gives the building a real perimeter and puts the player *outside* it, on an approach they have to cross to reach the one way in.

**Level generation**

- The grid interior is split into an **apron** and a **walled facility**. The apron is carved *out of* the span rather than added to it, so the two always tile the grid exactly; on a grid too small for the configured approach the apron gives way instead of running off the edge and stranding the spawn outside the world.
- The facility's perimeter is now listed wall like any partition, with exactly one cell missing: the gate. Only the grid's outer ring stays implicit.
- The gate is chosen *after* the rooms are known, from positions whose inner neighbour is open room floor (a partition can meet the perimeter anywhere along that face, and a gate opening onto the end of one would lead into solid wall). Among those, the best-connected room wins, so entering never lands in a stranded part of the room graph.
- Spawn moves to the far edge of the apron, straight out from the gate, so the run opens with the whole approach and the way in already lined up.

**A connectivity bug this surfaced**

BSP doors are now chosen after every cut instead of during each one. Choosing the door during a split and sealing it later when a perpendicular cut spoiled it silently dropped that split's edge from the room graph — seed 10 came out with 5 rooms and 2 doors, no route to lock, and so no keycard at all. Picking afterwards, from the cells with a room on either side, means every cut keeps its edge and the graph is a tree again. Verified as `doors === rooms - 1` across 500 seeds.

**Engine**

- The gate joins the existing door list, so its collider, its proximity trigger, and its blocking of paths and sight lines are the machinery the interior doors already use — one implementation of "a door is shut" for the pathfinder, the collision test and the sight lines to agree on. What is its own is the geometry: a ribbed cog leaf in a dressed stone portal, turning about the passage axis as it retracts.
- The approach is lit by lamps strung back from the gate, added to the **same list the stealth math reads**, so crossing the open ground genuinely costs cover rather than being a free hide.
- The apron is laid as square tiles rather than one stretched plane (it is a long thin band; a plane that shape smears the flagstone pattern along its length), and the facility shell is tinted apart from its partitions.
- A first objective line — "cross the approach and get through the gate" — latched the first time the player is inside.

Three rendering issues were found by looking at the result rather than assuming it: the status emissive flooded the whole leaf flat teal, `metalness: 0.85` with no environment map rendered it black, and deep jambs tunnelled the view so the wheel showed as a vertical slot. All three are fixed, with the reasoning recorded at each site.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — n/a, the easter egg is undocumented by design
- [x] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ — n/a, no external interface or security surface is touched
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Verification

- `npm run check`, `npm run lint`, `prettier --check` — clean
- `npm run test:run` — 2311 passed, 7 skipped
- New gate coverage in `level.test.ts`: spawn is on the apron; the gate is the **only** opening in the perimeter; it opens from apron to room floor; and **sealing it strands the terminal** — the property that makes the approach mean anything. Mutation-tested by punching a second hole in the perimeter, which fails 5 tests including all three of those.
- A 300-seed invariant harness over the generator: 0 failures, with all four approach sides represented.
- Production build driven in a real browser (Chromium/SwiftShader) across three seeds, close and zoomed out, with no console or page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Svo32ghwkyYTC8RDCNcwL

---
_Generated by [Claude Code](https://claude.ai/code/session_011Svo32ghwkyYTC8RDCNcwL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lit exterior approach area and a retractable, spinning gate.
  * Players now start outside the facility and must enter through the gate.
  * Added an “inside” objective milestone and updated HUD progress.
  * Updated objectives and briefing text to explain the approach and gate entry.
  * Improved facility layouts with a single perimeter entrance and revised key-location placement.

* **Bug Fixes**
  * Prevented guard patrols from appearing on the gate approach.
  * Ensured the gate, facility, and exterior approach remain properly separated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->