### PR TITLE
Fix ESLint v10 preserve-caught-error findings in torznab.ts

### DIFF
--- a/server/__tests__/torznab.test.ts
+++ b/server/__tests__/torznab.test.ts
@@ -396,6 +396,43 @@ describe("TorznabClient — download link rewriting", () => {
   });
 });
 
+describe("TorznabClient — searchGames error wrapping", () => {
+  let client: InstanceType<typeof TorznabClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new TorznabClient();
+  });
+
+  it("wraps a parse failure with the original error chained via cause", async () => {
+    // Neither <rss><channel> nor a Torznab <error> element — parseResponse's own
+    // catch throws "Invalid Torznab response format", which searchGames' catch
+    // then wraps again. Both throws must preserve the original error via `cause`.
+    mockFetchResponse(`<?xml version="1.0"?><nonsense/>`);
+    const indexer = makeIndexer();
+
+    await expect(client.searchGames(indexer, { query: "game" })).rejects.toMatchObject({
+      message:
+        "Failed to search indexer Test Indexer: Failed to parse response: Invalid Torznab response format",
+      cause: expect.objectContaining({
+        message: "Failed to parse response: Invalid Torznab response format",
+        cause: expect.objectContaining({ message: "Invalid Torznab response format" }),
+      }),
+    });
+  });
+
+  it("wraps a fetch rejection with the original error chained via cause", async () => {
+    const networkError = new Error("ECONNRESET");
+    mockSafeFetch.mockRejectedValue(networkError);
+    const indexer = makeIndexer();
+
+    await expect(client.searchGames(indexer, { query: "game" })).rejects.toMatchObject({
+      message: "Failed to search indexer Test Indexer: ECONNRESET",
+      cause: networkError,
+    });
+  });
+});
+
 describe("TorznabClient — testConnection", () => {
   let client: InstanceType<typeof TorznabClient>;
 

--- a/server/torznab.ts
+++ b/server/torznab.ts
@@ -163,7 +163,9 @@ export class TorznabClient {
     } catch (error) {
       torznabLogger.error({ indexerName: indexer.name, error }, `error searching indexer`);
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
-      throw new Error(`Failed to search indexer ${indexer.name}: ${errorMessage}`);
+      throw new Error(`Failed to search indexer ${indexer.name}: ${errorMessage}`, {
+        cause: error,
+      });
     }
   }
 
@@ -380,7 +382,7 @@ export class TorznabClient {
     } catch (error) {
       torznabLogger.error({ error }, "error parsing Torznab response");
       const errorMessage = error instanceof Error ? error.message : "Unknown error";
-      throw new Error(`Failed to parse response: ${errorMessage}`);
+      throw new Error(`Failed to parse response: ${errorMessage}`, { cause: error });
     }
   }
 


### PR DESCRIPTION
## Description

`main`'s CI is currently red on `build (26.x)` (confirmed on the latest `main` HEAD): the ESLint v10 upgrade in #1008 added the `preserve-caught-error` rule, which flags `TorznabClient.searchGames` and `TorznabClient.parseResponse` for discarding the original caught error when re-throwing a wrapped one. This attaches the original error via the standard `cause` option instead, so it survives in the stack/cause chain for debugging — the thrown message is unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (n/a — internal error-handling detail, no doc-visible behavior change)
- [x] This PR does not add a new actor/integration, external interface, or security-relevant change
- [x] I have added tests that prove my fix is effective or that my feature works (existing `server/__tests__/torznab.test.ts` suite covers these code paths; no behavior change)
- [x] New and existing unit tests pass locally with my changes (`npm run lint`, `npx tsc --noEmit`, `npm run format:check`, `npx vitest run server/__tests__/torznab.test.ts` — all clean)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sjsrrwh9aPuMUV2dk8xBTx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for search and parsing failures.
  * Error details are now preserved when requests fail or responses cannot be interpreted, making failures easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->