### PR TITLE
fix: restart extraction if unrar/7zip hangs longer than 60s

### DIFF
--- a/server/__tests__/archive_service.test.ts
+++ b/server/__tests__/archive_service.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -5,6 +6,20 @@ const { extractFullMock, ensureDirMock } = vi.hoisted(() => ({
   extractFullMock: vi.fn(),
   ensureDirMock: vi.fn().mockResolvedValue(undefined),
 }));
+
+/**
+ * Helper: create a mock 7z stream with a killable child process.
+ * The stream mimics node-7z's Readable + _childProcess.
+ */
+function makeMockStream(): EventEmitter {
+  const stream = new EventEmitter();
+  // node-7z attaches the spawned child process to the stream
+  (stream as unknown as { _childProcess: { kill: () => void; pid: number } })._childProcess = {
+    kill: vi.fn(),
+    pid: 12345,
+  };
+  return stream;
+}
 
 vi.mock("node-7z", () => ({
   default: {
@@ -32,7 +47,7 @@ describe("ArchiveService", () => {
   });
 
   it("extracts files from emitted events", async () => {
-    const stream = new EventEmitter();
+    const stream = makeMockStream();
     extractFullMock.mockReturnValue(stream);
 
     const service = new ArchiveService();
@@ -63,7 +78,7 @@ describe("ArchiveService", () => {
   });
 
   it("rejects when extraction stream emits an error", async () => {
-    const stream = new EventEmitter();
+    const stream = makeMockStream();
     extractFullMock.mockReturnValue(stream);
 
     const service = new ArchiveService();
@@ -97,7 +112,7 @@ describe("ArchiveService", () => {
 
   // Gap 2: extraction produces no files (empty output) — stream ends without any "extracted" events
   it("resolves with an empty array when no files are extracted", async () => {
-    const stream = new EventEmitter();
+    const stream = makeMockStream();
     extractFullMock.mockReturnValue(stream);
 
     const service = new ArchiveService();
@@ -124,7 +139,7 @@ describe("ArchiveService", () => {
 
   // Gap 4: destination directory pre-exists — ensureDir is always called (idempotent)
   it("calls ensureDir even when the destination directory already exists", async () => {
-    const stream = new EventEmitter();
+    const stream = makeMockStream();
     extractFullMock.mockReturnValue(stream);
     // ensureDirMock is already set up to resolve; simulate pre-existing dir (no-op behaviour)
     ensureDirMock.mockResolvedValue(undefined);
@@ -144,7 +159,7 @@ describe("ArchiveService", () => {
 
   // Gap 5: 7zip binary exits with a non-zero code — stream emits an error with stderr output
   it("rejects with stderr message when 7zip exits with non-zero code", async () => {
-    const stream = new EventEmitter();
+    const stream = makeMockStream();
     extractFullMock.mockReturnValue(stream);
 
     const service = new ArchiveService();
@@ -180,7 +195,7 @@ describe("ArchiveService", () => {
 
   // Requested: archive with a single file inside — extraction produces exactly one file
   it("extractIfArchive — archive with a single file inside produces exactly one path", async () => {
-    const stream = new EventEmitter();
+    const stream = makeMockStream();
     extractFullMock.mockReturnValue(stream);
 
     const service = new ArchiveService();
@@ -198,7 +213,7 @@ describe("ArchiveService", () => {
 
   // Gap 6: archive with nested directories — returned paths include full nested structure
   it("returns full nested paths for files inside subdirectories", async () => {
-    const stream = new EventEmitter();
+    const stream = makeMockStream();
     extractFullMock.mockReturnValue(stream);
 
     const service = new ArchiveService();
@@ -217,5 +232,155 @@ describe("ArchiveService", () => {
     expect(files[0]).toMatch(/tmp[\\/]nested-out[\\/]level1[\\/]level2[\\/]deep\.rom$/);
     expect(files[1]).toMatch(/tmp[\\/]nested-out[\\/]level1[\\/]level2[\\/]level3[\\/]extra\.bin$/);
     expect(files[2]).toMatch(/tmp[\\/]nested-out[\\/]root\.cfg$/);
+  });
+});
+
+describe("ArchiveService timeout and restart", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(process, "kill");
+    // Fully reset mocks (clearAllMocks doesn't clear mockReturnValueOnce queues)
+    extractFullMock.mockReset();
+    ensureDirMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("kills the process and restarts when extraction exceeds the timeout", async () => {
+    // First stream: hangs (never emits "end")
+    const hangingStream = makeMockStream();
+    // Second stream: completes normally
+    const successStream = makeMockStream();
+
+    extractFullMock.mockReturnValueOnce(hangingStream).mockReturnValueOnce(successStream);
+
+    const service = new ArchiveService();
+    const resultPromise = service.extract("/downloads/game.rar", "/tmp/out", {
+      timeoutMs: 60000,
+      maxRetries: 1,
+    });
+
+    // Let async setup complete (ensureDir + extractFull + listeners)
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Verify first extraction started
+    expect(extractFullMock).toHaveBeenCalledTimes(1);
+
+    // Advance past the timeout — this should trigger the kill + restart
+    await vi.advanceTimersByTimeAsync(61000);
+
+    // Verify the hanging process was killed via process.kill (process group)
+    // process.kill(-pid) is attempted first; in test env it throws ESRCH,
+    // so it falls back to child.kill()
+    const hangingChild = (
+      hangingStream as unknown as { _childProcess: { kill: ReturnType<typeof vi.fn> } }
+    )._childProcess;
+    expect(hangingChild.kill).toHaveBeenCalledWith("SIGKILL");
+
+    // Verify second extraction started (retry)
+    expect(extractFullMock).toHaveBeenCalledTimes(2);
+
+    // Complete the second extraction
+    successStream.emit("data", { status: "extracted", file: "game.rom" });
+    successStream.emit("end");
+
+    const result = await resultPromise;
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatch(/tmp[\\/]out[\\/]game\.rom$/);
+  });
+
+  it("throws timeout error when all retries are exhausted", async () => {
+    // Both streams hang — neither completes
+    const hangingStream1 = makeMockStream();
+    const hangingStream2 = makeMockStream();
+
+    extractFullMock.mockReturnValueOnce(hangingStream1).mockReturnValueOnce(hangingStream2);
+
+    const service = new ArchiveService();
+    const resultPromise = service.extract("/downloads/game.rar", "/tmp/out", {
+      timeoutMs: 60000,
+      maxRetries: 1,
+    });
+
+    // Prevent unhandled rejection warning: attach handler before timers advance
+    resultPromise.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    // First timeout fires — kills first process, starts retry
+    await vi.advanceTimersByTimeAsync(61000);
+
+    // Second timeout fires — retry exhausted
+    await vi.advanceTimersByTimeAsync(61000);
+
+    await expect(resultPromise).rejects.toThrow(/timed out/i);
+
+    // Both processes should have been killed
+    const child1 = (
+      hangingStream1 as unknown as { _childProcess: { kill: ReturnType<typeof vi.fn> } }
+    )._childProcess;
+    const child2 = (
+      hangingStream2 as unknown as { _childProcess: { kill: ReturnType<typeof vi.fn> } }
+    )._childProcess;
+    expect(child1.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(child2.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("does not restart if extraction completes before timeout", async () => {
+    const stream = makeMockStream();
+    extractFullMock.mockReturnValue(stream);
+
+    const service = new ArchiveService();
+    const resultPromise = service.extract("/downloads/game.rar", "/tmp/out", {
+      timeoutMs: 60000,
+      maxRetries: 1,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Complete extraction before timeout
+    stream.emit("data", { status: "extracted", file: "game.rom" });
+    stream.emit("end");
+
+    const result = await resultPromise;
+    expect(result).toHaveLength(1);
+
+    // Only one extraction attempt
+    expect(extractFullMock).toHaveBeenCalledTimes(1);
+
+    // Process should NOT have been killed
+    const child = (stream as unknown as { _childProcess: { kill: ReturnType<typeof vi.fn> } })
+      ._childProcess;
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("uses default 60s timeout and 1 retry when no options specified", async () => {
+    const hangingStream = makeMockStream();
+    const successStream = makeMockStream();
+
+    extractFullMock.mockReturnValueOnce(hangingStream).mockReturnValueOnce(successStream);
+
+    const service = new ArchiveService();
+    const resultPromise = service.extract("/downloads/game.rar", "/tmp/out");
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Advance just under the default 60s — should NOT trigger yet
+    await vi.advanceTimersByTimeAsync(59999);
+    expect(extractFullMock).toHaveBeenCalledTimes(1);
+
+    // Advance past 60s — triggers timeout + restart
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(extractFullMock).toHaveBeenCalledTimes(2);
+
+    // Complete the retry
+    successStream.emit("data", { status: "extracted", file: "game.rom" });
+    successStream.emit("end");
+
+    const result = await resultPromise;
+    expect(result).toHaveLength(1);
   });
 });

--- a/server/services/ArchiveService.ts
+++ b/server/services/ArchiveService.ts
@@ -7,14 +7,81 @@ import { logger } from "../logger.js";
 
 const sevenZipPath = pathTo7zip.path7za;
 
+/**
+ * Error thrown when an extraction exceeds the allowed timeout.
+ * Used by the retry loop to distinguish timeouts from fatal errors.
+ */
+export class ExtractionTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExtractionTimeoutError";
+  }
+}
+
+/** Default timeout: 60 seconds — if unrar/7zip hangs longer than this, restart. */
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+/** Default max retries after a timeout (single restart). */
+const DEFAULT_MAX_RETRIES = 1;
+
+export interface ExtractOptions {
+  /** Milliseconds before a hanging extraction is killed and restarted. Default 60_000. */
+  timeoutMs?: number;
+  /** Number of times to restart after a timeout. Default 1. */
+  maxRetries?: number;
+}
+
 export class ArchiveService {
   /**
    * Extracts an archive to a specified output directory.
+   * If extraction takes longer than `timeoutMs`, the 7zip process is killed
+   * and the extraction is restarted (up to `maxRetries` times).
+   *
    * @param filePath Full path to the archive file.
    * @param outputDir Directory where contents should be extracted.
+   * @param options Timeout and retry configuration.
    * @returns Paths of files reported as extracted by 7zip (constructed from event data).
    */
-  async extract(filePath: string, outputDir: string): Promise<string[]> {
+  async extract(
+    filePath: string,
+    outputDir: string,
+    options: ExtractOptions = {}
+  ): Promise<string[]> {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await this.extractOnce(filePath, outputDir, timeoutMs);
+      } catch (err) {
+        if (err instanceof ExtractionTimeoutError && attempt < maxRetries) {
+          logger.warn(
+            { filePath, attempt: attempt + 1, timeoutMs },
+            "Extraction timed out — restarting"
+          );
+          lastError = err;
+          continue;
+        }
+        throw err;
+      }
+    }
+
+    // All retries exhausted — rethrow the last timeout error.
+    throw lastError;
+  }
+
+  /**
+   * Single extraction attempt with a hard timeout.
+   * If the timeout fires before "end" or "error", the child process is
+   * killed (process group SIGKILL) and an ExtractionTimeoutError is thrown.
+   */
+  private async extractOnce(
+    filePath: string,
+    outputDir: string,
+    timeoutMs: number
+  ): Promise<string[]> {
     logger.debug({ filePath, outputDir }, "Extracting archive");
 
     await fs.ensureDir(outputDir);
@@ -28,23 +95,78 @@ export class ArchiveService {
         recursive: true,
       });
 
+      let timeoutId: NodeJS.Timeout | undefined;
+      let completed = false;
+
+      const cleanup = () => {
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId);
+          timeoutId = undefined;
+        }
+      };
+
+      // Hard timeout: if extraction hasn't finished by now, kill + reject.
+      timeoutId = setTimeout(() => {
+        if (completed) return;
+        completed = true;
+
+        this.killExtraction(stream);
+        cleanup();
+
+        reject(new ExtractionTimeoutError(`Extraction timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
       stream.on("data", (data: { status: string; file?: string }) => {
-        // data.file is the relative path of the file being extracted
         if (data.status === "extracted" && data.file) {
           extractedFiles.push(path.join(outputDir, data.file));
         }
       });
 
       stream.on("end", () => {
+        if (completed) return;
+        completed = true;
+        cleanup();
+
         logger.debug({ count: extractedFiles.length }, "Extraction complete");
         resolve(extractedFiles);
       });
 
       stream.on("error", (err: Error) => {
+        if (completed) return;
+        completed = true;
+        cleanup();
+
         logger.error({ err }, "Extraction failed");
         reject(err);
       });
     });
+  }
+
+  /**
+   * Kills the 7zip child process spawned by node-7z.
+   * Attempts a process-group kill first (the process is spawned detached),
+   * falling back to a direct child.kill() if that fails.
+   */
+  private killExtraction(stream: NodeJS.ReadableStream): void {
+    const child = (
+      stream as unknown as { _childProcess?: { pid: number; kill: (signal?: string) => void } }
+    )._childProcess;
+
+    if (!child) {
+      logger.warn("No child process found on extraction stream — cannot kill");
+      return;
+    }
+
+    try {
+      // node-7z spawns with detached: true, so the child leads its own process
+      // group. Killing the group (-pid) takes down spawned helpers like unrar.
+      process.kill(-child.pid, "SIGKILL");
+      logger.debug({ pid: child.pid }, "Killed extraction process group");
+    } catch {
+      // Fallback: kill just the child process itself.
+      child.kill("SIGKILL");
+      logger.debug({ pid: child.pid }, "Killed extraction child process");
+    }
   }
 
   isArchive(filePath: string): boolean {


### PR DESCRIPTION
## Summary
- `ArchiveService.extract()` now has a hard 60-second timeout — if the 7zip/unrar process hangs longer than that, the process group is SIGKILL'd and the extraction restarts
- Configurable via `{ timeoutMs?, maxRetries? }` options (defaults: 60s, 1 retry)
- Only timeouts trigger retries; real errors fail immediately

## Why
If unrar hangs on a corrupt or heavily compressed .rar, the extraction would block forever — the import pipeline stalls and never recovers.

## How
- New `extract()` wraps `extractOnce()` in a retry loop
- `extractOnce()` sets a `setTimeout` — on fire, calls `killExtraction()` which does `process.kill(-pid, "SIGKILL")` (kills the whole process group including unrar) with a `child.kill("SIGKILL")` fallback
- `ExtractionTimeoutError` distinguishes timeouts from fatal errors

## Test coverage
- kills process and restarts on timeout
- throws after all retries exhausted
- no restart when extraction completes before timeout
- default 60s/1-retry behavior

All 17 archive service tests pass. TypeScript compiles clean.

---

Feel free to edit this PR with your agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Archive extraction now supports configurable timeouts and retry attempts.
  - Timed-out extraction processes are terminated and can be automatically restarted.
  - Extraction failures now distinguish timeout errors from other errors.

- **Tests**
  - Added coverage for timeout handling, process restarts, retry exhaustion, successful completion, and default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->