### PR TITLE
fix: don't re-trigger import for downloads already unpacking

### DIFF
--- a/server/__tests__/cron_download_status.test.ts
+++ b/server/__tests__/cron_download_status.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // --- Mocks ---
@@ -376,5 +377,53 @@ describe("Cron - checkDownloadStatus", () => {
     expect(mockUpdateGameStatus).toHaveBeenCalledWith(baseDownload.gameId, { status: "owned" });
     expect(mockGetDownloadDetails).not.toHaveBeenCalled();
     expect(mockProcessImport).not.toHaveBeenCalled();
+  });
+
+  // Reproduction test for the large-archive "extraction restarts" bug:
+  // when processImport() starts extracting a large .rar it sets the DB row to
+  // "unpacking" (ImportManager.ts). checkDownloadStatus() runs every 60s and
+  // picks the row back up ("unpacking" is not a terminal status), sees the
+  // remote download as completed, and calls processImport() AGAIN — starting a
+  // second extraction into the same _extracted directory and clobbering the
+  // first. That is the "file grows, then starts small again" symptom at ~60s.
+  it("should not re-trigger processImport for a download already unpacking", async () => {
+    const unpackingDownload = {
+      ...baseDownload,
+      status: "unpacking" as const,
+    };
+    mockGetDownloadingGameDownloads.mockResolvedValue([unpackingDownload]);
+    mockGetDownloader.mockResolvedValue(baseDownloader);
+    mockGetImportConfig.mockResolvedValue({ enablePostProcessing: true });
+
+    // Remote client still reports the download as completed/available while
+    // the extraction (which can take minutes for large archives) is running.
+    mockGetAllDownloads.mockResolvedValue([
+      {
+        id: "SABnzbd_nzo_abc123",
+        name: "Test Game",
+        status: "completed",
+        progress: 100,
+        downloadType: "usenet",
+      },
+    ]);
+    mockGetDownloadDetails.mockResolvedValue({
+      id: "SABnzbd_nzo_abc123",
+      name: "Test Game",
+      status: "completed",
+      progress: 100,
+      downloadType: "usenet",
+      downloadDir: "/downloads/complete/Test Game",
+      files: [],
+      trackers: [],
+    });
+
+    await checkDownloadStatus();
+
+    // A row mid-import must be left alone — processImport for it is already
+    // running from the previous cron tick. Re-invoking it would extract into
+    // the same directory a second time and clobber the in-flight extraction.
+    expect(mockProcessImport).not.toHaveBeenCalled();
+    expect(mockUpdateGameDownloadStatus).not.toHaveBeenCalled();
+    expect(mockUpdateGameStatus).not.toHaveBeenCalled();
   });
 });

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -566,6 +566,21 @@ export async function checkDownloadStatus() {
       );
 
       for (const download of downloads) {
+        // Skip rows whose import is already in flight: processImport() from a
+        // previous tick set these statuses and is still working (extracting a
+        // large archive can take minutes). checkDownloadStatus runs every 60s
+        // and setInterval does not wait for the previous run to finish, so a
+        // second concurrent run would re-invoke processImport() and start a
+        // second extraction into the same _extracted directory — clobbering
+        // the in-flight extraction ("file grows, then starts small again").
+        if (download.status === "unpacking" || download.status === "completed_pending_import") {
+          igdbLogger.debug(
+            { downloadId: download.id, status: download.status },
+            "Skipping download — import already in progress"
+          );
+          continue;
+        }
+
         // Match by hash/ID (handle case sensitivity just in case)
         let remoteDownload = activeDownloadMap.get(download.downloadHash.toLowerCase());
 

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -566,13 +566,10 @@ export async function checkDownloadStatus() {
       );
 
       for (const download of downloads) {
-        // Skip rows whose import is already in flight: processImport() from a
-        // previous tick set these statuses and is still working (extracting a
-        // large archive can take minutes). checkDownloadStatus runs every 60s
-        // and setInterval does not wait for the previous run to finish, so a
-        // second concurrent run would re-invoke processImport() and start a
-        // second extraction into the same _extracted directory — clobbering
-        // the in-flight extraction ("file grows, then starts small again").
+        // Skip rows whose import is already in flight — the earlier tick's
+        // processImport() is still extracting (large archives take minutes).
+        // Re-invoking here would start a second extraction into the same
+        // directory and clobber the in-flight one.
         if (download.status === "unpacking" || download.status === "completed_pending_import") {
           igdbLogger.debug(
             { downloadId: download.id, status: download.status },


### PR DESCRIPTION
## Problem

Large .rar files take **longer than 60s** to extract — and during that window, the download **restarts from scratch** (the extraction directory's file grows, then starts small again).

## Root cause (reproduced)

1. When a download finishes, cron's `checkDownloadStatus()` calls `processImport()`, which sets the DB row to `"unpacking"` and starts extracting via 7zip/unrar
2. `checkDownloadStatus()` runs **every 60s** (`DOWNLOAD_CHECK_INTERVAL_MS = 60 * 1000`), and `setInterval` does **not** wait for the previous run to finish
3. `getDownloadingGameDownloads()` only excludes *terminal* statuses — `"unpacking"` (and `"completed_pending_import"`) are still returned
4. So on the next 60s tick, the still-extracting row is picked up again, the remote download still reports `completed`, and cron calls `processImport()` a **second time** → a second `extractFull` writes into the same `_extracted` directory, clobbering the first extraction

That is exactly the observed symptom: files grow, then "start small again" at ~60s.

## Fix

Skip rows whose status is `"unpacking"` or `"completed_pending_import"` in `checkDownloadStatus()` — an import already in flight is left alone until the current run finishes or fails (failures route to `manual_review_required`, where they remain re-actionable).

## Test

- Reproduction test added: `cron re-triggers processImport for an unpacking download` — **failed before the fix** (demonstrating `processImport` was called again), **passes after**

All 9 cron tests pass. TypeScript compiles clean.

---

Note: this will be most useful alongside #803 — once the 7zip bin permissions fix merges, real extraction in Docker runs for large .rar files, which is exactly the long-running case this guard protects from being double-triggered into the same directory.

Feel free to edit this PR with your agent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented in-progress downloads from being processed again when their status is already unpacking or awaiting import.
  - Avoided duplicate extraction attempts that could interfere with an active import.
- **Tests**
  - Added coverage confirming that completed remote downloads remain untouched while an import is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->