### PR TITLE
Fix Prowlarr download links double-wrapped when the proxy URL comes back on a container IP

### DIFF
--- a/server/__tests__/torznab.test.ts
+++ b/server/__tests__/torznab.test.ts
@@ -5,7 +5,11 @@ vi.mock("../db.js", () => ({ pool: {}, db: {} }));
 vi.mock("../logger.js", () => ({
   torznabLogger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
-vi.mock("../ssrf.js", () => ({ isSafeUrl: vi.fn(), safeFetch: vi.fn() }));
+vi.mock("../ssrf.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../ssrf.js")>()),
+  isSafeUrl: vi.fn(),
+  safeFetch: vi.fn(),
+}));
 
 const { TorznabClient } = await import("../torznab.js");
 const { torznabLogger } = await import("../logger.js");

--- a/server/__tests__/torznab.test.ts
+++ b/server/__tests__/torznab.test.ts
@@ -77,6 +77,16 @@ describe("TorznabClient — download link rewriting", () => {
     client = new TorznabClient();
   });
 
+  /** Search a Prowlarr-backed indexer that returns `enclosure`, and parse the rewritten link. */
+  async function searchProwlarrLink(indexerUrl: string, enclosure: string): Promise<URL> {
+    mockFetchResponse(makeTorznabXml(enclosure));
+    const indexer = makeIndexer({ url: indexerUrl, apiKey: "prowlarr-api-key" });
+
+    const result = await client.searchGames(indexer, { query: "game" });
+
+    return new URL(result.items[0].link);
+  }
+
   it("leaves the link unchanged when it already points to the indexer host", async () => {
     const indexer = makeIndexer({ url: "http://indexer.example.com/api" });
     const expectedLink = "http://indexer.example.com/download/file.torrent";
@@ -180,85 +190,68 @@ describe("TorznabClient — download link rewriting", () => {
     );
   });
 
-  it("does not double-wrap a Prowlarr proxy URL returned on the container IP behind a Docker service name", async () => {
-    // Prowlarr reflects the address the request arrived on, so a Questarr container
-    // querying http://prowlarr:9696 can get its download links back on the container
-    // IP. Re-wrapping those nests the real token one level too deep and Prowlarr
-    // answers "Failed to normalize provided link" (500). See issue #812.
-    const prowlarrIndexer = makeIndexer({
-      url: "http://prowlarr:9696/39/api",
-      apiKey: "prowlarr-api-key",
-    });
-    const proxyUrlOnContainerIp =
-      "http://172.19.0.8:9696/39/download?apikey=prowlarr-api-key&link=cHJvd2xhcnItdG9rZW4%3D&file=Sunderfolk";
-    mockFetchResponse(makeTorznabXml(proxyUrlOnContainerIp));
+  // Prowlarr builds its download links from the address the request arrived on, so its
+  // /{id}/download proxy links come back on whatever alias reached it: the container IP
+  // behind a Docker service name, or the internal address behind a reverse proxy.
+  // Re-wrapping one nests Prowlarr's own token a level too deep and it answers
+  // "Failed to normalize provided link" (500). See issue #812.
+  const proxyToken = "cHJvd2xhcnItdG9rZW4=";
+  const aliasedProxyCases = [
+    {
+      alias: "the container IP behind a Docker service name",
+      indexerUrl: "http://prowlarr:9696/39/api",
+      enclosure: `http://172.19.0.8:9696/39/download?apikey=prowlarr-api-key&link=${proxyToken}&file=Sunderfolk`,
+      expectedOrigin: "http://prowlarr:9696",
+      expectedPath: "/39/download",
+    },
+    {
+      // The configured URL terminates TLS on 443 while Prowlarr answers HTTP on 9696
+      // internally, so scheme and port both differ from the link Prowlarr returns.
+      alias: "the internal address behind a reverse proxy",
+      indexerUrl: "https://prowlarr.example.com/5/api",
+      enclosure: `http://10.1.2.3:9696/5/download?apikey=prowlarr-api-key&link=${proxyToken}&file=Sunderfolk`,
+      expectedOrigin: "https://prowlarr.example.com",
+      expectedPath: "/5/download",
+    },
+  ];
 
-    const result = await client.searchGames(prowlarrIndexer, { query: "game" });
+  it.each(aliasedProxyCases)(
+    "does not double-wrap a Prowlarr proxy URL returned on $alias",
+    async ({ indexerUrl, enclosure, expectedOrigin, expectedPath }) => {
+      const link = await searchProwlarrLink(indexerUrl, enclosure);
 
-    const rewritten = new URL(result.items[0].link);
-    expect(rewritten.host).toBe("prowlarr:9696");
-    expect(rewritten.pathname).toBe("/39/download");
-    expect(rewritten.searchParams.get("apikey")).toBe("prowlarr-api-key");
-    // The real Prowlarr token is preserved as-is, not re-encoded into a nested link
-    expect(rewritten.searchParams.get("link")).toBe("cHJvd2xhcnItdG9rZW4=");
-    expect(rewritten.searchParams.get("file")).toBe("Sunderfolk");
-  });
+      expect(link.origin).toBe(expectedOrigin);
+      expect(link.pathname).toBe(expectedPath);
+      expect(link.searchParams.get("apikey")).toBe("prowlarr-api-key");
+      // Prowlarr's own token survives verbatim rather than being nested one level down
+      expect(link.searchParams.get("link")).toBe(proxyToken);
+      expect(link.searchParams.get("file")).toBe("Sunderfolk");
+    }
+  );
 
-  it("does not double-wrap a Prowlarr proxy URL returned on an internal address behind a reverse proxy", async () => {
-    // The configured URL terminates TLS on 443 while Prowlarr answers HTTP on 9696
-    // internally, so scheme and port both differ from the link Prowlarr returns.
-    const prowlarrIndexer = makeIndexer({
-      url: "https://prowlarr.example.com/5/api",
-      apiKey: "prowlarr-api-key",
-    });
-    const proxyUrlOnInternalAddress =
-      "http://10.1.2.3:9696/5/download?apikey=prowlarr-api-key&link=cHJvd2xhcnItdG9rZW4%3D&file=Some+Game";
-    mockFetchResponse(makeTorznabXml(proxyUrlOnInternalAddress));
+  const wrappedCases = [
+    {
+      kind: "a raw external download URL",
+      enclosure: "https://tracker.example/torrents/download/42.torrent",
+    },
+    {
+      // Same host and shape, but the numeric id belongs to another indexer, so this is
+      // not the proxy URL for the indexer we queried.
+      kind: "a proxy-shaped link carrying a different Prowlarr indexer id",
+      enclosure: "http://172.19.0.8:9696/40/download?apikey=prowlarr-api-key&link=dG9rZW4%3D",
+    },
+  ];
 
-    const result = await client.searchGames(prowlarrIndexer, { query: "game" });
+  it.each(wrappedCases)(
+    "still wraps $kind when Prowlarr is addressed by service name",
+    async ({ enclosure }) => {
+      const link = await searchProwlarrLink("http://prowlarr:9696/39/api", enclosure);
 
-    const rewritten = new URL(result.items[0].link);
-    expect(rewritten.protocol).toBe("https:");
-    expect(rewritten.host).toBe("prowlarr.example.com");
-    expect(rewritten.pathname).toBe("/5/download");
-    expect(rewritten.searchParams.get("link")).toBe("cHJvd2xhcnItdG9rZW4=");
-  });
-
-  it("still wraps a raw external download URL when Prowlarr is addressed by service name", async () => {
-    const prowlarrIndexer = makeIndexer({
-      url: "http://prowlarr:9696/39/api",
-      apiKey: "prowlarr-api-key",
-    });
-    const rawUrl = "https://tracker.example/torrents/download/42.torrent";
-    mockFetchResponse(makeTorznabXml(rawUrl));
-
-    const result = await client.searchGames(prowlarrIndexer, { query: "game" });
-
-    const wrapped = new URL(result.items[0].link);
-    expect(wrapped.host).toBe("prowlarr:9696");
-    expect(wrapped.pathname).toBe("/39/download");
-    expect(Buffer.from(wrapped.searchParams.get("link")!, "base64").toString()).toBe(rawUrl);
-  });
-
-  it("re-wraps a proxy-shaped link for a different Prowlarr indexer id", async () => {
-    const prowlarrIndexer = makeIndexer({
-      url: "http://prowlarr:9696/39/api",
-      apiKey: "prowlarr-api-key",
-    });
-    // Same host and shape, but the numeric id belongs to another indexer, so this is
-    // not the proxy URL for the indexer we queried.
-    const otherIndexerProxyUrl =
-      "http://172.19.0.8:9696/40/download?apikey=prowlarr-api-key&link=dG9rZW4%3D";
-    mockFetchResponse(makeTorznabXml(otherIndexerProxyUrl));
-
-    const result = await client.searchGames(prowlarrIndexer, { query: "game" });
-
-    const wrapped = new URL(result.items[0].link);
-    expect(wrapped.pathname).toBe("/39/download");
-    expect(Buffer.from(wrapped.searchParams.get("link")!, "base64").toString()).toBe(
-      otherIndexerProxyUrl
-    );
-  });
+      expect(link.host).toBe("prowlarr:9696");
+      expect(link.pathname).toBe("/39/download");
+      expect(Buffer.from(link.searchParams.get("link")!, "base64").toString()).toBe(enclosure);
+    }
+  );
 
   it("re-wraps external URLs that mimic Prowlarr proxy path/query on a different host", async () => {
     const prowlarrIndexer = makeIndexer({

--- a/server/__tests__/torznab.test.ts
+++ b/server/__tests__/torznab.test.ts
@@ -213,6 +213,16 @@ describe("TorznabClient — download link rewriting", () => {
       expectedOrigin: "https://prowlarr.example.com",
       expectedPath: "/5/download",
     },
+    {
+      // TLS terminated in front of Prowlarr: it sees plain HTTP and reflects http://
+      // back on the same host and port, so only the scheme differs from the configured
+      // URL — the link still has to be normalized onto the configured endpoint.
+      alias: "the same private address under a plain-HTTP scheme",
+      indexerUrl: "https://172.19.0.8:9696/39/api",
+      enclosure: `http://172.19.0.8:9696/39/download?apikey=prowlarr-api-key&link=${proxyToken}&file=Sunderfolk`,
+      expectedOrigin: "https://172.19.0.8:9696",
+      expectedPath: "/39/download",
+    },
   ];
 
   it.each(aliasedProxyCases)(

--- a/server/__tests__/torznab.test.ts
+++ b/server/__tests__/torznab.test.ts
@@ -176,6 +176,86 @@ describe("TorznabClient — download link rewriting", () => {
     );
   });
 
+  it("does not double-wrap a Prowlarr proxy URL returned on the container IP behind a Docker service name", async () => {
+    // Prowlarr reflects the address the request arrived on, so a Questarr container
+    // querying http://prowlarr:9696 can get its download links back on the container
+    // IP. Re-wrapping those nests the real token one level too deep and Prowlarr
+    // answers "Failed to normalize provided link" (500). See issue #812.
+    const prowlarrIndexer = makeIndexer({
+      url: "http://prowlarr:9696/39/api",
+      apiKey: "prowlarr-api-key",
+    });
+    const proxyUrlOnContainerIp =
+      "http://172.19.0.8:9696/39/download?apikey=prowlarr-api-key&link=cHJvd2xhcnItdG9rZW4%3D&file=Sunderfolk";
+    mockFetchResponse(makeTorznabXml(proxyUrlOnContainerIp));
+
+    const result = await client.searchGames(prowlarrIndexer, { query: "game" });
+
+    const rewritten = new URL(result.items[0].link);
+    expect(rewritten.host).toBe("prowlarr:9696");
+    expect(rewritten.pathname).toBe("/39/download");
+    expect(rewritten.searchParams.get("apikey")).toBe("prowlarr-api-key");
+    // The real Prowlarr token is preserved as-is, not re-encoded into a nested link
+    expect(rewritten.searchParams.get("link")).toBe("cHJvd2xhcnItdG9rZW4=");
+    expect(rewritten.searchParams.get("file")).toBe("Sunderfolk");
+  });
+
+  it("does not double-wrap a Prowlarr proxy URL returned on an internal address behind a reverse proxy", async () => {
+    // The configured URL terminates TLS on 443 while Prowlarr answers HTTP on 9696
+    // internally, so scheme and port both differ from the link Prowlarr returns.
+    const prowlarrIndexer = makeIndexer({
+      url: "https://prowlarr.example.com/5/api",
+      apiKey: "prowlarr-api-key",
+    });
+    const proxyUrlOnInternalAddress =
+      "http://10.1.2.3:9696/5/download?apikey=prowlarr-api-key&link=cHJvd2xhcnItdG9rZW4%3D&file=Some+Game";
+    mockFetchResponse(makeTorznabXml(proxyUrlOnInternalAddress));
+
+    const result = await client.searchGames(prowlarrIndexer, { query: "game" });
+
+    const rewritten = new URL(result.items[0].link);
+    expect(rewritten.protocol).toBe("https:");
+    expect(rewritten.host).toBe("prowlarr.example.com");
+    expect(rewritten.pathname).toBe("/5/download");
+    expect(rewritten.searchParams.get("link")).toBe("cHJvd2xhcnItdG9rZW4=");
+  });
+
+  it("still wraps a raw external download URL when Prowlarr is addressed by service name", async () => {
+    const prowlarrIndexer = makeIndexer({
+      url: "http://prowlarr:9696/39/api",
+      apiKey: "prowlarr-api-key",
+    });
+    const rawUrl = "https://tracker.example/torrents/download/42.torrent";
+    mockFetchResponse(makeTorznabXml(rawUrl));
+
+    const result = await client.searchGames(prowlarrIndexer, { query: "game" });
+
+    const wrapped = new URL(result.items[0].link);
+    expect(wrapped.host).toBe("prowlarr:9696");
+    expect(wrapped.pathname).toBe("/39/download");
+    expect(Buffer.from(wrapped.searchParams.get("link")!, "base64").toString()).toBe(rawUrl);
+  });
+
+  it("re-wraps a proxy-shaped link for a different Prowlarr indexer id", async () => {
+    const prowlarrIndexer = makeIndexer({
+      url: "http://prowlarr:9696/39/api",
+      apiKey: "prowlarr-api-key",
+    });
+    // Same host and shape, but the numeric id belongs to another indexer, so this is
+    // not the proxy URL for the indexer we queried.
+    const otherIndexerProxyUrl =
+      "http://172.19.0.8:9696/40/download?apikey=prowlarr-api-key&link=dG9rZW4%3D";
+    mockFetchResponse(makeTorznabXml(otherIndexerProxyUrl));
+
+    const result = await client.searchGames(prowlarrIndexer, { query: "game" });
+
+    const wrapped = new URL(result.items[0].link);
+    expect(wrapped.pathname).toBe("/39/download");
+    expect(Buffer.from(wrapped.searchParams.get("link")!, "base64").toString()).toBe(
+      otherIndexerProxyUrl
+    );
+  });
+
   it("re-wraps external URLs that mimic Prowlarr proxy path/query on a different host", async () => {
     const prowlarrIndexer = makeIndexer({
       url: "http://localhost:9696/5/api",

--- a/server/__tests__/torznab.test.ts
+++ b/server/__tests__/torznab.test.ts
@@ -232,26 +232,38 @@ describe("TorznabClient — download link rewriting", () => {
   const wrappedCases = [
     {
       kind: "a raw external download URL",
+      indexerUrl: "http://prowlarr:9696/39/api",
       enclosure: "https://tracker.example/torrents/download/42.torrent",
+      expectedHost: "prowlarr:9696",
     },
     {
       // Same host and shape, but the numeric id belongs to another indexer, so this is
       // not the proxy URL for the indexer we queried.
       kind: "a proxy-shaped link carrying a different Prowlarr indexer id",
+      indexerUrl: "http://prowlarr:9696/39/api",
       enclosure: "http://172.19.0.8:9696/40/download?apikey=prowlarr-api-key&link=dG9rZW4%3D",
+      expectedHost: "prowlarr:9696",
+    },
+    {
+      // Prowlarr itself addressed by container IP, the workaround from issue #812. A
+      // public host that mimics the proxy path is still an external link Prowlarr has
+      // to fetch for us, so it must be wrapped and given the API key — the configured
+      // host being private proves nothing about where the link points.
+      kind: "a public proxy-shaped link for this indexer id when Prowlarr is addressed by IP",
+      indexerUrl: "http://172.19.0.8:9696/39/api",
+      enclosure: "https://tracker.example/39/download?file=Some+Game&link=dG9rZW4%3D",
+      expectedHost: "172.19.0.8:9696",
     },
   ];
 
-  it.each(wrappedCases)(
-    "still wraps $kind when Prowlarr is addressed by service name",
-    async ({ enclosure }) => {
-      const link = await searchProwlarrLink("http://prowlarr:9696/39/api", enclosure);
+  it.each(wrappedCases)("still wraps $kind", async ({ indexerUrl, enclosure, expectedHost }) => {
+    const link = await searchProwlarrLink(indexerUrl, enclosure);
 
-      expect(link.host).toBe("prowlarr:9696");
-      expect(link.pathname).toBe("/39/download");
-      expect(Buffer.from(link.searchParams.get("link")!, "base64").toString()).toBe(enclosure);
-    }
-  );
+    expect(link.host).toBe(expectedHost);
+    expect(link.pathname).toBe("/39/download");
+    expect(link.searchParams.get("apikey")).toBe("prowlarr-api-key");
+    expect(Buffer.from(link.searchParams.get("link")!, "base64").toString()).toBe(enclosure);
+  });
 
   it("re-wraps external URLs that mimic Prowlarr proxy path/query on a different host", async () => {
     const prowlarrIndexer = makeIndexer({

--- a/server/ssrf.ts
+++ b/server/ssrf.ts
@@ -379,6 +379,21 @@ export function isSafeIp(ip: string, allowPrivate = true): boolean {
 }
 
 /**
+ * True when the hostname is a literal IP address that is not publicly routable:
+ * loopback, RFC1918 / ULA private space, or link-local. A DNS name is not
+ * classified here and returns false — resolving it is the caller's business.
+ */
+export function isPrivateNetworkAddress(hostname: string): boolean {
+  const normalizedHostname = normalizeHostname(hostname);
+  if (isIP(normalizedHostname) === 0) {
+    return false;
+  }
+  // isSafeIp(..., false) answers "is this address reachable from the public
+  // internet", so its negation is exactly the private/loopback/link-local set.
+  return !isSafeIp(normalizedHostname, false);
+}
+
+/**
  * Fetches a URL while validating each request target against SSRF risks and DNS rebinding.
  *
  * Follows redirects when configured, validating every redirect target and applying redirect

--- a/server/torznab.ts
+++ b/server/torznab.ts
@@ -76,14 +76,13 @@ export class TorznabClient {
     // link that already carries its /{id}/download proxy path must not be re-wrapped
     // — Prowlarr rejects a nested link with "Failed to normalize provided link".
     //
-    // A private or loopback address on either side can only be an alias of the
-    // Prowlarr we just queried: no public indexer hands back a download link on one.
-    // Accept it regardless of scheme or port, since a reverse proxy terminating TLS
-    // on 443 fronts a container answering HTTP on 9696.
-    if (
-      isPrivateNetworkAddress(candidate.hostname) ||
-      isPrivateNetworkAddress(configured.hostname)
-    ) {
+    // Only the returned link can carry that signal. A loopback or private address
+    // there can only be the Prowlarr we just queried, since no public indexer hands
+    // back a download link on one, and scheme and port may still differ — a reverse
+    // proxy terminating TLS on 443 fronts a container answering HTTP on 9696. The
+    // configured host being private says nothing about a candidate on a public host:
+    // that is an external link Prowlarr still has to fetch on our behalf.
+    if (candidate.hostname === "localhost" || isPrivateNetworkAddress(candidate.hostname)) {
       return true;
     }
 

--- a/server/torznab.ts
+++ b/server/torznab.ts
@@ -1,7 +1,6 @@
-import { isIP } from "net";
 import { type Indexer } from "@shared/schema";
 import { torznabLogger } from "./logger.js";
-import { isSafeUrl, safeFetch } from "./ssrf.js";
+import { isPrivateNetworkAddress, isSafeUrl, safeFetch } from "./ssrf.js";
 import { XMLParser } from "fast-xml-parser";
 
 interface TorznabItem {
@@ -44,17 +43,6 @@ interface TorznabServerInfo {
   version?: string;
 }
 
-/**
- * Strip the brackets URL parsing keeps around an IPv6 literal (`[::1]` -> `::1`)
- * so the hostname can be compared and classified.
- */
-function stripBrackets(hostname: string): string {
-  if (hostname.startsWith("[") && hostname.endsWith("]")) {
-    return hostname.slice(1, -1);
-  }
-  return hostname;
-}
-
 export class TorznabClient {
   private parser: XMLParser;
 
@@ -80,44 +68,6 @@ export class TorznabClient {
     return url;
   }
 
-  /**
-   * True when the hostname is a literal IP address that can only belong to the
-   * local machine or a private network (Docker bridge, LAN, VPN). No public
-   * indexer can hand back a download link on such an address, so seeing one is
-   * a reliable sign that the URL was produced by the Prowlarr instance we just
-   * queried rather than by a third-party tracker.
-   */
-  private isPrivateAddress(hostname: string): boolean {
-    const host = stripBrackets(hostname);
-    const version = isIP(host);
-
-    if (version === 4) {
-      const [a, b] = host.split(".").map(Number);
-      return (
-        a === 127 || // loopback
-        a === 10 || // private
-        (a === 172 && b >= 16 && b <= 31) || // private (Docker's default pools live here)
-        (a === 192 && b === 168) || // private
-        (a === 169 && b === 254) // link-local
-      );
-    }
-
-    if (version === 6) {
-      const lower = host.toLowerCase();
-      return (
-        lower === "::1" ||
-        lower.startsWith("fc") || // unique local
-        lower.startsWith("fd") ||
-        lower.startsWith("fe8") || // link-local
-        lower.startsWith("fe9") ||
-        lower.startsWith("fea") ||
-        lower.startsWith("feb")
-      );
-    }
-
-    return false;
-  }
-
   private isSameProwlarrHost(candidate: URL, configured: URL): boolean {
     // Prowlarr builds its download links from the address the request arrived on,
     // which is rarely the address we configured: a Docker service name resolves to
@@ -125,10 +75,15 @@ export class TorznabClient {
     // internal container. Any of those forms still points at the same Prowlarr, so a
     // link that already carries its /{id}/download proxy path must not be re-wrapped
     // — Prowlarr rejects a nested link with "Failed to normalize provided link".
-    if (this.isPrivateAddress(candidate.hostname) || this.isPrivateAddress(configured.hostname)) {
-      // A private/loopback address on either side can only be an alias of the
-      // Prowlarr we queried, so accept it regardless of scheme or port (a reverse
-      // proxy terminating TLS on 443 fronts a container answering HTTP on 9696).
+    //
+    // A private or loopback address on either side can only be an alias of the
+    // Prowlarr we just queried: no public indexer hands back a download link on one.
+    // Accept it regardless of scheme or port, since a reverse proxy terminating TLS
+    // on 443 fronts a container answering HTTP on 9696.
+    if (
+      isPrivateNetworkAddress(candidate.hostname) ||
+      isPrivateNetworkAddress(configured.hostname)
+    ) {
       return true;
     }
 
@@ -136,7 +91,7 @@ export class TorznabClient {
       return false;
     }
 
-    return stripBrackets(candidate.hostname) === stripBrackets(configured.hostname);
+    return candidate.hostname === configured.hostname;
   }
 
   /**

--- a/server/torznab.ts
+++ b/server/torznab.ts
@@ -415,7 +415,10 @@ export class TorznabClient {
         if (linkUrl.protocol === "http:" || linkUrl.protocol === "https:") {
           const indexerUrlObj = new URL(indexerUrl);
 
-          if (linkUrl.host !== indexerUrlObj.host) {
+          // Compare origins, not just hosts: a link that differs from the configured
+          // URL only by scheme (Prowlarr behind TLS termination reflects http://) still
+          // needs normalizing onto the endpoint we were told to use.
+          if (linkUrl.origin !== indexerUrlObj.origin) {
             // Check if this is a Prowlarr indexer URL (pattern: /{numericId}/api).
             // When Prowlarr returns a raw external download URL (e.g. from a Cloudflare-protected
             // indexer), a naive host swap would produce an invalid path on Prowlarr. Instead,
@@ -462,8 +465,8 @@ export class TorznabClient {
               torznabItem.link = linkUrl.toString();
             }
           }
-          // If hosts already match the configured indexer (e.g. Prowlarr already returned its
-          // own proxy URL), leave the link unchanged.
+          // If the origin already matches the configured indexer (e.g. Prowlarr already
+          // returned its own proxy URL), leave the link unchanged.
         }
       } catch {
         // Ignore invalid URLs or parsing errors

--- a/server/torznab.ts
+++ b/server/torznab.ts
@@ -87,11 +87,9 @@ export class TorznabClient {
       return true;
     }
 
-    if (candidate.protocol !== configured.protocol || candidate.port !== configured.port) {
-      return false;
-    }
-
-    return candidate.hostname === configured.hostname;
+    // Any other host has to name the configured Prowlarr origin exactly: scheme,
+    // hostname and port all have to line up before the link counts as already proxied.
+    return candidate.origin === configured.origin;
   }
 
   /**

--- a/server/torznab.ts
+++ b/server/torznab.ts
@@ -1,3 +1,4 @@
+import { isIP } from "net";
 import { type Indexer } from "@shared/schema";
 import { torznabLogger } from "./logger.js";
 import { isSafeUrl, safeFetch } from "./ssrf.js";
@@ -43,6 +44,17 @@ interface TorznabServerInfo {
   version?: string;
 }
 
+/**
+ * Strip the brackets URL parsing keeps around an IPv6 literal (`[::1]` -> `::1`)
+ * so the hostname can be compared and classified.
+ */
+function stripBrackets(hostname: string): string {
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    return hostname.slice(1, -1);
+  }
+  return hostname;
+}
+
 export class TorznabClient {
   private parser: XMLParser;
 
@@ -68,25 +80,63 @@ export class TorznabClient {
     return url;
   }
 
-  private isLoopbackHostname(hostname: string): boolean {
-    return (
-      hostname === "localhost" ||
-      hostname === "127.0.0.1" ||
-      hostname === "::1" ||
-      hostname === "[::1]"
-    );
+  /**
+   * True when the hostname is a literal IP address that can only belong to the
+   * local machine or a private network (Docker bridge, LAN, VPN). No public
+   * indexer can hand back a download link on such an address, so seeing one is
+   * a reliable sign that the URL was produced by the Prowlarr instance we just
+   * queried rather than by a third-party tracker.
+   */
+  private isPrivateAddress(hostname: string): boolean {
+    const host = stripBrackets(hostname);
+    const version = isIP(host);
+
+    if (version === 4) {
+      const [a, b] = host.split(".").map(Number);
+      return (
+        a === 127 || // loopback
+        a === 10 || // private
+        (a === 172 && b >= 16 && b <= 31) || // private (Docker's default pools live here)
+        (a === 192 && b === 168) || // private
+        (a === 169 && b === 254) // link-local
+      );
+    }
+
+    if (version === 6) {
+      const lower = host.toLowerCase();
+      return (
+        lower === "::1" ||
+        lower.startsWith("fc") || // unique local
+        lower.startsWith("fd") ||
+        lower.startsWith("fe8") || // link-local
+        lower.startsWith("fe9") ||
+        lower.startsWith("fea") ||
+        lower.startsWith("feb")
+      );
+    }
+
+    return false;
   }
 
   private isSameProwlarrHost(candidate: URL, configured: URL): boolean {
+    // Prowlarr builds its download links from the address the request arrived on,
+    // which is rarely the address we configured: a Docker service name resolves to
+    // the container IP, `localhost` to `127.0.0.1`, a reverse-proxy hostname to the
+    // internal container. Any of those forms still points at the same Prowlarr, so a
+    // link that already carries its /{id}/download proxy path must not be re-wrapped
+    // — Prowlarr rejects a nested link with "Failed to normalize provided link".
+    if (this.isPrivateAddress(candidate.hostname) || this.isPrivateAddress(configured.hostname)) {
+      // A private/loopback address on either side can only be an alias of the
+      // Prowlarr we queried, so accept it regardless of scheme or port (a reverse
+      // proxy terminating TLS on 443 fronts a container answering HTTP on 9696).
+      return true;
+    }
+
     if (candidate.protocol !== configured.protocol || candidate.port !== configured.port) {
       return false;
     }
-    if (candidate.hostname === configured.hostname) {
-      return true;
-    }
-    return (
-      this.isLoopbackHostname(candidate.hostname) && this.isLoopbackHostname(configured.hostname)
-    );
+
+    return stripBrackets(candidate.hostname) === stripBrackets(configured.hostname);
   }
 
   /**
@@ -433,9 +483,13 @@ export class TorznabClient {
 
               if (isProwlarrProxyUrl) {
                 // Prowlarr already returned a proxy URL. Avoid double-wrapping when only
-                // hostnames differ (e.g. localhost vs 127.0.0.1) by doing host rewrite only.
+                // the host form differs (localhost vs 127.0.0.1, a Docker service name vs
+                // the container IP it resolves to) by doing a host rewrite only.
                 linkUrl.protocol = indexerUrlObj.protocol;
                 linkUrl.host = indexerUrlObj.host;
+                // Assigning `host` without a port leaves the previous port in place, which
+                // would keep Prowlarr's internal port on a reverse-proxied configured URL.
+                linkUrl.port = indexerUrlObj.port;
                 torznabItem.link = linkUrl.toString();
               } else {
                 const prowlarrUrl = new URL(`${indexerUrlObj.protocol}//${indexerUrlObj.host}`);


### PR DESCRIPTION
## Description

Fixes #812 (regression reported on v1.4.2 with Prowlarr `2.5.2.5491`).

Prowlarr builds its `/{id}/download` proxy links from the address the request arrived on, so a Questarr container querying `http://prowlarr:9696` can get those links back on the container IP (`http://172.19.0.8:9696`).

`TorznabClient.isSameProwlarrHost` only accepted an exact hostname match or a `localhost` ↔ `127.0.0.1` pair (the #647 fix), so the service-name ↔ container-IP form fell through to the wrapping branch. The already-proxied URL was then base64-encoded into a new `link` parameter, burying Prowlarr's own token one level too deep:

```
http://prowlarr:9696/39/download?file=...&link=base64(http://172.19.0.8:9696/39/download?...&link=<real token>)&apikey=...
```

Prowlarr answers `BadRequestException: Failed to normalize provided link`, and every download fails with a 500.

### Change

A returned link counts as already proxied when **the link itself** names a loopback or private address (`localhost`, or an IP literal in loopback/RFC1918/ULA/link-local space) — no public indexer hands back a download link on one, so it can only be the Prowlarr we just queried. Scheme and port may legitimately differ there, since a reverse proxy terminating TLS on 443 fronts a container answering HTTP on 9696. Any other host has to match the configured origin exactly.

The signal deliberately does **not** come from the configured host: with Prowlarr addressed by container IP (the workaround #812 reporters are using), a public link mimicking the proxy path would otherwise be treated as already proxied and reach the download client without the API key. That case is covered by a regression test.

Supporting fixes, both in the same normalization gap:

- **Port.** Assigning `URL.host` without a port leaves the previous port in place, which kept Prowlarr's internal `:9696` on a reverse-proxied configured URL. The port is now set explicitly.
- **Scheme.** The outer rewrite guard compared hosts, so a link differing only by scheme was skipped entirely — Prowlarr behind TLS termination reflects `http://`, and a configured `https://` endpoint got an `http://` link that need not be reachable. It compares origins now.

`isPrivateNetworkAddress` lives in `server/ssrf.ts`, defined as the negation of the existing `isSafeIp` with private access disallowed, so the address ranges have one home rather than two.

Links that mimic the proxy path on a public host, and proxy-shaped links carrying a different indexer id, are still wrapped as before.

No dependency changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — no user-facing or API surface change
- [ ] If this PR adds a new actor/integration, external interface, or security-relevant change, I have updated docs/ARCHITECTURE.md, docs/API.md, and/or docs/SECURITY_ASSESSMENT.md accordingly — not applicable; no new interface, and links are still routed to the configured indexer origin
- [x] I have added tests that prove my fix is effective or that my feature works — `server/__tests__/torznab.test.ts` gains two case tables: aliased proxy URLs that must not be re-wrapped (Docker container IP, reverse-proxied internal address, same address under a plain-HTTP scheme) and links that must still be wrapped (raw external URL, a different indexer id, a public proxy-shaped link while Prowlarr is addressed by IP). The three cases covering a reported or reviewed failure were each confirmed to fail against the code they guard.
- [x] New and existing unit tests pass locally with my changes — `npx vitest run server/__tests__/` → 1599 passed, 6 skipped; server + client → 2227 passed. `npm run check`, ESLint and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYZecXcbu6GcJiQmRMFqLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYZecXcbu6GcJiQmRMFqLH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved download link handling when using Prowlarr through Docker service names, reverse proxies, or private network addresses.
  - Prevented links from being wrapped multiple times or incorrectly associated with another indexer.
  - Preserved Prowlarr access tokens without unnecessary re-encoding.
  - Synchronized rewritten proxy links with the configured scheme and port.
  - Improved handling of external and proxy-based indexer links so they are wrapped only when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
